### PR TITLE
Rename accessor classes and methods for API consistency

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,7 +25,7 @@ New Features
 
 -  Add ``DatasetBoundsAccessor`` class for filling missing bounds,
    returning mapping of bounds, returning names of bounds keys
--  Add ``XCDATBoundsAccessor`` class for accessing xcdat public methods
+-  Add ``BoundsAccessor`` class for accessing xcdat public methods
    from other accessor classes
 
    -  This will be probably be the API endpoint for most users, unless

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -3,17 +3,17 @@ import pytest
 import xarray as xr
 
 from tests.fixtures import generate_dataset, lat_bnds, lon_bnds, time_bnds
-from xcdat.bounds import DatasetBoundsAccessor
+from xcdat.bounds import BoundsAccessor
 
 
-class TestDatasetBoundsAccessor:
+class TestBoundsAccessor:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=False)
         self.ds_with_bnds = generate_dataset(cf_compliant=True, has_bounds=True)
 
     def test__init__(self):
-        obj = DatasetBoundsAccessor(self.ds)
+        obj = BoundsAccessor(self.ds)
         assert obj._dataset.identical(self.ds)
 
     def test_decorator_call(self):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -54,7 +54,7 @@ class TestOpenDataset:
 
         result_ds = open_dataset(self.file_path, data_var="ts")
         # Replicates decode_times=False, which adds units to "time" coordinate.
-        # Refer to xcdat.bounds.BoundsAcccessor._add_bounds() for
+        # Refer to xcdat.bounds.BoundsAccessor._add_bounds() for
         # how attributes propagate from coord to coord bounds.
         result_ds["time_bnds"].attrs["units"] = "months since 2000-01-01"
 
@@ -129,7 +129,7 @@ class TestOpenMfDataset:
         result_ds = open_mfdataset([self.file_path1, self.file_path2], data_var="ts")
 
         # Replicates decode_times=False, which adds units to "time" coordinate.
-        # Refer to xcdat.bounds.BoundsAcccessor._add_bounds() for
+        # Refer to xcdat.bounds.BoundsAccessor._add_bounds() for
         # how attributes propagate from coord to coord bounds.
         result_ds.time_bnds.attrs["units"] = "months since 2000-01-01"
 
@@ -160,7 +160,7 @@ class TestOpenMfDataset:
 
         result_ds = open_mfdataset([self.file_path1, self.file_path2], data_var="ts")
         # Replicates decode_times=False, which adds units to "time" coordinate.
-        # Refer to xcdat.bounds.BoundsAcccessor._add_bounds() for
+        # Refer to xcdat.bounds.BoundsAccessor._add_bounds() for
         # how attributes propagate from coord to coord bounds.
         result_ds.time_bnds.attrs["units"] = "months since 2000-01-01"
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -54,7 +54,7 @@ class TestOpenDataset:
 
         result_ds = open_dataset(self.file_path, data_var="ts")
         # Replicates decode_times=False, which adds units to "time" coordinate.
-        # Refer to xcdat.bounds.DatasetBoundsAccessor._add_bounds() for
+        # Refer to xcdat.bounds.BoundsAcccessor._add_bounds() for
         # how attributes propagate from coord to coord bounds.
         result_ds["time_bnds"].attrs["units"] = "months since 2000-01-01"
 
@@ -129,7 +129,7 @@ class TestOpenMfDataset:
         result_ds = open_mfdataset([self.file_path1, self.file_path2], data_var="ts")
 
         # Replicates decode_times=False, which adds units to "time" coordinate.
-        # Refer to xcdat.bounds.DatasetBoundsAccessor._add_bounds() for
+        # Refer to xcdat.bounds.BoundsAcccessor._add_bounds() for
         # how attributes propagate from coord to coord bounds.
         result_ds.time_bnds.attrs["units"] = "months since 2000-01-01"
 
@@ -160,7 +160,7 @@ class TestOpenMfDataset:
 
         result_ds = open_mfdataset([self.file_path1, self.file_path2], data_var="ts")
         # Replicates decode_times=False, which adds units to "time" coordinate.
-        # Refer to xcdat.bounds.DatasetBoundsAccessor._add_bounds() for
+        # Refer to xcdat.bounds.BoundsAcccessor._add_bounds() for
         # how attributes propagate from coord to coord bounds.
         result_ds.time_bnds.attrs["units"] = "months since 2000-01-01"
 

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -2,11 +2,29 @@ import numpy as np
 import pytest
 import xarray as xr
 
-import xcdat.spatial_avg  # noqa: F401
 from tests.fixtures import generate_dataset
+from xcdat.spatial_avg import SpatialAverageAccessor
 
 
-class TestSpatialAverage:
+class TestSpatialAverageAcccessor:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
+
+    def test__init__(self):
+        ds = self.ds.copy()
+        obj = SpatialAverageAccessor(ds)
+
+        assert obj._dataset.identical(ds)
+
+    def test_decorator_call(self):
+        ds = self.ds.copy()
+        obj = ds.spatial
+
+        assert obj._dataset.identical(ds)
+
+
+class TestSpatialAvg:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
@@ -20,7 +38,7 @@ class TestSpatialAverage:
 
     def test_raises_error_if_data_var_not_in_dataset(self):
         with pytest.raises(KeyError):
