### PR TITLE
Refactor bugfix/150-refactor-spatial-avg (PR #152)

### DIFF
--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -31,7 +31,7 @@ class SpatialAverageAccessor:
         self,
         data_var: Optional[str] = None,
         axis: Union[List[SupportedAxes], SupportedAxes] = ["lat", "lon"],
-        weights: xr.DataArray = None,
+        weights: Union[Literal["generate"], xr.DataArray] = "generate",
         lat_bounds: Optional[RegionAxisBounds] = None,
         lon_bounds: Optional[RegionAxisBounds] = None,
     ) -> xr.Dataset:
@@ -58,11 +58,12 @@ class SpatialAverageAccessor:
         axis : Union[List[SupportedAxes], SupportedAxes]
             List of axis dimensions or single axes dimension to average over.
             For example, ["lat", "lon"]  or "lat", by default ["lat", "lon"].
-        weights : Optional[xr.DataArray], optional
-            A DataArray containing the regional weights used for weighted
+        weights : Union[Literal["generate"], xr.DataArray], optional
+            If "generate", then weights are generated. Otherwise, pass a
+            DataArray containing the regional weights used for weighted
             averaging. ``weights`` must include the same spatial axis dimensions
-            and have the same dimensional sizes as the data variable. If None,
-            then weights are generated; by default None.
+            and have the same dimensional sizes as the data variable, by default
+            "generate".
         lat_bounds : Optional[RegionAxisBounds], optional
             A tuple of floats/ints for the regional latitude lower and upper
             boundaries. This arg is used when calculating axis weights, but is
@@ -140,7 +141,7 @@ class SpatialAverageAccessor:
 
         axis = self._validate_axis(da_data_var, axis)
 
-        if weights is None:
+        if weights == "generate":
             if lat_bounds is not None:
                 self._validate_region_bounds("lat", lat_bounds)
             if lon_bounds is not None:
@@ -182,8 +183,8 @@ class SpatialAverageAccessor:
         if isinstance(axis, str):
             axis = [axis]
 
