### PR TITLE
Add support for spatial averaging parallelism via Dask

### DIFF
--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -228,12 +228,12 @@ class TestSwapRegionLonAxis:
 
     def test_successful_swap_from_180_to_360_for_dataarray(self):
         result = self.ds.spatial._swap_lon_axes(self.ds.lon, to="360")
-        expected = np.array([0., 1.875, 356.25, 358.125])
+        expected = np.array([0.0, 1.875, 356.25, 358.125])
 
         assert np.array_equal(result, expected)
 
     def test_successful_swap_from_360_to_180_for_dataarray(self):
-        expected = np.array([0., 1.875, -3.75, -1.875])
+        expected = np.array([0.0, 1.875, -3.75, -1.875])
         result = self.ds.spatial._swap_lon_axes(self.ds.lon, to="180")
 
         assert np.array_equal(result, expected)

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -713,19 +713,17 @@ class TestAverager:
         assert result.identical(expected)
 
     def test_weighted_avg_over_lat_and_lon_axes_in_chunks(self):
-        self.ds = self.ds.chunk(2)
+        ds = self.ds.copy().chunk(2)
 
         weights = xr.DataArray(
             data=np.array([[1, 2, 3, 4], [2, 4, 6, 8], [3, 6, 9, 12], [4, 8, 12, 16]]),
-            coords={"lat": self.ds.lat, "lon": self.ds.lon},
+            coords={"lat": ds.lat, "lon": ds.lon},
             dims=["lat", "lon"],
         )
 
-        result = self.ds.spatial._averager(
-            self.ds.ts, axis=["lat", "lon"], weights=weights
-        )
+        result = ds.spatial._averager(ds.ts, axis=["lat", "lon"], weights=weights)
         expected = xr.DataArray(
-            name="ts", data=np.ones(12), coords={"time": self.ds.time}, dims=["time"]
+            name="ts", data=np.ones(12), coords={"time": ds.time}, dims=["time"]
         )
 
         assert result.identical(expected)

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -216,37 +216,35 @@ class TestSwapRegionLonAxis:
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
 
     def test_successful_swap_from_180_to_360(self):
-        result = self.ds.spatial._swap_lon_axes(np.array([-65, 0, 120]), to="360")
+        result = self.ds.spatial._swap_lon_axes(np.array([-65, 0, 120]), to=360)
         expected = np.array([295, 0, 120])
 
         assert np.array_equal(result, expected)
 
         expected = np.array([180, 0, 180])
-        result = self.ds.spatial._swap_lon_axes(np.array([-180, 0, 180]), to="360")
+        result = self.ds.spatial._swap_lon_axes(np.array([-180, 0, 180]), to=360)
 
         assert np.array_equal(result, expected)
 
     def test_successful_swap_from_180_to_360_for_dataarray(self):
-        result = self.ds.spatial._swap_lon_axes(self.ds.lon, to="360")
+        result = self.ds.spatial._swap_lon_axes(self.ds.lon, to=360)
         expected = np.array([0.0, 1.875, 356.25, 358.125])
 
         assert np.array_equal(result, expected)
 
     def test_successful_swap_from_360_to_180_for_dataarray(self):
         expected = np.array([0.0, 1.875, -3.75, -1.875])
-        result = self.ds.spatial._swap_lon_axes(self.ds.lon, to="180")
+        result = self.ds.spatial._swap_lon_axes(self.ds.lon, to=180)
 
         assert np.array_equal(result, expected)
 
     def test_successful_swap_from_360_to_180(self):
-        result = self.ds.spatial._swap_lon_axes(np.array([0, 120, 181, 360]), to="180")
+        result = self.ds.spatial._swap_lon_axes(np.array([0, 120, 181, 360]), to=180)
         expected = np.array([0, 120, -179, 0])
 
         assert np.array_equal(result, expected)
 
-        result = self.ds.spatial._swap_lon_axes(
-            np.array([-0.25, 120, 359.75]), to="180"
-        )
+        result = self.ds.spatial._swap_lon_axes(np.array([-0.25, 120, 359.75]), to=180)
         expected = np.array([-0.25, 120, -0.25])
 
         assert np.array_equal(result, expected)

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -356,8 +356,8 @@ class TestSwapLonAxes:
 
         assert np.array_equal(result, expected)
 
-        expected = np.array([180, 0, 180])
         result = self.ds.spatial._swap_lon_axes(np.array([-180, 0, 180]), to=360)