-            self.ds.spatial.avg(
+            self.ds.spatial.spatial_avg(
                 "not_a_data_var",
                 axis=["lat", "incorrect_axess"],
             )
@@ -32,7 +50,7 @@ class TestSpatialAverage:
         ds.attrs["xcdat_infer"] = "ts"
 
         # `data_var` kwarg is not specified, so an inference is attempted
-        result = ds.spatial.avg(
+        result = ds.spatial.spatial_avg(
             axis=["lat", "lon"], lat_bounds=(-5.0, 5), lon_bounds=(-170, -120.1)
         )
 
@@ -50,7 +68,7 @@ class TestSpatialAverage:
         self,
     ):
         ds = self.ds.copy()
-        result = ds.spatial.avg(
+        result = ds.spatial.spatial_avg(
             "ts", axis=["lat", "lon"], lat_bounds=(-5.0, 5), lon_bounds=(-170, -120.1)
         )
 
@@ -67,7 +85,7 @@ class TestSpatialAverage:
         ds = self.ds.copy()
 
         # Specifying axis as a str instead of list of str.
-        result = ds.spatial.avg(
+        result = ds.spatial.spatial_avg(
             "ts", axis="lat", lat_bounds=(-5.0, 5), lon_bounds=(-170, -120.1)
         )
 
@@ -86,7 +104,7 @@ class TestSpatialAverage:
         ds = self.ds.copy().chunk(2)
 
         # Specifying axis as a str instead of list of str.
-        result = ds.spatial.avg(
+        result = ds.spatial.spatial_avg(
             "ts", axis="lat", lat_bounds=(-5.0, 5), lon_bounds=(-170, -120.1)
         )
 

--- a/xcdat/__init__.py
+++ b/xcdat/__init__.py
@@ -1,5 +1,7 @@
 """Top-level package for xcdat."""
+from xcdat.bounds import BoundsAccessor  # noqa: F401
 from xcdat.dataset import decode_time_units, open_dataset, open_mfdataset  # noqa: F401
+from xcdat.spatial_avg import SpatialAverageAccessor  # noqa: F401
 from xcdat.xcdat import XCDATAccessor  # noqa: F401
 
 __version__ = "0.1.0"

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -18,7 +18,7 @@ SUPPORTED_COORDS: Tuple[Coord, ...] = get_args(Coord)
 
 @xr.register_dataset_accessor("bounds")
 class BoundsAccessor:
-    """A class to represent the BoundsAcccessor.
+    """A class to represent the BoundsAccessor.
 
     Examples
     ---------

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -17,8 +17,8 @@ SUPPORTED_COORDS: Tuple[Coord, ...] = get_args(Coord)
 
 
 @xr.register_dataset_accessor("bounds")
-class DatasetBoundsAccessor:
-    """A class to represent the DatasetBoundsAccessor.
+class BoundsAccessor:
+    """A class to represent the BoundsAcccessor.
 
     Examples
     ---------

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -21,13 +21,13 @@ RegionAxisBounds = Tuple[Union[float, int], Union[float, int]]
 
 
 @xr.register_dataset_accessor("spatial")
-class DatasetSpatialAverageAccessor:
-    """A class to represent the DatasetSpatialAverageAccessor."""
+class SpatialAverageAccessor:
+    """A class to represent the SpatialAverageAccessor."""
 
     def __init__(self, dataset: xr.Dataset):
         self._dataset: xr.Dataset = dataset
 
-    def avg(
+    def spatial_avg(
         self,
         data_var: Optional[str] = None,
         axis: Union[List[SupportedAxes], SupportedAxes] = ["lat", "lon"],
@@ -103,17 +103,17 @@ class DatasetSpatialAverageAccessor:
 
         Get global average time series:
 
-        >>> ts_global = ds.spatial.avg("tas", axis=["lat", "lon"])["tas"]
+        >>> ts_global = ds.spatial.spatial_avg("tas", axis=["lat", "lon"])["tas"]
 
         Get time series in Nino 3.4 domain:
 
-        >>> ts_n34 = ds.spatial.avg("ts", axis=["lat", "lon"],
+        >>> ts_n34 = ds.spatial.spatial_avg("ts", axis=["lat", "lon"],
         >>>     lat_bounds=(-5, 5),
         >>>     lon_bounds=(-170, -120))["ts"]
 
         Get zonal mean time series:
 
-        >>> ts_zonal = ds.spatial.avg("tas", axis=['lon'])["tas"]
+        >>> ts_zonal = ds.spatial.spatial_avg("tas", axis=['lon'])["tas"]
 
         Using custom weights for averaging:
 
@@ -124,7 +124,7 @@ class DatasetSpatialAverageAccessor:
         >>>     dims=["lat", "lon"],
         >>> )
         >>>
-        >>> ts_global = ds.spatial.avg("tas", axis=["lat","lon"],
+        >>> ts_global = ds.spatial.spatial_avg("tas", axis=["lat","lon"],
         >>>     weights=weights)["tas"]
         """
         dataset = self._dataset.copy()
@@ -603,7 +603,7 @@ class DatasetSpatialAverageAccessor:
         This methods checks for the dimensional alignment between the
         ``weights`` and ``data_var``. It assumes that ``data_var`` has the same
         keys that are specified  in ``axis``, which has already been validated
-        using ``self._validate_axis()`` in ``self.avg()``.
+        using ``self._validate_axis()`` in ``self.spatial_avg()``.
 
         Parameters
         ----------

--- a/xcdat/xcdat.py
+++ b/xcdat/xcdat.py
@@ -3,9 +3,8 @@ from typing import Dict, List, Optional, Union
 
 import xarray as xr
 
-from xcdat.bounds import BoundsAccessor, Coord  # noqa: F401
-from xcdat.spatial_avg import SpatialAverageAccessor  # noqa: F401
-from xcdat.spatial_avg import RegionAxisBounds, SupportedAxes
+from xcdat.bounds import BoundsAccessor, Coord
+from xcdat.spatial_avg import RegionAxisBounds, SpatialAverageAccessor, SupportedAxes
 from xcdat.utils import is_documented_by
 
 

--- a/xcdat/xcdat.py
+++ b/xcdat/xcdat.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Optional, Union
 
 import xarray as xr
 
-from xcdat.bounds import Coord, DatasetBoundsAccessor  # noqa: F401
-from xcdat.spatial_avg import DatasetSpatialAverageAccessor  # noqa: F401
+from xcdat.bounds import BoundsAccessor, Coord  # noqa: F401
+from xcdat.spatial_avg import SpatialAverageAccessor  # noqa: F401
 from xcdat.spatial_avg import RegionAxisBounds, SupportedAxes
 from xcdat.utils import is_documented_by
 
@@ -32,7 +32,7 @@ class XCDATAccessor:
     def __init__(self, dataset: xr.Dataset):
         self._dataset: xr.Dataset = dataset
 
-    @is_documented_by(DatasetSpatialAverageAccessor.avg)
+    @is_documented_by(SpatialAverageAccessor.spatial_avg)
     def spatial_avg(
         self,
         data_var: Optional[str] = None,
@@ -41,26 +41,26 @@ class XCDATAccessor:
         lat_bounds: Optional[RegionAxisBounds] = None,
         lon_bounds: Optional[RegionAxisBounds] = None,
     ) -> xr.Dataset:
-        obj = DatasetSpatialAverageAccessor(self._dataset)
-        return obj.avg(data_var, axis, weights, lat_bounds, lon_bounds)
+        obj = SpatialAverageAccessor(self._dataset)
+        return obj.spatial_avg(data_var, axis, weights, lat_bounds, lon_bounds)
 
     @property  # type: ignore
-    @is_documented_by(DatasetBoundsAccessor.bounds)
+    @is_documented_by(BoundsAccessor.bounds)
     def bounds(self) -> Dict[str, Optional[xr.DataArray]]:
-        obj = DatasetBoundsAccessor(self._dataset)
+        obj = BoundsAccessor(self._dataset)
         return obj.bounds
 
-    @is_documented_by(DatasetBoundsAccessor.fill_missing)
+    @is_documented_by(BoundsAccessor.fill_missing)
     def fill_missing_bounds(self) -> xr.Dataset:
-        obj = DatasetBoundsAccessor(self._dataset)
+        obj = BoundsAccessor(self._dataset)
         return obj.fill_missing()
 
-    @is_documented_by(DatasetBoundsAccessor.get_bounds)
+    @is_documented_by(BoundsAccessor.get_bounds)
     def get_bounds(self, coord: Coord) -> xr.DataArray:
-        obj = DatasetBoundsAccessor(self._dataset)
+        obj = BoundsAccessor(self._dataset)
         return obj.get_bounds(coord)
 
-    @is_documented_by(DatasetBoundsAccessor.add_bounds)
+    @is_documented_by(BoundsAccessor.add_bounds)
     def add_bounds(self, coord: Coord, width: float = 0.5) -> xr.Dataset:
-        obj = DatasetBoundsAccessor(self._dataset)
+        obj = BoundsAccessor(self._dataset)
         return obj.add_bounds(coord, width)


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
The goal of this PR is to make the API naming convention consistent across accessor classes.

The `Dataset` portion of accessor class names are removed because it is redundant.

- Closes #140 
- Rename `DatasetBoundsAccessor` to `BoundsAccessor` (breaking change)
- Rename `DatasetSpatialAverageAccessor` to `SpatialAverageAccessor` (breaking change)
- Rename `SpatialAverageAccessor.avg()` to `SpatialAverageAccessor.spatial_avg()` (breaking change)
  - The original reason why it was called `.avg()` was because the accessor class and decorator (`ds.spatial.avg`) already describes what the averaging operation was targeting. However, it was not aligned with `ds.xcdat.spatial_avg()`, which can throw users off. 
- Add tests for `SpatialAverageAccessor` class 
- Add accessor classes to `xcdat.__init__.py`
- Remove flake8 noqa comments in `xcdat.py`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected) -- won't increment as a major release, just note in `v0.2.0` changelog
