### PR TITLE
Add exception for coords of len <= 1 or multidimensional coords in `fill_missing_bounds()`

### DIFF
--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -9,7 +9,7 @@ from typing_extensions import Literal, get_args
 
 from xcdat.logger import setup_custom_logger
 
-logger = setup_custom_logger("root")
+logger = setup_custom_logger(__name__)
 
 Coord = Literal["lat", "latitude", "lon", "longitude", "time"]
 #: Tuple of supported coordinates in XCDAT functions and methods.
@@ -34,7 +34,7 @@ class BoundsAccessor:
     Fill missing coordinate bounds in the Dataset:
 
     >>> ds = xr.open_dataset("file_path")
-    >>> ds = ds.bounds.fill_missing()
+    >>> ds = ds.bounds.fill_missing_bounds()
 
     Get coordinate bounds if they exist:
 
@@ -96,19 +96,27 @@ class BoundsAccessor:
             )
         )
 
-    def fill_missing(self) -> xr.Dataset:
+    def fill_missing_bounds(self) -> xr.Dataset:
         """Fills any missing bounds for supported coordinates in the Dataset.
 
         Returns
         -------
         xr.Dataset
         """
-        for coord in [*self._dataset.coords]:
-            if coord in SUPPORTED_COORDS:
+        coords = [
+            coord for coord in [*self._dataset.coords] if coord in SUPPORTED_COORDS
+        ]
+
+        for coord in coords:
+            try:
+                self.get_bounds(coord)
+            except KeyError:
                 try:
-                    self._dataset.cf.get_bounds(coord)
-                except KeyError:
                     self._dataset = self.add_bounds(coord)
+                except ValueError as err:
+                    logger.warning(
+                        f"{err} Make sure '{coord}' coordinates don't require bounds."
+                    )
 
         return self._dataset
 
@@ -170,7 +178,7 @@ class BoundsAccessor:
             If bounds already exist. They must be dropped first.
         """
         try:
-            self._dataset.cf.get_bounds(coord)
+            self.get_bounds(coord)
             raise ValueError(
                 f"{coord} bounds already exist. Drop them first to add new bounds."
             )

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -75,7 +75,7 @@ def open_dataset(
     if ds.cf.dims.get("T") is not None:
         ds = decode_time_units(ds)
 
-    ds = ds.bounds.fill_missing()
+    ds = ds.bounds.fill_missing_bounds()
     return ds
 
 
@@ -152,7 +152,7 @@ def open_mfdataset(
     if ds.cf.dims.get("T") is not None:
         ds = decode_time_units(ds)
 
-    ds = ds.bounds.fill_missing()
+    ds = ds.bounds.fill_missing_bounds()
     return ds
 
 

--- a/xcdat/xcdat.py
+++ b/xcdat/xcdat.py
@@ -49,10 +49,10 @@ class XCDATAccessor:
         obj = BoundsAccessor(self._dataset)
         return obj.bounds
 
-    @is_documented_by(BoundsAccessor.fill_missing)
+    @is_documented_by(BoundsAccessor.fill_missing_bounds)
     def fill_missing_bounds(self) -> xr.Dataset:
         obj = BoundsAccessor(self._dataset)
-        return obj.fill_missing()
+        return obj.fill_missing_bounds()
 
     @is_documented_by(BoundsAccessor.get_bounds)
     def get_bounds(self, coord: Coord) -> xr.DataArray:


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #137 
- Rename `fill_missing()` to `fill_missing_bounds()` -- breaking change
- Update logger name to `root` in `bounds.py`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected) -- skipping major release, will note in changelog for `v0.2.0`
