### PR TITLE
Update `open_dataset()` and `open_mfdataset()` to only run `decode_time_units()` with datasets that have a time dimension

### DIFF
--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -12,7 +12,8 @@ def open_dataset(path: str, var: str, **kwargs: Dict[str, Any]) -> xr.Dataset:
 
     Operations include:
 
-    - Decode all time units, including non-CF compliant units (months and years).
+    - If the dataset a time dimension, decode both CF and non-CF time units
+      (months and years).
     - Generate bounds for supported coordinates if they don't exist.
     - Limit the Dataset to a single variable. XCDAT operations are performed on
       a single variable.
@@ -68,9 +69,11 @@ def open_dataset(path: str, var: str, **kwargs: Dict[str, Any]) -> xr.Dataset:
     # bounds (becomes "days since 1970-01-01  00:00:00").
     ds = xr.open_dataset(path, decode_times=False, **kwargs)
     ds = keep_var(ds, var)
-    ds = decode_time_units(ds)
-    ds = ds.bounds.fill_missing()
 
+    if ds.cf.dims.get("T") is not None:
+        ds = decode_time_units(ds)
+
+    ds = ds.bounds.fill_missing()
     return ds
 
 
@@ -81,7 +84,8 @@ def open_mfdataset(
 
     Operations include:
 
-    - Decode all time units, including non-CF compliant units (months and years).
+    - If the dataset a time dimension, decode both CF and non-CF time units
+      (months and years).
     - Generate bounds for supported coordinates if they don't exist.
     - Limit the Dataset to a single variable. XCDAT operations are performed on
       a single variable.
@@ -143,9 +147,11 @@ def open_mfdataset(
     # bounds (becomes "days since 1970-01-01  00:00:00").
     ds = xr.open_mfdataset(paths, decode_times=False, **kwargs)
     ds = keep_var(ds, var)
-    ds = decode_time_units(ds)
-    ds = ds.bounds.fill_missing()
 
+    if ds.cf.dims.get("T") is not None:
+        ds = decode_time_units(ds)
+
+    ds = ds.bounds.fill_missing()
     return ds
 
 


### PR DESCRIPTION

## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #112 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