+        expected = np.array([180, 0, 180])
 
         assert np.array_equal(result, expected)
 

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -210,12 +210,31 @@ class TestValidateWeights:
             )
 
 
-class TestSwapRegionLonAxis:
+class TestSwapLonAxes:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
 
-    def test_successful_swap_from_180_to_360(self):
+    def test_successful_swap_domain_dataarray_from_180_to_360(self):
+        # TODO: Create longitude datarray
+        lon_data = np.array([-65, 0, 120])
+        lon = xr.DataArray(data=lon_data, coords={"lon": lon_data}, dims="lon")
+
+        result = self.ds.spatial._swap_lon_axes(lon, to=360)
+        expected = np.array([295, 0, 120])
+
+        assert np.array_equal(result, expected)
+
+    def test_successful_swap_domain_dataarray_from_360_to_180(self):
+        # TODO: Create longitude datarray
+        lon_data = np.array([0, 120, 181, 360])
+        lon = xr.DataArray(data=lon_data, coords={"lon": lon_data}, dims="lon")
+
+        result = self.ds.spatial._swap_lon_axes(lon, to=180)
+        expected = np.array([0, 120, -179, 0])
+        assert np.array_equal(result, expected)
+
+    def test_successful_swap_region_ndarray_from_180_to_360(self):
         result = self.ds.spatial._swap_lon_axes(np.array([-65, 0, 120]), to=360)
         expected = np.array([295, 0, 120])
 
@@ -226,19 +245,7 @@ class TestSwapRegionLonAxis:
 
         assert np.array_equal(result, expected)
 
-    def test_successful_swap_from_180_to_360_for_dataarray(self):
-        result = self.ds.spatial._swap_lon_axes(self.ds.lon, to=360)
-        expected = np.array([0.0, 1.875, 356.25, 358.125])
-
-        assert np.array_equal(result, expected)
-
-    def test_successful_swap_from_360_to_180_for_dataarray(self):
-        expected = np.array([0.0, 1.875, -3.75, -1.875])
-        result = self.ds.spatial._swap_lon_axes(self.ds.lon, to=180)
-
-        assert np.array_equal(result, expected)
-
-    def test_successful_swap_from_360_to_180(self):
+    def test_successful_swap_region_ndarray_from_360_to_180(self):
         result = self.ds.spatial._swap_lon_axes(np.array([0, 120, 181, 360]), to=180)
         expected = np.array([0, 120, -179, 0])
 

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -55,7 +55,6 @@ class TestSpatialAverage:
         )
 
         expected = self.ds.copy()
-
         expected["ts"] = xr.DataArray(
             data=np.array([2.25, 1.0, 1.0]),
             coords={"time": expected.time},
@@ -127,6 +126,7 @@ class TestValidateAxis:
     def test_returns_list_of_str_if_axis_is_a_single_supported_str_input(self):
         result = self.ds.spatial._validate_axis(self.ds.ts, axis="lat")
         expected = ["lat"]
+
         assert result == expected
 
 
@@ -384,6 +384,7 @@ class TestGetWeights:
             coords={"lat": self.ds.lat, "lon": self.ds.lon},
             dims=["lat", "lon"],
         )
+
         xr.testing.assert_allclose(result, expected)
 
     def test_returns_area_weights_for_region_within_lat(self):
@@ -533,6 +534,7 @@ class TestSetEqualLonBoundsToDomain:
             domain_bounds=self.domain_bounds, region_bounds=np.array([50, 50])
         )
         expected = np.array([-90, 90])
+
         assert np.array_equal(result, expected)
 
     def test_returns_same_region_bounds_if_values_are_not_equal(self):
@@ -540,6 +542,7 @@ class TestSetEqualLonBoundsToDomain:
             domain_bounds=self.domain_bounds, region_bounds=np.array([0, 50])
         )
         expected = np.array([0, 50])
+
         assert np.array_equal(result, expected)
 
 
@@ -557,6 +560,7 @@ class TestScaleDimToRegion:
             coords={"lat": self.ds.lat},
             dims=["lat", "bnds"],
         ).chunk(2)
+
         result = self.ds.spatial._scale_domain_to_region(
             domain_bounds=domain_bounds, region_bounds=np.array([-5, 5])
         )
@@ -583,6 +587,7 @@ class TestScaleDimToRegion:
             coords={"lat": self.ds.lat},
             dims=["lat", "bnds"],
         ).chunk(2)
