### PR TITLE
Update `open_mfdataset()` to avoid data vars dim concatenation

### DIFF
--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -20,7 +20,7 @@ def open_dataset(
 
     - Decode both CF and non-CF compliant time units if the Dataset has a time
       dimension
-    - Fill missing bounds for supported axes
+    - Fill missing bounds for supported axis
     - Option to limit the Dataset to a single regular (non-bounds) data
       variable, while retaining any bounds data variables
 
@@ -94,7 +94,7 @@ def open_mfdataset(
 
     - Decode both CF and non-CF compliant time units if the Dataset has a time
       dimension
-    - Fill missing bounds for supported axes
+    - Fill missing bounds for supported axis
     - Option to limit the Dataset to a single regular (non-bounds) data
       variable, while retaining any bounds data variables
 

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -98,11 +98,12 @@ def open_mfdataset(
     - Option to limit the Dataset to a single regular (non-bounds) data
       variable, while retaining any bounds data variables
 
-    ``data_vars`` defaults to `"minimal"` so that data variables across files
-    are concatenated together in a single Dataset object with only preexisting
-    dimensions. For example, the time dimension will not be concatenated to the
-    dimensions of non-time data variables such as "lat_bnds" or "lon_bnds". This
-    behavior is similar to opening up a single file using `open_dataset()`.
+    ``data_vars`` defaults to `"minimal"`, which concatenates data variables in
+    a manner where only data variables in which the dimension already appears
+    are included. For example, the time dimension will not be concatenated to
+    the dimensions of non-time data variables such as "lat_bnds" or "lon_bnds".
+    `"minimal"` is required for some XCDAT functions, including spatial
+    averaging where a reduction is performed using the lat/lon bounds.
 
     ``decode_times`` is statically set to ``False``. This enables a check
     for whether the units in the time dimension (if it exists) contains CF or

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -18,10 +18,11 @@ def open_dataset(
 
     Operations include:
 
-    - If the dataset has a time dimension, decode both CF and non-CF time units.
-    - Generate bounds for supported coordinates if they don't exist.
+    - Decode both CF and non-CF compliant time units if the Dataset has a time
+      dimension
+    - Fill missing bounds for supported axes
     - Option to limit the Dataset to a single regular (non-bounds) data
-      variable while retaining any bounds data variables.
+      variable, while retaining any bounds data variables
 
     ``decode_times`` is statically set to ``False``. This enables a check
     for whether the units in the time dimension (if it exists) contains CF or
@@ -91,10 +92,11 @@ def open_mfdataset(
 
     Operations include:
 
-    - If the dataset has a time dimension, decode both CF and non-CF time units.
-    - Generate bounds for supported coordinates if they don't exist.
-    - Option to limit the Dataset to a single regular (non-bounds) data variable
-      while retaining any bounds data variables.
+    - Decode both CF and non-CF compliant time units if the Dataset has a time
+      dimension
+    - Fill missing bounds for supported axes
+    - Option to limit the Dataset to a single regular (non-bounds) data
+      variable, while retaining any bounds data variables
 
     ``data_vars`` defaults to `"minimal"` so that data variables across files
     are concatenated together in a single Dataset object with only preexisting
@@ -129,9 +131,8 @@ def open_mfdataset(
           * list of str: The listed data variables will be concatenated, in
             addition to the "minimal" data variables.
     kwargs : Dict[str, Any]
-        Additional arguments passed on to ``xarray.open_mfdataset`` and/or
-        ``xarray.open_dataset``. Refer to the [1]_ xarray docs for accepted
-        keyword arguments.
+        Additional arguments passed on to ``xarray.open_mfdataset``. Refer to
+        the [2]_ xarray docs for accepted keyword arguments.
 
     Returns
     -------

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -23,9 +23,9 @@ def open_dataset(
     - Option to limit the Dataset to a single regular (non-bounds) data
       variable while retaining any bounds data variables.
 
-    ``decode_times`` is set statically to ``False`` to check if the dataset
-    contains CF or non-CF compliant units, which determines if manual
-    decoding is necessary.
+    ``decode_times`` is statically set to ``False``. This enables a check
+    for whether the units in the time dimension (if it exists) contains CF or
+    non-CF compliant units, which determines if manual decoding is necessary.
 
     Parameters
     ----------
@@ -96,15 +96,15 @@ def open_mfdataset(
     - Option to limit the Dataset to a single regular (non-bounds) data variable
       while retaining any bounds data variables.
 
-    ``data_vars`` defaults to `"minimal"` so that data variables are
-    concatenated together with only preexisting dimensions. For example, the
-    time dimension will not be concatenated to the dimension of non-time data
-    variables such as "lat_bnds" or "lon_bnds". This behavior is similar to
-    opening up just a single Dataset.
+    ``data_vars`` defaults to `"minimal"` so that data variables across files
+    are concatenated together in a single Dataset object with only preexisting
+    dimensions. For example, the time dimension will not be concatenated to the
+    dimensions of non-time data variables such as "lat_bnds" or "lon_bnds". This
+    behavior is similar to opening up a single file using `open_dataset()`.
 
-    ``decode_times`` is set statically to ``False`` to check if the dataset
-    contains CF or non-CF compliant units, which determines if manual
-    decoding is necessary.
+    ``decode_times`` is statically set to ``False``. This enables a check
+    for whether the units in the time dimension (if it exists) contains CF or
+    non-CF compliant units, which determines if manual decoding is necessary.
 
     Parameters
     ----------

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -146,7 +146,10 @@ def open_mfdataset(
     >>> from xcdat.dataset import open_dataset
     >>> ds = open_mfdataset(["file_path1", "file_path2"], data_var=["ts", "tas"])
     """
-    ds = xr.open_mfdataset(paths, decode_times=False, **kwargs)
+    # Data variables are concatenated together with data_vars=“minimal”, where
+    # only data variables in which the dimension already appears are included.
+    # https://github.com/pydata/xarray/issues/438
+    ds = xr.open_mfdataset(paths, decode_times=False, data_vars="minimal", **kwargs)
     ds = infer_or_keep_var(ds, data_var)
 
     if ds.cf.dims.get("T") is not None:

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Hashable, List, Optional, Union
 
 import pandas as pd
 import xarray as xr
+from typing_extensions import Literal
 
 from xcdat import bounds  # noqa: F401
 from xcdat.logger import setup_custom_logger
@@ -22,6 +23,10 @@ def open_dataset(
     - Option to limit the Dataset to a single regular (non-bounds) data
       variable while retaining any bounds data variables.
 
+    ``decode_times`` is set statically to ``False`` to check if the dataset
+    contains CF or non-CF compliant units, which determines if manual
+    decoding is necessary.
+
     Parameters
     ----------
     path : str
@@ -29,11 +34,8 @@ def open_dataset(
     data_var: Optional[str], optional
         The key of the data variable to keep in the Dataset, by default None.
     kwargs : Dict[str, Any]
-        Additional arguments passed on to ``xarray.open_dataset``.
-
-        - Visit the xarray docs for accepted arguments [1]_.
-        - ``decode_times`` defaults to ``False`` to allow for the manual
-          decoding of non-CF time units.
+        Additional arguments passed on to ``xarray.open_dataset``. Refer to the
+        [1]_ xarray docs for accepted keyword arguments.
 
     Returns
     -------
@@ -82,6 +84,7 @@ def open_dataset(
 def open_mfdataset(
     paths: Union[str, List[str]],
     data_var: Optional[str] = None,
+    data_vars: Union[Literal["minimal", "different", "all"], List[str]] = "minimal",
     **kwargs: Dict[str, Any],
 ) -> xr.Dataset:
     """Wrapper for ``xarray.open_mfdataset()`` that applies common operations.
@@ -90,8 +93,18 @@ def open_mfdataset(
 
     - If the dataset has a time dimension, decode both CF and non-CF time units.
     - Generate bounds for supported coordinates if they don't exist.
-    - Option to limit the Dataset to a single regular (non-bounds) data
-      variable while retaining any bounds data variables.
+    - Option to limit the Dataset to a single regular (non-bounds) data variable
+      while retaining any bounds data variables.
+
+    ``data_vars`` defaults to `"minimal"` so that data variables are
+    concatenated together with only preexisting dimensions. For example, the
+    time dimension will not be concatenated to the dimension of non-time data
+    variables such as "lat_bnds" or "lon_bnds". This behavior is similar to
+    opening up just a single Dataset.
+
+    ``decode_times`` is set statically to ``False`` to check if the dataset
+    contains CF or non-CF compliant units, which determines if manual
+    decoding is necessary.
 
     Parameters
     ----------
@@ -103,13 +116,22 @@ def open_mfdataset(
         for details). (A string glob will be expanded to a 1-dimensional list.)
     data_var: Optional[str], optional
         The key of the data variable to keep in the Dataset, by default None.
+    data_vars: Union[Literal["minimal", "different", "all"], List[str]], optional
+        These data variables will be concatenated together:
+          * "minimal": Only data variables in which the dimension already
+            appears are included, default.
+          * "different": Data variables which are not equal (ignoring
+            attributes) across all datasets are also concatenated (as well as
+            all for which dimension already appears). Beware: this option may
+            load the data payload of data variables into memory if they are not
+            already loaded.
+          * "all": All data variables will be concatenated.
+          * list of str: The listed data variables will be concatenated, in
+            addition to the "minimal" data variables.
     kwargs : Dict[str, Any]
         Additional arguments passed on to ``xarray.open_mfdataset`` and/or
-        ``xarray.open_dataset``.
-
-        - Visit the xarray docs for accepted arguments, [2]_ and [3]_.
-        - ``decode_times`` defaults to ``False`` to allow for the manual
-          decoding of non-CF time units.
+        ``xarray.open_dataset``. Refer to the [1]_ xarray docs for accepted
+        keyword arguments.
 
     Returns
     -------
@@ -127,7 +149,6 @@ def open_mfdataset(
     ----------
 
     .. [2] https://xarray.pydata.org/en/stable/generated/xarray.open_mfdataset.html
-    .. [3] https://xarray.pydata.org/en/stable/generated/xarray.open_dataset.html
 
     Examples
     --------
@@ -146,10 +167,7 @@ def open_mfdataset(
     >>> from xcdat.dataset import open_dataset
     >>> ds = open_mfdataset(["file_path1", "file_path2"], data_var=["ts", "tas"])
     """
-    # Data variables are concatenated together with data_vars=“minimal”, where
-    # only data variables in which the dimension already appears are included.
-    # https://github.com/pydata/xarray/issues/438
-    ds = xr.open_mfdataset(paths, decode_times=False, data_vars="minimal", **kwargs)
+    ds = xr.open_mfdataset(paths, decode_times=False, data_vars=data_vars, **kwargs)
     ds = infer_or_keep_var(ds, data_var)
 
     if ds.cf.dims.get("T") is not None:


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
- Closes #136 

This PR updates `xcdat.open_mfdataset()` with a default option for `data_vars="minimal` to avoid data vars dim concatenation (which breaks a reduction in spatial averaging).

The default `xr.open_mfdataset()` behavior is to concat dims across data vars.  Adding `data_vars="minimal"` stops this from happening. Notice below that the `time` dimension is no longer added to dims of `lat_bnds` and `lon_bnds` when passing this kwarg.
```
>>> dir = "/p/user_pub/PCMDIobs/PCMDIobs2/atmos/3hr/pr/TRMM-3B43v-7/gn/v20200707"
>>> file_pattern = "pr_3hr_TRMM-3B43v-7_BE_gn_v20200707_1998*.nc"
>>> files = os.path.join(dir, file_pattern)

>>> ds_xr = xr.open_mfdataset(files)
>>> ds_xr2 = xr.open_mfdataset(files, data_vars="minimal")

>>> print(ds_xr)
<xarray.Dataset>
Dimensions:    (time: 2920, bnds: 2, lat: 400, lon: 1440)
Coordinates:
  * time       (time) datetime64[ns] 1998-01-01 ... 1998-12-31T21:00:00
  * lat        (lat) float64 -49.88 -49.62 -49.38 -49.12 ... 49.38 49.62 49.88
  * lon        (lon) float64 0.125 0.375 0.625 0.875 ... 359.1 359.4 359.6 359.9
Dimensions without coordinates: bnds
Data variables:
    time_bnds  (time, bnds) datetime64[ns] dask.array<chunksize=(248, 2), meta=np.ndarray>
    lat_bnds   (time, lat, bnds) float64 dask.array<chunksize=(248, 400, 2), meta=np.ndarray>
    lon_bnds   (time, lon, bnds) float64 dask.array<chunksize=(248, 1440, 2), meta=np.ndarray>
    pr         (time, lat, lon) float32 dask.array<chunksize=(248, 400, 1440), meta=np.ndarray>

>>> print(ds_xr2)
<xarray.Dataset>
Dimensions:    (time: 2920, bnds: 2, lat: 400, lon: 1440)
Coordinates:
  * time       (time) datetime64[ns] 1998-01-01 ... 1998-12-31T21:00:00
  * lat        (lat) float64 -49.88 -49.62 -49.38 -49.12 ... 49.38 49.62 49.88
  * lon        (lon) float64 0.125 0.375 0.625 0.875 ... 359.1 359.4 359.6 359.9
Dimensions without coordinates: bnds
Data variables:
    time_bnds  (time, bnds) datetime64[ns] dask.array<chunksize=(248, 2), meta=np.ndarray>
    lat_bnds   (lat, bnds) float64 dask.array<chunksize=(400, 2), meta=np.ndarray>
    lon_bnds   (lon, bnds) float64 dask.array<chunksize=(1440, 2), meta=np.ndarray>
    pr         (time, lat, lon) float32 dask.array<chunksize=(248, 400, 1440), meta=np.ndarray>
```
In #136, the `time` dimension was being added to `lat_bnds` and `lon_bnds`.
As a result, the `lat` and `lon` dims were being reduced down, leaving just the `time` dimension. This would produce the error  `KeyError: 'Check weights DataArray includes lat dimension.'`
https://github.com/XCDAT/xcdat/blob/ca9dee4390cad2ad9856f9959e75981575cc69d7/xcdat/spatial_avg.py#L592-L596

More info on [xarray.open_mfdataset()](https://xarray.pydata.org/en/stable/generated/xarray.open_mfdataset.html).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