-        for axes in axis:
-            if axes not in SUPPORTED_AXES:
+        for dim in axis:
+            if dim not in SUPPORTED_AXES:
                 raise ValueError(
                     "Incorrect `axis` argument. Supported axes include: "
                     f"{', '.join(SUPPORTED_AXES)}."
@@ -194,10 +195,10 @@ class SpatialAverageAccessor:
             # linked to a "latitude" key ), and cf_xarray does not support
             # `data_var.cf.get(axes, None)`.
             try:
-                data_var.cf[axes]
+                data_var.cf[dim]
             except KeyError:
                 raise KeyError(
-                    f"The data variable '{data_var.name}' is missing a '{axes}' "
+                    f"The data variable '{data_var.name}' is missing a '{dim}' "
                     "dimension, which is required for spatial averaging."
                 )
 
@@ -324,93 +325,156 @@ class SpatialAverageAccessor:
         """
         BoundsByType = TypedDict(
             "BoundsByType",
-            {"domain": Optional[xr.DataArray], "region": Optional[RegionAxisBounds]},
+            {"domain": xr.DataArray, "region": Optional[RegionAxisBounds]},
         )
+
         bounds: Dict[str, BoundsByType] = {
             "lat": {
-                "domain": self._dataset.bounds.get_bounds("lat"),
+                "domain": self._dataset.bounds.get_bounds("lat").copy(),
                 "region": lat_bounds,
             },
             "lon": {
-                "domain": self._dataset.bounds.get_bounds("lon"),
+                "domain": self._dataset.bounds.get_bounds("lon").copy(),
                 "region": lon_bounds,
             },
         }
         axis_weights: AxisWeights = {}
-
         for dim, bounds_by_type in bounds.items():
-            domain_bounds = bounds_by_type["domain"]
-            region_bounds = bounds_by_type["region"]
+            if dim in axis:
+                d_bounds = bounds_by_type["domain"]
+                self._validate_domain_bounds(d_bounds)
 
-            if domain_bounds is not None:
-                dom_bounds = domain_bounds.copy()
+                r_bounds = bounds_by_type["region"]
+                if r_bounds is not None:
+                    r_bounds = np.array(r_bounds, dtype="float")
 
-                # validate domain bounds
-                self._validate_domain_bounds(dom_bounds)
+                if dim == "lon":
+                    weights = self._get_longitude_weights(d_bounds, r_bounds)
+                elif dim == "lat":
+                    weights = self._get_latitude_weights(d_bounds, r_bounds)
 
-                if region_bounds is not None:
-                    reg_bounds = np.array(region_bounds).astype(float)
-                    if dim == "lon":
-                        # Ensure that domain and regional bounds are both
-                        # in the range of 0 -> 360
-                        dom_bounds = self._swap_lon_axes(dom_bounds, to=360)
-                        reg_bounds = self._swap_lon_axes(reg_bounds, to=360)
+                weights.attrs = d_bounds.attrs
+                weights.name = dim + "_wts"
+                axis_weights[dim] = weights
 
-                        # Some grid cells cross the prime meridian (
-                        # e.g., [-1, 1]). Check for this special case. If it
-                        # applies, return the index of that grid cell
-                        # (otherwise None) and recreate the dims with two
-                        # grid cells ([0, 1] and [359, 360]).
-                        pmb_index, dom_bounds = self._align_longitude_to_360_axis(
-                            dom_bounds
-                        )
-
-                        # If the region bounds are equal, it means all
-                        # longitude values are specified (e.g., (360, 360) ==
-                        # (0, 360)). As a result, set the region lon bounds to
-                        # [0, 360].
-                        if reg_bounds[1] - reg_bounds[0] == 0:
-                            reg_bounds[0] = 0.0
-                            reg_bounds[1] = 360.0
-
-                    # Scale the domain boundaries to the regional domain
-                    dom_bounds = self._scale_domain_to_region(dom_bounds, reg_bounds)
-
-                if dim == "lat":
-                    # The area between two lines of latitude scales as the
-                    # difference of the sine of latitude bounds. This scaling
-                    # is applied here.
-                    dom_bounds = np.sin(np.radians(dom_bounds))
-                    pmb_index = None
-
-                # Perform differencing to get weights and add metadata.
-                dim_wts = np.abs(dom_bounds[:, 1] - dom_bounds[:, 0])
-
-                # If pmb_index is not None it means that an extra
-                # longitude bound was added and the weight vector
-                # is too long. This extra weight should be added to the
-                # grid cell that crossed the prime meridian (and then
-                # removed from the dim_wts vector).
-                if pmb_index is not None:
-                    dim_wts[pmb_index] = dim_wts[pmb_index] + dim_wts[-1]
-                    dim_wts = dim_wts[0:-1]
-
-                # ensure attributes remain on dim_wts
-                dim_wts.attrs = dom_bounds.attrs
-                dim_wts.name = dim + "_wts"
-                axis_weights[dim] = dim_wts
-
-        weights = self._combine_weights(axis, axis_weights)
+        weights = self._combine_weights(axis_weights)
         return weights
 
-    def _align_longitude_to_360_axis(self, domain_bounds: xr.DataArray):
-        """
-        Ensure the domain bounds are within 0 to 360.
+    def _get_longitude_weights(
+        self, domain_bounds: xr.DataArray, region_bounds: np.array
+    ) -> xr.DataArray:
+        """Gets weights for the longitude axis.
 
-        This method is designed to deal with the special case that
-        a grid cell encompasses the prime meridian (e.g., [359, 1]).
-        In this case, calculating longitudinal weights is complicated
-        because the weights are determined by the difference of the bounds.
+        This method performs longitudinal processing including (in order):
+
+        1. Align the axis orientations of the domain and region bounds to
+           (0, 360) to ensure compatibility in the proceeding steps.
+        2. Handle grid cells that cross the prime meridian (e.g., [-1, 1]) by
+           breaking such grid cells into two (e.g., [0, 1] and [359, 360]) to
+           ensure alignment with the (0, 360) axis orientation. This results in
+           a bounds axis of length(nlon)+1. The index of the grid cell that
+           crosses the prime meridian is returned in order to reduce the length
+           of weights to nlon.
+        3. Scale the domain down to a region (if selected).
+        4. Calculate weights using the domain bounds.
+        5. If the prime meridian grid cell exists, use this cell's index to
+           handle the weights vector's increased length as a result of the two
+           additional grid cells. The extra weights are added to the prime
+           meridian grid cell and removed from the weights vector to ensure the
+           lengths of the weights and its corresponding domain remain in
+           alignment.
+
+        Parameters
+        ----------
+        domain_bounds : xr.DataArray
+            The array of bounds for the latitude domain.
+        region_bounds : np.array
+            The array of bounds for latitude regional selection.
+
+        Returns
+        -------
+        xr.DataArray
+            The longitude axes weights.
+        """
+        p_meridian_index: Optional[np.array] = None
+
+        if region_bounds is not None:
+            domain_bounds = self._swap_lon_axis(domain_bounds, to=360)
+            region_bounds = self._swap_lon_axis(region_bounds, to=360)
+
+            is_region_circular = region_bounds[1] - region_bounds[0] == 0
+            if is_region_circular:
+                region_bounds = np.array([0.0, 360.0])
+
+            (
+                domain_bounds,
+                p_meridian_index,
+            ) = self._align_longitude_to_360_axis(domain_bounds)
+            domain_bounds = self._scale_domain_to_region(domain_bounds, region_bounds)
+
+        weights = self._calculate_weights(domain_bounds)
+        if p_meridian_index is not None:
+            weights[p_meridian_index] = weights[p_meridian_index] + weights[-1]
+            weights = weights[0:-1]
+
+        return weights
+
+    def _get_latitude_weights(
+        self, domain_bounds: xr.DataArray, region_bounds: xr.DataArray
+    ) -> xr.DataArray:
+        """Gets weights for the latitude axis.
+
+        This method scales the domain to a region (if selected). It also scales
+        the area between two lines of latitude scales as the difference of the
+        sine of latitude bounds.
+
+        Parameters
+        ----------
+        domain_bounds : xr.DataArray
+            The array of bounds for the latitude domain.
+        region_bounds : np.array
+            The array of bounds for latitude regional selection.
+
+        Returns
+        -------
+        xr.DataArray
+            The latitude axis weights.
+        """
+        if region_bounds is not None:
+            domain_bounds = self._scale_domain_to_region(domain_bounds, region_bounds)
+
+        domain_bounds = np.sin(np.radians(domain_bounds))
+        weights = self._calculate_weights(domain_bounds)
+
+        return weights
+
+    def _calculate_weights(self, domain_bounds: xr.DataArray):
+        """Calculate weights for the domain.
+
+        This method takes the absolute difference between the upper and lower
+        bound values to calculate weights.
+
+        Parameters
+        ----------
+        domain_bounds : xr.DataArray
+            The array of bounds for a domain.
+
+        Returns
+        -------
+        xr.DataArray
+            The weights for an axes.
+        """
+        return np.abs(domain_bounds[:, 1] - domain_bounds[:, 0])
+
+    def _align_longitude_to_360_axis(
+        self, domain_bounds: xr.DataArray
+    ) -> Tuple[xr.DataArray, np.array]:
+        """Handles a prime meridian cell to align longitude axes to (0, 360).
+
+        This method ensures the domain bounds are within 0 to 360 by handling
+        the grid cell that encompasses the prime meridian (e.g., [359, 1]). In
+        this case, calculating longitudinal weights is complicated because the
+        weights are determined by the difference of the bounds.
 
         If this situation exists, the method will split this grid cell into
         two parts (one east and west of the prime meridian). The original
@@ -419,11 +483,11 @@ class SpatialAverageAccessor:
         corresponding to the domain bounds west of the prime meridian. For
         instance, a grid cell spanning -1 to 1, will be broken into a cell
         from 0 to 1 and 359 to 360 (or -1 to 0). The index of the original
-        grid cell is returned as ``pmb_index`` along with the updated
-        ``domain_bounds``.
+        prime meridian grid cell is returned as ``p_meridian_index`` along with
+        the updated ``domain_bounds``.
 
-        If no domain grid bounds span across the prime meridian, ``pmb_index``
-        is set to None and the original ``domain_bounds`` are returned.
+        If no domain grid bounds span across the prime meridian, the original
+        ``domain_bounds`` are returned and `p_meridian_index` returns None.
 
         Parameters
         ----------
@@ -433,53 +497,56 @@ class SpatialAverageAccessor:
 
         Returns
         -------
-        xr.DataArray
-           A DataArray containing the original or upated longitude bounds.
+        Tuple[xr.DataArray, Optional[np.array]]
+           A tuple, with the first element being the domain bounds DataArray,
+           and the second being an np.array with a single element representing
+           the index of the prime meridian grid cell.
 
         Notes
         -----
         This method returns ``domain_bounds`` that are intended for calculating
         spatial weights only.
         """
-
-        # copy bounds to work on
-        d_bounds = domain_bounds.copy()
-        # find instances of d_bounds spanning the prime meridian
-        pmb_index = np.where(d_bounds[:, 1] - d_bounds[:, 0] < 0)[0]
-        # check bounds to ensure they range from 0 to 360
-        if (np.min(d_bounds).values < 0) | (np.max(d_bounds).values > 360):
+        if (domain_bounds.values.min() < 0) | (domain_bounds.values.max() > 360):
             raise ValueError(
-                "Longitude bounds between 0 and 360. Use _swap_lon_axes"
-                "before calling _align_longitude_to_360_axis."
+                "Longitude bounds aren't inclusively between 0 and 360. "
+                "Use `_swap_lon_axis()` before calling `_align_longitude_to_360_axis()`."
             )
 
-        # there should be 0 or 1 such grid cells
-        if len(pmb_index) > 1:
+        p_meridian_index = np.where(domain_bounds[:, 1] - domain_bounds[:, 0] < 0)[0]
+        if len(p_meridian_index) == 0:
+            p_meridian_index = None
+        elif len(p_meridian_index) > 1:
             raise ValueError("More than one grid cell spans prime meridian.")
-        elif len(pmb_index) == 1:
-            # convert index array to integer index
-            pmb_index = pmb_index[0]
-            # reorient bound to span across zero (i.e., [361, 1] -> [-1, 1])
-            d_bounds[pmb_index, 0] = d_bounds[pmb_index, 0] - 360.0
-            # extend the dataarray to nlon+1 by concatenating the grid cell
-            # that spans the prime meridian to the end
-            d_bounds = xr.concat((d_bounds, d_bounds[pmb_index, :]), dim="lon")
-            # produce an equivalent bound that spans 360
-            # (i.e., [-1, 1] -> [359, 361])
-            repeat_bound = d_bounds[pmb_index, :] + 360.0
-            # place this repeat bound at the end of the DataArray
-            d_bounds[-1, :] = repeat_bound
-            # limit bounds to [0, 360]
-            d_bounds[pmb_index, 0] = 0.0
-            d_bounds[-1, 1] = 360.0
-        else:
-            pmb_index = None
-        return pmb_index, d_bounds
+        elif len(p_meridian_index) == 1:
+            # Example array: [[359, 1], [1, 90], [90, 180], [180, 359]]
+            # Reorient bound to span across zero (i.e., [359, 1] -> [-1, 1]).
+            # Result: [[-1, 1], [1, 90], [90, 180], [180, 359]]
+            domain_bounds[p_meridian_index, 0] = (
+                domain_bounds[p_meridian_index, 0] - 360.0
+            )
+            # Extend the array to nlon+1 by concatenating the grid cell that
+            # spans the prime meridian to the end.
+            # Result: [[-1, 1], [1, 90], [90, 180], [180, 359], [-1, 1]]
+            domain_bounds = xr.concat(
+                (domain_bounds, domain_bounds[p_meridian_index, :]), dim="lon"
+            )
+            # Add an equivalent bound that spans 360
+            # (i.e., [-1, 1] -> [359, 361]) to the end of the array.
+            # Result: [[-1, 1], [1, 90], [90, 180], [180, 359], [359, 361]]
+            repeat_bound = domain_bounds[p_meridian_index, :][0] + 360.0
+            domain_bounds[-1, :] = repeat_bound
 
-    def _swap_lon_axes(
+            # Update the lower-most min and upper-most max bounds to [0, 360].
+            # Result: [[0, 1], [1, 90], [90, 180], [180, 359], [359, 360]]
+            domain_bounds[p_meridian_index, 0], domain_bounds[-1, 1] = (0.0, 360.0)
+
+        return domain_bounds, p_meridian_index
+
+    def _swap_lon_axis(
         self, lon: Union[xr.DataArray, np.ndarray], to: Literal[180, 360]
     ) -> Union[xr.DataArray, np.ndarray]:
-        """Swap the longitude axes orientation.
+        """Swap the longitude axis orientation.
 
         Parameters
         ----------
@@ -610,9 +677,7 @@ class SpatialAverageAccessor:
 
         return d_bounds
 
-    def _combine_weights(
-        self, axis: List[SupportedAxes], axis_weights: AxisWeights
-    ) -> xr.DataArray:
+    def _combine_weights(self, axis_weights: AxisWeights) -> xr.DataArray:
         """Generically rescales axis weights for a given region.
 
         This method creates an n-dimensional weighting array by performing
@@ -621,8 +686,6 @@ class SpatialAverageAccessor:
 
         Parameters
         ----------
-        axis : List[SupportedAxes]
-            List of axes that should be weighted.
         axis_weights : AxisWeights
             Dictionary of axis weights, where key is axes and value is the
             corresponding DataArray of weights.
@@ -634,10 +697,7 @@ class SpatialAverageAccessor:
             ``weights`` are 1-D and correspond to the specified axes (``axis``)
             in the region.
         """
-        weights = {
-            axes: weights for axes, weights in axis_weights.items() if axes in axis
-        }
-        region_weights = reduce((lambda x, y: x * y), weights.values())
+        region_weights = reduce((lambda x, y: x * y), axis_weights.values())
         return region_weights
 
     def _validate_weights(

--- a/xcdat/xcdat.py
+++ b/xcdat/xcdat.py
@@ -2,6 +2,7 @@
 from typing import Dict, List, Optional, Union
 
 import xarray as xr
+from typing_extensions import Literal
 
 from xcdat.bounds import Axis, BoundsAccessor
 from xcdat.spatial_avg import RegionAxisBounds, SpatialAverageAccessor, SupportedAxes
@@ -36,7 +37,7 @@ class XCDATAccessor:
         self,
         data_var: Optional[str] = None,
         axis: Union[List[SupportedAxes], SupportedAxes] = ["lat", "lon"],
-        weights: xr.DataArray = None,
+        weights: Union[Literal["generate"], xr.DataArray] = "generate",
         lat_bounds: Optional[RegionAxisBounds] = None,
         lon_bounds: Optional[RegionAxisBounds] = None,
     ) -> xr.Dataset:


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This PR is a refactoring effort of PR #152.

Summary of Changes
- Update `spatial_avg()` `weights` kwarg default val to `"generate"`
  - Closes #147 
- Refactor `get_weights()`
  - Update so that it only gets weights based on `axis` arg
  - Add `_get_longitude_weights()` and `_get_latitude_weights()`
  - Add `_calculate_weights()`
- Update `combine_weights()` to not parse the `axis_weights()` dict 
  - Only the relevant weights from `get_weights()` based on specified `axis` arg
- Refactor `_align_longitude_to_360_axis()`
- Update `_swap_lon_axes` to `_swap_lon_axis`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