+
         result = self.ds.spatial._scale_domain_to_region(
             domain_bounds=domain_bounds, region_bounds=np.array([190, 240])
         )
@@ -605,6 +610,7 @@ class TestScaleDimToRegion:
             coords={"lat": self.ds.lat},
             dims=["lat", "bnds"],
         )
+
         result = self.ds.spatial._scale_domain_to_region(
             domain_bounds=domain_bounds, region_bounds=np.array([-5, 5])
         )
@@ -631,6 +637,7 @@ class TestScaleDimToRegion:
             coords={"lat": self.ds.lat},
             dims=["lat", "bnds"],
         )
+
         result = self.ds.spatial._scale_domain_to_region(
             domain_bounds=domain_bounds, region_bounds=np.array([190, 240])
         )
@@ -642,6 +649,7 @@ class TestScaleDimToRegion:
             coords={"lat": self.ds.lat},
             dims=["lat", "bnds"],
         )
+
         assert result.identical(expected)
 
     def test_scales_lon_bounds_when_wrapping_around_prime_meridian(self):
@@ -662,6 +670,7 @@ class TestScaleDimToRegion:
             coords={"lat": self.ds.lat},
             dims=["lat", "bnds"],
         )
+
         result = self.ds.spatial._scale_domain_to_region(
             domain_bounds=domain_bounds, region_bounds=np.array([357.5, 10.0])
         )
@@ -682,6 +691,7 @@ class TestScaleDimToRegion:
             coords={"lat": self.ds.lat},
             dims=["lat", "bnds"],
         )
+
         assert result.identical(expected)
 
 
@@ -737,6 +747,7 @@ class TestAverager:
             coords={"lat": self.ds.lat},
             dims=["lat"],
         )
+
         result = self.ds.spatial._averager(self.ds.ts, axis=["lat"], weights=weights)
         expected = xr.DataArray(
             name="ts",
@@ -754,6 +765,7 @@ class TestAverager:
             coords={"lon": self.ds.lon},
             dims=["lon"],
         )
+
         result = self.ds.spatial._averager(self.ds.ts, axis=["lon"], weights=weights)
         expected = xr.DataArray(
             name="ts",
@@ -770,6 +782,7 @@ class TestAverager:
             coords={"lat": self.ds.lat, "lon": self.ds.lon},
             dims=["lat", "lon"],
         )
+
         result = self.ds.spatial._averager(
             self.ds.ts, axis=["lat", "lon"], weights=weights
         )

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -226,6 +226,18 @@ class TestSwapRegionLonAxis:
 
         assert np.array_equal(result, expected)
 
+    def test_successful_swap_from_180_to_360_for_dataarray(self):
+        result = self.ds.spatial._swap_lon_axes(self.ds.lon, to="360")
+        expected = np.array([0., 1.875, 356.25, 358.125])
+
+        assert np.array_equal(result, expected)
+
+    def test_successful_swap_from_360_to_180_for_dataarray(self):
+        expected = np.array([0., 1.875, -3.75, -1.875])
+        result = self.ds.spatial._swap_lon_axes(self.ds.lon, to="180")
+
+        assert np.array_equal(result, expected)
+
     def test_successful_swap_from_360_to_180(self):
         result = self.ds.spatial._swap_lon_axes(np.array([0, 120, 181, 360]), to="180")
         expected = np.array([0, 120, -179, 0])
@@ -599,6 +611,24 @@ class TestAverager:
             coords={"lat": self.ds.lat, "lon": self.ds.lon},
             dims=["lat", "lon"],
         )
+        result = self.ds.spatial._averager(
+            self.ds.ts, axis=["lat", "lon"], weights=weights
+        )
+        expected = xr.DataArray(
+            name="ts", data=np.ones(12), coords={"time": self.ds.time}, dims=["time"]
+        )
+
+        assert result.identical(expected)
+
+    def test_weighted_avg_over_lat_and_lon_axes_in_chunks(self):
+        self.ds = self.ds.chunk(2)
+
+        weights = xr.DataArray(
+            data=np.array([[1, 2, 3, 4], [2, 4, 6, 8], [3, 6, 9, 12], [4, 8, 12, 16]]),
+            coords={"lat": self.ds.lat, "lon": self.ds.lon},
+            dims=["lat", "lon"],
+        )
+
         result = self.ds.spatial._averager(
             self.ds.ts, axis=["lat", "lon"], weights=weights
         )

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -234,6 +234,16 @@ class TestSwapLonAxes:
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
 
+    def test_raises_error_with_incorrect_orientation_to_swap_to(self):
+        domain = xr.DataArray(
+            name="lon_bnds",
+            data=np.array([[-65, -5], [-5, 0], [0, 120]]),
+            dims=["lon", "bnds"],
+            attrs={"is_generated": "True"},
+        )
+        with pytest.raises(ValueError):
+            self.ds.spatial._swap_lon_axes(domain, to=9000)
+
     def test_swap_chunked_domain_dataarray_from_180_to_360(self):
         domain = xr.DataArray(
             name="lon_bnds",

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -215,26 +215,113 @@ class TestSwapLonAxes:
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
 
-    def test_successful_swap_domain_dataarray_from_180_to_360(self):
-        # TODO: Create longitude datarray
-        lon_data = np.array([-65, 0, 120])
-        lon = xr.DataArray(data=lon_data, coords={"lon": lon_data}, dims="lon")
+    def test_swap_chunked_domain_dataarray_from_180_to_360(self):
+        domain = xr.DataArray(
+            name="lon_bnds",
+            data=np.array([[-65, -5], [-5, 0], [0, 120]]),
+            dims=["lon", "bnds"],
+            attrs={"is_generated": "True"},
+        ).chunk(2)
 
-        result = self.ds.spatial._swap_lon_axes(lon, to=360)
-        expected = np.array([295, 0, 120])
+        result = self.ds.spatial._swap_lon_axes(domain, to=360)
+        expected = xr.DataArray(
+            name="lon_bnds",
+            data=np.array([[295, 355], [355, 0], [0, 120]]),
+            dims=["lon", "bnds"],
+            attrs={"is_generated": "True"},
+        )
 
-        assert np.array_equal(result, expected)
+        assert result.identical(expected)
 
-    def test_successful_swap_domain_dataarray_from_360_to_180(self):
-        # TODO: Create longitude datarray
-        lon_data = np.array([0, 120, 181, 360])
-        lon = xr.DataArray(data=lon_data, coords={"lon": lon_data}, dims="lon")
+    def test_swap_chunked_domain_dataarray_from_360_to_180(self):
+        domain = xr.DataArray(
+            name="lon_bnds",
+            data=np.array([[0, 120], [120, 181], [181, 360]]),
+            dims=["lon", "bnds"],
+            attrs={"is_generated": "True"},
+        ).chunk(2)
 
-        result = self.ds.spatial._swap_lon_axes(lon, to=180)
-        expected = np.array([0, 120, -179, 0])
-        assert np.array_equal(result, expected)
+        result = self.ds.spatial._swap_lon_axes(domain, to=180)
+        expected = xr.DataArray(
+            name="lon_bnds",
+            data=np.array([[0, 120], [120, -179], [-179, 0]]),
+            dims=["lon", "bnds"],
+            attrs={"is_generated": "True"},
+        )
 
-    def test_successful_swap_region_ndarray_from_180_to_360(self):
+        assert result.identical(expected)
+
+        domain = xr.DataArray(
+            name="lon_bnds",
+            data=np.array([[-0.25, 120], [120, 359.75]]),
+            dims=["lon", "bnds"],
+            attrs={"is_generated": "True"},
+        ).chunk(2)
+
+        result = self.ds.spatial._swap_lon_axes(domain, to=180)
+        expected = xr.DataArray(
+            name="lon_bnds",
+            data=np.array([[-0.25, 120], [120, -0.25]]),
+            dims=["lon", "bnds"],
+            attrs={"is_generated": "True"},
+        )
+
+        assert result.identical(expected)
+
+    def test_swap_domain_dataarray_from_180_to_360(self):
+        domain = xr.DataArray(
+            name="lon_bnds",
+            data=np.array([[-65, -5], [-5, 0], [0, 120]]),
+            dims=["lon", "bnds"],
+            attrs={"is_generated": "True"},
+        )
+
+        result = self.ds.spatial._swap_lon_axes(domain, to=360)
+        expected = xr.DataArray(
+            name="lon_bnds",
+            data=np.array([[295, 355], [355, 0], [0, 120]]),
+            dims=["lon", "bnds"],
+            attrs={"is_generated": "True"},
+        )
+
+        assert result.identical(expected)
+
+    def test_swap_domain_dataarray_from_360_to_180(self):
+        domain = xr.DataArray(
+            name="lon_bnds",
+            data=np.array([[0, 120], [120, 181], [181, 360]]),
+            dims=["lon", "bnds"],
+            attrs={"is_generated": "True"},
+        )
+
+        result = self.ds.spatial._swap_lon_axes(domain, to=180)
+        expected = xr.DataArray(
+            name="lon_bnds",
+            data=np.array([[0, 120], [120, -179], [-179, 0]]),
+            dims=["lon", "bnds"],
+            attrs={"is_generated": "True"},
+        )
+
+        assert result.identical(expected)
+
+        domain = xr.DataArray(
+            name="lon_bnds",
+            data=np.array([[-0.25, 120], [120, 359.75]]),
+            dims=["lon", "bnds"],
+            attrs={"is_generated": "True"},
+        )
+
+        result = self.ds.spatial._swap_lon_axes(domain, to=180)
+        expected = xr.DataArray(
+            name="lon_bnds",
+            data=np.array([[-0.25, 120], [120, -0.25]]),
+            dims=["lon", "bnds"],
+            attrs={"is_generated": "True"},
+        )
+
+        assert result.identical(expected)
+
+    def test_swap_region_ndarray_from_180_to_360(self):
         result = self.ds.spatial._swap_lon_axes(np.array([-65, 0, 120]), to=360)
         expected = np.array([295, 0, 120])
 
@@ -245,7 +332,7 @@ class TestSwapLonAxes:
 
         assert np.array_equal(result, expected)
 
-    def test_successful_swap_region_ndarray_from_360_to_180(self):
+    def test_swap_region_ndarray_from_360_to_180(self):
         result = self.ds.spatial._swap_lon_axes(np.array([0, 120, 181, 360]), to=180)
         expected = np.array([0, 120, -179, 0])
 

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -750,6 +750,22 @@ class TestAverager:
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
 
+    def test_chunked_weighted_avg_over_lat_and_lon_axes(self):
+        ds = self.ds.copy().chunk(2)
+
+        weights = xr.DataArray(
+            data=np.array([[1, 2, 3, 4], [2, 4, 6, 8], [3, 6, 9, 12], [4, 8, 12, 16]]),
+            coords={"lat": ds.lat, "lon": ds.lon},
+            dims=["lat", "lon"],
+        )
+
+        result = ds.spatial._averager(ds.ts, axis=["lat", "lon"], weights=weights)
+        expected = xr.DataArray(
+            name="ts", data=np.ones(12), coords={"time": ds.time}, dims=["time"]
+        )
+
+        assert result.identical(expected)
+
     def test_weighted_avg_over_lat_axes(self):
         weights = xr.DataArray(
             name="lat_wts",
@@ -798,22 +814,6 @@ class TestAverager:
         )
         expected = xr.DataArray(
             name="ts", data=np.ones(12), coords={"time": self.ds.time}, dims=["time"]
-        )
-
-        assert result.identical(expected)
-
-    def test_weighted_avg_over_lat_and_lon_axes_in_chunks(self):
-        ds = self.ds.copy().chunk(2)
-
-        weights = xr.DataArray(
-            data=np.array([[1, 2, 3, 4], [2, 4, 6, 8], [3, 6, 9, 12], [4, 8, 12, 16]]),
-            coords={"lat": ds.lat, "lon": ds.lon},
-            dims=["lat", "lon"],
-        )
-
-        result = ds.spatial._averager(ds.ts, axis=["lat", "lon"], weights=weights)
-        expected = xr.DataArray(
-            name="ts", data=np.ones(12), coords={"time": ds.time}, dims=["time"]
         )
 
         assert result.identical(expected)

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -525,8 +525,7 @@ class DatasetSpatialAverageAccessor:
         # the domain (e.g., for a left bound of 300 degrees and a right bound
         # of 20, then the grid cells in between the region bounds (20 and 300)
         # are given zero weight (or partial weight if the grid bounds overlap
-        # with the region bounds). We update the values attribute, to maintain
-        # compatibility with chunked dataarrays.
+        # with the region bounds).
         if r_bounds[1] >= r_bounds[0]:
             # Case 1 (simple case): not wrapping around prime meridian.
             # Adjustments for above / right of region.

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -428,6 +428,8 @@ class DatasetSpatialAverageAccessor:
         lon_swap = lon.copy()
         if to == "180":
             inds = np.where(lon_swap > 180)
+            # if dataarray, update values attribute
+            # (compatible with chunked data)
             if type(lon_swap) == xr.core.dataarray.DataArray:
                 lon_swap.values[inds] = lon_swap[inds] - 360
             else:
@@ -515,7 +517,8 @@ class DatasetSpatialAverageAccessor:
         # the domain (e.g., for a left bound of 300 degrees and a right bound
         # of 20, then the grid cells in between the region bounds (20 and 300)
         # are given zero weight (or partial weight if the grid bounds overlap
-        # with the region bounds).
+        # with the region bounds). We update the values attribute, to maintain
+        # compatibility with chunked dataarrays.
         if r_bounds[1] >= r_bounds[0]:
             # Case 1 (simple case): not wrapping around prime meridian.
             # Adjustments for above / right of region.

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -427,19 +427,22 @@ class DatasetSpatialAverageAccessor:
         """
         lon_swap = lon.copy()
 
-        # Must convert convert an xarray data structure from lazy Dask arrays
-        # into eager, in-memory NumPy arrays before performing manipulations on
-        # the data. Otherwise, it raises `NotImplementedError xarray can't set
-        # arrays with multiple array indices to dask yet`
+        # If chunking, must convert convert an xarray data structure from lazy
+        # Dask arrays into eager, in-memory NumPy arrays before performing
+        # manipulations on the data. Otherwise it raises `NotImplementedError
+        # xarray can't set arrays with multiple array indices to dask yet`
         if type(lon_swap.data) == Array:
             lon_swap.load()
 
-        if to == 180:
-            lon_swap = ((lon_swap + 180) % 360) - 180
-        elif to == 360:
-            lon_swap = lon_swap % 360
-        else:
-            raise ValueError("Only longitude axis orientation 180 or 360 is supported.")
+        with xr.set_options(keep_attrs=True):
+            if to == 180:
+                lon_swap = ((lon_swap + 180) % 360) - 180
+            elif to == 360:
+                lon_swap = lon_swap % 360
+            else:
+                raise ValueError(
+                    "Only longitude axis orientation 180 or 360 is supported."
+                )
 
         return lon_swap
 

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -429,7 +429,7 @@ class DatasetSpatialAverageAccessor:
 
         # If chunking, must convert convert the xarray data structure from lazy
         # Dask arrays into eager, in-memory NumPy arrays before performing
-        # manipulations on the data. Otherwise,it raises `NotImplementedError
+        # manipulations on the data. Otherwise, it raises `NotImplementedError
         # xarray can't set arrays with multiple array indices to dask yet`
         if type(lon_swap.data) == Array:
             lon_swap.load()

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -5,6 +5,7 @@ from typing import Dict, Hashable, List, Optional, Tuple, Union
 import cf_xarray  # noqa: F401
 import numpy as np
 import xarray as xr
+from dask.array.core import Array
 from typing_extensions import Literal, TypedDict, get_args
 
 from xcdat.dataset import get_inferred_var
@@ -384,8 +385,8 @@ class DatasetSpatialAverageAccessor:
         """
         # Normalize the lon axis orientation to 360 for domain and region
         # bounds for orientation compatibility in the proceeding operations.
-        d_bounds: xr.DataArray = self._swap_lon_axes(domain_bounds.copy(), 360)
-        r_bounds: np.ndarray = self._swap_lon_axes(region_bounds.copy(), 360)
+        d_bounds: xr.DataArray = self._swap_lon_axes(domain_bounds.copy(), to=360)
+        r_bounds: np.ndarray = self._swap_lon_axes(region_bounds.copy(), to=360)
 
         # Find lon bound elements where the lower bound is greater than the
         # upper bound (e.g., across prime meridian or dateline, (359.375, 0.625))
@@ -402,23 +403,22 @@ class DatasetSpatialAverageAccessor:
         return d_bounds, r_bounds
 
     def _swap_lon_axes(
-        self, lon: Union[np.ndarray, xr.DataArray], to: Literal[180, 360]
-    ) -> Union[np.ndarray, xr.DataArray]:
-        """
-        Swap longitude axes orientation to 180 (-180 to 180) or 360 (0 to
-        360).
+        self, lon: Union[xr.DataArray, np.ndarray], to: Literal[180, 360]
+    ) -> Union[xr.DataArray, np.ndarray]:
+        """Swap the domain longitude axes orientation.
 
         Parameters
         ----------
-        lon : Union[np.ndarray, xr.DataArray]
-            Longitude values to convert.
-        to : Union[180, 360]
-            Axis orientation to convert to.
+        lon : Union[xr.DataArray, np.ndarray]
+             Longitude values to convert.
+        to : Literal[180, 360]
+            Axis orientation to convert to, either 180 (-180 to 180) or 360 (0 to
+            360).
 
         Returns
         -------
-        Union[np.ndarray, xr.DataArray]
-            Converted longitude values.
+        xr.DataArray
+            Converted domain longitude values.
 
         Notes
         -----
@@ -431,19 +431,13 @@ class DatasetSpatialAverageAccessor:
         # into eager, in-memory NumPy arrays before performing manipulations on
         # the data. Otherwise, it raises `NotImplementedError xarray can't set
         # arrays with multiple array indices to dask yet`
-        if type(lon_swap) == xr.DataArray:
+        if type(lon_swap.data) == Array:
             lon_swap.load()
 
         if to == 180:
-            indices = np.where(lon_swap > 180)
-            count = len(indices[0])
-            if count > 0:
-                lon_swap[indices] = lon_swap[indices] - 360
+            lon_swap = ((lon_swap + 180) % 360) - 180
         elif to == 360:
-            indices = np.where(lon_swap < 0)
-            count = len(indices[0])
-            if count > 0:
-                lon_swap[indices] = lon_swap[indices] + 360
+            lon_swap = lon_swap % 360
         else:
             raise ValueError("Only longitude axis orientation 180 or 360 is supported.")
 

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -417,7 +417,7 @@ class DatasetSpatialAverageAccessor:
 
         Returns
         -------
-        xr.DataArray
+        Union[xr.DataArray, np.ndarray]
             Converted longitude values.
 
         Notes
@@ -430,7 +430,7 @@ class DatasetSpatialAverageAccessor:
         # If chunking, must convert convert the xarray data structure from lazy
         # Dask arrays into eager, in-memory NumPy arrays before performing
         # manipulations on the data. Otherwise, it raises `NotImplementedError
-        # xarray can't set arrays with multiple array indices to dask yet`
+        # xarray can't set arrays with multiple array indices to dask yet`.
         if type(lon_swap.data) == Array:
             lon_swap.load()
 

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -426,6 +426,8 @@ class DatasetSpatialAverageAccessor:
         in-place between longitude conventions (-180 to 180) or (0 to 360).
         """
         lon_swap = lon.copy()
+        if type(lon_swap) == xr.core.dataarray.DataArray:
+            lon_swap.load()
         if to == "180":
             inds = np.where(lon_swap > 180)
             lon_swap[inds] = lon_swap[inds] - 360
@@ -510,6 +512,7 @@ class DatasetSpatialAverageAccessor:
         # of 20, then the grid cells in between the region bounds (20 and 300)
         # are given zero weight (or partial weight if the grid bounds overlap
         # with the region bounds).
+        d_bounds.load()
         if r_bounds[1] >= r_bounds[0]:
             # Case 1 (simple case): not wrapping around prime meridian.
             # Adjustments for above / right of region.

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -405,20 +405,20 @@ class DatasetSpatialAverageAccessor:
     def _swap_lon_axes(
         self, lon: Union[xr.DataArray, np.ndarray], to: Literal[180, 360]
     ) -> Union[xr.DataArray, np.ndarray]:
-        """Swap the domain longitude axes orientation.
+        """Swap the longitude axes orientation.
 
         Parameters
         ----------
         lon : Union[xr.DataArray, np.ndarray]
              Longitude values to convert.
         to : Literal[180, 360]
-            Axis orientation to convert to, either 180 (-180 to 180) or 360 (0 to
-            360).
+            Axis orientation to convert to, either 180 (-180 to 180) or 360
+            (0 to 360).
 
         Returns
         -------
         xr.DataArray
-            Converted domain longitude values.
+            Converted longitude values.
 
         Notes
         -----
@@ -427,13 +427,15 @@ class DatasetSpatialAverageAccessor:
         """
         lon_swap = lon.copy()
 
-        # If chunking, must convert convert an xarray data structure from lazy
+        # If chunking, must convert convert the xarray data structure from lazy
         # Dask arrays into eager, in-memory NumPy arrays before performing
-        # manipulations on the data. Otherwise it raises `NotImplementedError
+        # manipulations on the data. Otherwise,it raises `NotImplementedError
         # xarray can't set arrays with multiple array indices to dask yet`
         if type(lon_swap.data) == Array:
             lon_swap.load()
 
+        # Must set keep_attrs=True or the xarray DataArray attrs will get
+        # dropped. This has no affect on NumPy arrays.
         with xr.set_options(keep_attrs=True):
             if to == 180:
                 lon_swap = ((lon_swap + 180) % 360) - 180

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -426,14 +426,18 @@ class DatasetSpatialAverageAccessor:
         in-place between longitude conventions (-180 to 180) or (0 to 360).
         """
         lon_swap = lon.copy()
-        if type(lon_swap) == xr.core.dataarray.DataArray:
-            lon_swap.load()
         if to == "180":
             inds = np.where(lon_swap > 180)
-            lon_swap[inds] = lon_swap[inds] - 360
+            if type(lon_swap) == xr.core.dataarray.DataArray:
+                lon_swap.values[inds] = lon_swap[inds] - 360
+            else:
+                lon_swap[inds] = lon_swap[inds] - 360
         elif to == "360":
             inds = np.where(lon_swap < 0)
-            lon_swap[inds] = lon_swap[inds] + 360
+            if type(lon_swap) == xr.core.dataarray.DataArray:
+                lon_swap.values[inds] = lon_swap[inds] + 360
+            else:
+                lon_swap[inds] = lon_swap[inds] + 360
 
         return lon_swap
 
@@ -512,15 +516,14 @@ class DatasetSpatialAverageAccessor:
         # of 20, then the grid cells in between the region bounds (20 and 300)
         # are given zero weight (or partial weight if the grid bounds overlap
         # with the region bounds).
-        d_bounds.load()
         if r_bounds[1] >= r_bounds[0]:
             # Case 1 (simple case): not wrapping around prime meridian.
             # Adjustments for above / right of region.
-            d_bounds[d_bounds[:, 0] > r_bounds[1], 0] = r_bounds[1]
-            d_bounds[d_bounds[:, 1] > r_bounds[1], 1] = r_bounds[1]
+            d_bounds.values[d_bounds[:, 0] > r_bounds[1], 0] = r_bounds[1]
+            d_bounds.values[d_bounds[:, 1] > r_bounds[1], 1] = r_bounds[1]
             # Adjustments for below / left of region.
-            d_bounds[d_bounds[:, 0] < r_bounds[0], 0] = r_bounds[0]
-            d_bounds[d_bounds[:, 1] < r_bounds[0], 1] = r_bounds[0]
+            d_bounds.values[d_bounds[:, 0] < r_bounds[0], 0] = r_bounds[0]
+            d_bounds.values[d_bounds[:, 1] < r_bounds[0], 1] = r_bounds[0]
 
         else:
             # Case 2: wrapping around prime meridian [for longitude only]

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -515,6 +515,9 @@ class DatasetSpatialAverageAccessor:
         d_bounds = domain_bounds.copy()
         r_bounds = region_bounds.copy()
 
+        if type(d_bounds.data) == Array:
+            d_bounds.load()
+
         # Since longitude is circular, the logic depends on whether the region
         # spans across the prime meridian or not. If a region does not include
         # the prime meridian, then grid cells between the upper/lower region
@@ -527,11 +530,11 @@ class DatasetSpatialAverageAccessor:
         if r_bounds[1] >= r_bounds[0]:
             # Case 1 (simple case): not wrapping around prime meridian.
             # Adjustments for above / right of region.
-            d_bounds.values[d_bounds[:, 0] > r_bounds[1], 0] = r_bounds[1]
-            d_bounds.values[d_bounds[:, 1] > r_bounds[1], 1] = r_bounds[1]
+            d_bounds[d_bounds[:, 0] > r_bounds[1], 0] = r_bounds[1]
+            d_bounds[d_bounds[:, 1] > r_bounds[1], 1] = r_bounds[1]
             # Adjustments for below / left of region.
-            d_bounds.values[d_bounds[:, 0] < r_bounds[0], 0] = r_bounds[0]
-            d_bounds.values[d_bounds[:, 1] < r_bounds[0], 1] = r_bounds[0]
+            d_bounds[d_bounds[:, 0] < r_bounds[0], 0] = r_bounds[0]
+            d_bounds[d_bounds[:, 1] < r_bounds[0], 1] = r_bounds[0]
 
         else:
             # Case 2: wrapping around prime meridian [for longitude only]


### PR DESCRIPTION
## Description

This PR is intended to fix #115. It simply updates the `dataarray.values` attribute directly (when applicable) to maintain compatibility with chunked dataarray data (for spatial averaging routines). 

- Closes #115 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected) [Not Applicable]
