### PR TITLE
Fix indexing on axis keys using generic map (related to spatial averaging)

### DIFF
--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -40,7 +40,7 @@ class TestSpatialAvg:
         with pytest.raises(KeyError):
             self.ds.spatial.spatial_avg(
                 "not_a_data_var",
-                axis=["lat", "incorrect_axess"],
+                axis=["lat", "incorrect_axis"],
             )
 
     def test_weighted_spatial_average_for_lat_and_lon_region_for_an_inferred_data_var(
@@ -125,17 +125,17 @@ class TestValidateAxis:
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
 
-    def test_raises_error_if_axis_list_contains_unsupported_axes(self):
+    def test_raises_error_if_axis_list_contains_unsupported_axis(self):
         with pytest.raises(ValueError):
-            self.ds.spatial._validate_axis(self.ds.ts, axis=["lat", "incorrect_axes"])
+            self.ds.spatial._validate_axis(self.ds.ts, axis=["lat", "incorrect_axis"])
 
-    def test_raises_error_if_lat_axes_does_not_exist(self):
+    def test_raises_error_if_lat_axis_does_not_exist(self):
         ds = self.ds.copy()
         ds["ts"] = xr.DataArray(data=None, coords={"lon": ds.lon}, dims=["lon"])
         with pytest.raises(KeyError):
             ds.spatial._validate_axis(ds.ts, axis=["lat", "lon"])
 
-    def test_raises_error_if_lon_axes_does_not_exist(self):
+    def test_raises_error_if_lon_axis_does_not_exist(self):
         ds = self.ds.copy()
         ds["ts"] = xr.DataArray(data=None, coords={"lat": ds.lat}, dims=["lat"])
         with pytest.raises(KeyError):
@@ -247,7 +247,7 @@ class TestValidateWeights:
             )
 
 
-class TestSwapLonAxes:
+class TestSwapLonAxis:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
@@ -460,7 +460,7 @@ class TestGetLongitudeWeights:
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
 
     def test_weights_for_region_in_lon_domain(self):
-        # Longitude axes orientation swaps from (-180, 180) to (0, 360).
+        # Longitude axis orientation swaps from (-180, 180) to (0, 360).
         result = self.ds.spatial._get_longitude_weights(
             domain_bounds=self.ds.lon_bnds.copy(),
             region_bounds=np.array([-170.0, -120.0]),
@@ -496,7 +496,7 @@ class TestGetLongitudeWeights:
         # Domain spans prime meridian.
         ds.lon_bnds.data[:] = np.array([[359, 1], [1, 90], [90, 180], [180, 359]])
 
-        # Longitude axes orientation swaps from (-180, 180) to (0, 360).
+        # Longitude axis orientation swaps from (-180, 180) to (0, 360).
         result = ds.spatial._get_longitude_weights(
             domain_bounds=ds.lon_bnds,
             region_bounds=np.array([-170.0, -120.0]),
@@ -911,7 +911,7 @@ class TestAverager:
 
         assert result.identical(expected)
 
-    def test_weighted_avg_over_lat_axes(self):
+    def test_weighted_avg_over_lat_axis(self):
         weights = xr.DataArray(
             name="lat_wts",
             data=np.array([1, 2, 3, 4]),
@@ -929,7 +929,7 @@ class TestAverager:
 
         assert result.identical(expected)
 
-    def test_weighted_avg_over_lon_axes(self):
+    def test_weighted_avg_over_lon_axis(self):
         weights = xr.DataArray(
             name="lon_wts",
             data=np.array([1, 2, 3, 4]),
@@ -947,7 +947,7 @@ class TestAverager:
 
         assert result.identical(expected)
 
-    def test_weighted_avg_over_lat_and_lon_axes(self):
+    def test_weighted_avg_over_lat_and_lon_axis(self):
         weights = xr.DataArray(
             data=np.array([[1, 2, 3, 4], [2, 4, 6, 8], [3, 6, 9, 12], [4, 8, 12, 16]]),
             coords={"lat": self.ds.lat, "lon": self.ds.lon},

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -962,3 +962,14 @@ class TestAverager:
         )
 
         assert result.identical(expected)
+
+
+class TestGetGenericAxisKeys:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
+
+    def test_generic_keys(self):
+        result = self.ds.spatial._get_generic_axis_keys(["lat", "lon"])
+        expected = ["Y", "X"]
+        assert result == expected

--- a/xcdat/axes.py
+++ b/xcdat/axes.py
@@ -1,0 +1,23 @@
+"""Axes module for resources related to axes."""
+
+from typing import Dict
+
+from typing_extensions import Literal
+
+# Mapping of CF compliant long and short axes names to their generic
+# representations. This map is useful for indexing a Dataset/DataArray on
+# a key by falling back on the generic version. Attempting to index on the short
+# key when the long key is used will fail, but using the generic key should
+# work.
+CFAxes = Literal["lat", "latitude", "Y", "lon", "longitude", "X", "time", "T"]
+GenericAxes = Literal["X", "Y", "T"]
+GENERIC_AXIS_MAP: Dict[CFAxes, GenericAxes] = {
+    "lat": "Y",
+    "latitude": "Y",
+    "Y": "Y",
+    "lon": "X",
+    "longitude": "X",
+    "X": "X",
+    "time": "T",
+    "T": "T",
+}

--- a/xcdat/axis.py
+++ b/xcdat/axis.py
@@ -1,17 +1,17 @@
-"""Axes module for resources related to axes."""
+"""Axis module for utilities related to axes."""
 
 from typing import Dict
 
 from typing_extensions import Literal
 
-# Mapping of CF compliant long and short axes names to their generic
+# Mapping of CF compliant long and short axis keys to their generic
 # representations. This map is useful for indexing a Dataset/DataArray on
 # a key by falling back on the generic version. Attempting to index on the short
 # key when the long key is used will fail, but using the generic key should
 # work.
-CFAxes = Literal["lat", "latitude", "Y", "lon", "longitude", "X", "time", "T"]
-GenericAxes = Literal["X", "Y", "T"]
-GENERIC_AXIS_MAP: Dict[CFAxes, GenericAxes] = {
+CFAxis = Literal["lat", "latitude", "Y", "lon", "longitude", "X", "time", "T"]
+GenericAxis = Literal["X", "Y", "T"]
+GENERIC_AXIS_MAP: Dict[CFAxis, GenericAxis] = {
     "lat": "Y",
     "latitude": "Y",
     "Y": "Y",

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -7,7 +7,7 @@ import numpy as np
 import xarray as xr
 from typing_extensions import Literal
 
-from xcdat.axes import GENERIC_AXIS_MAP
+from xcdat.axis import GENERIC_AXIS_MAP
 from xcdat.logger import setup_custom_logger
 
 logger = setup_custom_logger(__name__)

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -12,7 +12,7 @@ from xcdat.logger import setup_custom_logger
 
 logger = setup_custom_logger(__name__)
 
-#: Tuple of supported CF-compliant axis names for bounds operations.
+#: Tuple of supported CF compliant axis keys for bounds operations.
 BoundsAxis = Literal["lat", "latitude", "Y", "lon", "longitude", "X", "time", "T"]
 
 

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -13,7 +13,7 @@ from xcdat.dataset import get_inferred_var
 
 #: Type alias for a dictionary of axes keys mapped to their bounds.
 AxisWeights = Dict[Hashable, xr.DataArray]
-#: Type alias for supported axis strings for spatial averaging.
+#: Type alias for supported axis keys for spatial averaging.
 SpatialAxis = Literal["lat", "lon"]
 SPATIAL_AXES: Tuple[SpatialAxis, ...] = get_args(SpatialAxis)
 #: Type alias for a tuple of floats/ints for the regional selection bounds.

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -8,7 +8,7 @@ import xarray as xr
 from dask.array.core import Array
 from typing_extensions import Literal, TypedDict, get_args
 
-from xcdat.axes import GENERIC_AXIS_MAP, GenericAxes
+from xcdat.axis import GENERIC_AXIS_MAP, GenericAxis
 from xcdat.dataset import get_inferred_var
 
 #: Type alias for a dictionary of axes keys mapped to their bounds.
@@ -784,7 +784,7 @@ class SpatialAverageAccessor:
             )
             return weighted_mean
 
-    def _get_generic_axis_keys(self, axis: List[SpatialAxis]) -> List[GenericAxes]:
+    def _get_generic_axis_keys(self, axis: List[SpatialAxis]) -> List[GenericAxis]:
         """Converts supported axis keys to their generic CF representations.
 
         Since XCDAT's spatial averaging accepts the CF short version of axes
@@ -801,7 +801,7 @@ class SpatialAverageAccessor:
 
         Returns
         -------
-        List[GenericAxes]
+        List[GenericAxis]
             List of axis dimension(s) to average over.
         """
         generic_axis_keys = []

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -11,7 +11,7 @@ from typing_extensions import Literal, TypedDict, get_args
 from xcdat.axis import GENERIC_AXIS_MAP, GenericAxis
 from xcdat.dataset import get_inferred_var
 
-#: Type alias for a dictionary of axes keys mapped to their bounds.
+#: Type alias for a dictionary of axis keys mapped to their bounds.
 AxisWeights = Dict[Hashable, xr.DataArray]
 #: Type alias for supported axis keys for spatial averaging.
 SpatialAxis = Literal["lat", "lon"]
@@ -43,7 +43,7 @@ class SpatialAverageAccessor:
 
         - If a regional boundary is specified, check to ensure it is within the
           data variable's domain boundary.
-        - If axis weights are not provided, get axis weights for standard axes
+        - If axis weights are not provided, get axis weights for standard axis
           domains specified in ``axis``.
         - Adjust weights to conform to the specified regional boundary.
         - Compute spatial weighted average.
@@ -85,12 +85,6 @@ class SpatialAverageAccessor:
         ------
         KeyError
             If data variable does not exist in the Dataset.
-        KeyError
-            If data variable does not contain an "Y" axes (latitude dimension).
-        KeyError
-            If data variable does not contain an "X" axes (longitude dimension).
-        ValueError
-            If an incorrect axes is specified in ``axis``.
 
         Examples
         --------
@@ -162,19 +156,19 @@ class SpatialAverageAccessor:
         data_var : xr.DataArray
             The data variable.
         axis : Union[List[SpatialAxis], SpatialAxis]
-            List of axis dimensions or single axes dimension to average over.
+            List of axis dimensions or single axis dimension to average over.
 
         Returns
         -------
         List[SpatialAxis]
-            List of axis dimensions or single axes dimension to average over.
+            List of axis dimensions or single axis dimension to average over.
 
         Raises
         ------
         ValueError
-            If any value inside ``axis`` is not supported.
+            If any key in ``axis`` is not supported for spatial averaging.
         KeyError
-            If any value inside ``axis`` does not exist in the ``data_var``.
+            If any key in ``axis`` does not exist in the ``data_var``.
         """
         if isinstance(axis, str):
             axis = [axis]
@@ -279,9 +273,9 @@ class SpatialAverageAccessor:
         lon_bounds: Optional[RegionAxisBounds],
     ) -> xr.DataArray:
         """
-        Get area weights for specified axes and an optional target domain.
+        Get area weights for specified axis keys and an optional target domain.
 
-        This method first determines the weights for individual axes based on
+        This method first determines the weights for individual axis based on
         the difference between the upper and lower bound. For latitude the
         weight is determined by the difference of sine(latitude). The individual
         axis weights are then combined to form a DataArray of weights that can
@@ -385,7 +379,7 @@ class SpatialAverageAccessor:
         Returns
         -------
         xr.DataArray
-            The longitude axes weights.
+            The longitude axis weights.
         """
         p_meridian_index: Optional[np.array] = None
 
@@ -460,7 +454,7 @@ class SpatialAverageAccessor:
     def _align_longitude_to_360_axis(
         self, domain_bounds: xr.DataArray
     ) -> Tuple[xr.DataArray, np.array]:
-        """Handles a prime meridian cell to align longitude axes to (0, 360).
+        """Handles a prime meridian cell to align longitude axis to (0, 360).
 
         This method ensures the domain bounds are within 0 to 360 by handling
         the grid cell that encompasses the prime meridian (e.g., [359, 1]). In
@@ -672,21 +666,21 @@ class SpatialAverageAccessor:
         """Generically rescales axis weights for a given region.
 
         This method creates an n-dimensional weighting array by performing
-        matrix multiplication for a list of specified axes using a dictionary of
-        axis weights.
+        matrix multiplication for a list of specified axis keys using a
+        dictionary of axis weights.
 
         Parameters
         ----------
         axis_weights : AxisWeights
-            Dictionary of axis weights, where key is axes and value is the
+            Dictionary of axis weights, where key is axis and value is the
             corresponding DataArray of weights.
 
         Returns
         -------
         xr.DataArray
             A DataArray containing the region weights to use during averaging.
-            ``weights`` are 1-D and correspond to the specified axes (``axis``)
-            in the region.
+            ``weights`` are 1-D and correspond to the specified axis keys
+            (``axis``) in the region.
         """
         region_weights = reduce((lambda x, y: x * y), axis_weights.values())
         return region_weights
@@ -746,7 +740,7 @@ class SpatialAverageAccessor:
     ):
         """Perform a weighted average of a data variable.
 
-        This method assumes all specified axes in ``axis`` exists in the data
+        This method assumes all specified keys in ``axis`` exists in the data
         variable. Validation for this criteria is performed in
         ``_validate_weights()``.
 

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -332,23 +332,22 @@ class SpatialAverageAccessor:
         }
 
         axis_weights: AxisWeights = {}
-        for axis_key, bounds in axis_bounds.items():
-            if axis_key in axis_key:
-                d_bounds = bounds["domain"]
-                self._validate_domain_bounds(d_bounds)
+        for key in axis:
+            d_bounds = axis_bounds[key]["domain"]
+            self._validate_domain_bounds(d_bounds)
 
-                r_bounds = bounds["region"]
-                if r_bounds is not None:
-                    r_bounds = np.array(r_bounds, dtype="float")
+            r_bounds = axis_bounds[key]["region"]
+            if r_bounds is not None:
+                r_bounds = np.array(r_bounds, dtype="float")
 
-                if axis_key == "lon":
-                    weights = self._get_longitude_weights(d_bounds, r_bounds)
-                elif axis_key == "lat":
-                    weights = self._get_latitude_weights(d_bounds, r_bounds)
+            if key == "lon":
+                weights = self._get_longitude_weights(d_bounds, r_bounds)
+            elif key == "lat":
+                weights = self._get_latitude_weights(d_bounds, r_bounds)
 
-                weights.attrs = d_bounds.attrs
-                weights.name = axis_key + "_wts"
-                axis_weights[axis_key] = weights
+            weights.attrs = d_bounds.attrs
+            weights.name = key + "_wts"
+            axis_weights[key] = weights
 
         weights = self._combine_weights(axis_weights)
         return weights
@@ -786,7 +785,7 @@ class SpatialAverageAccessor:
             )
             return weighted_mean
 
-    def _get_generic_axis_keys(self, axis_keys: List[SpatialAxis]) -> List[GenericAxes]:
+    def _get_generic_axis_keys(self, axis: List[SpatialAxis]) -> List[GenericAxes]:
         """Converts supported axis keys to their generic CF representations.
 
         Since XCDAT's spatial averaging accepts the CF short version of axes
@@ -807,7 +806,7 @@ class SpatialAverageAccessor:
             List of axis dimension(s) to average over.
         """
         generic_axis_keys = []
-        for axis in axis_keys:
-            generic_axis_keys.append(GENERIC_AXIS_MAP[axis])
+        for key in axis:
+            generic_axis_keys.append(GENERIC_AXIS_MAP[key])
 
         return generic_axis_keys

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -13,7 +13,7 @@ from xcdat.dataset import get_inferred_var
 
 #: Type alias for a dictionary of axes keys mapped to their bounds.
 AxisWeights = Dict[Hashable, xr.DataArray]
-#: Type alias of supported axes strings for spatial averaging.
+#: Type alias for supported axis strings for spatial averaging.
 SpatialAxis = Literal["lat", "lon"]
 SPATIAL_AXES: Tuple[SpatialAxis, ...] = get_args(SpatialAxis)
 #: Type alias for a tuple of floats/ints for the regional selection bounds.
@@ -56,7 +56,7 @@ class SpatialAverageAccessor:
             attempted with the Dataset's "xcdat_infer" attr and
             ``get_inferred_var()``, by default None.
         axis : Union[List[SpatialAxis], SpatialAxis]
-            List of axis dimensions or single axes dimension to average over.
+            List of axis dimensions or single axis dimension to average over.
             For example, ["lat", "lon"]  or "lat", by default ["lat", "lon"].
         weights : Union[Literal["generate"], xr.DataArray], optional
             If "generate", then weights are generated. Otherwise, pass a
@@ -163,7 +163,6 @@ class SpatialAverageAccessor:
             The data variable.
         axis : Union[List[SpatialAxis], SpatialAxis]
             List of axis dimensions or single axes dimension to average over.
-            For example, ["lat", "lon"]  or "lat".
 
         Returns
         -------
@@ -790,7 +789,7 @@ class SpatialAverageAccessor:
 
         Since XCDAT's spatial averaging accepts the CF short version of axes
         keys, attempting to index a Dataset/DataArray on the short key through
-        CF-xarray might fail in cases where the long key is used instead (e.g.,
+        cf_xarray might fail for cases where the long key is used instead (e.g.,
         "latitude" instead of "lat"). This method handles this edge case by
         converting the list of axis keys to their generic representations (e.g.,
         "Y" instead of "lat") for indexing operations.

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -275,11 +275,11 @@ class SpatialAverageAccessor:
         """
         Get area weights for specified axis keys and an optional target domain.
 
-        This method first determines the weights for individual axis based on
+        This method first determines the weights for an individual axis based on
         the difference between the upper and lower bound. For latitude the
-        weight is determined by the difference of sine(latitude). The individual
-        axis weights are then combined to form a DataArray of weights that can
-        be used to perform a weighted (spatial) average.
+        weight is determined by the difference of sine(latitude). All axis
+        weights are then combined to form a DataArray of weights that can be
+        used to perform a weighted (spatial) average.
 
         If ``lat_bounds`` or ``lon_bounds`` are supplied, then grid cells
         outside this selected regional domain are given zero weight. Grid cells

--- a/xcdat/xcdat.py
+++ b/xcdat/xcdat.py
@@ -4,8 +4,8 @@ from typing import Dict, List, Optional, Union
 import xarray as xr
 from typing_extensions import Literal
 
-from xcdat.bounds import Axis, BoundsAccessor
-from xcdat.spatial_avg import RegionAxisBounds, SpatialAverageAccessor, SupportedAxes
+from xcdat.bounds import BoundsAccessor, BoundsAxis
+from xcdat.spatial_avg import RegionAxisBounds, SpatialAverageAccessor, SpatialAxis
 from xcdat.utils import is_documented_by
 
 
@@ -36,7 +36,7 @@ class XCDATAccessor:
     def spatial_avg(
         self,
         data_var: Optional[str] = None,
-        axis: Union[List[SupportedAxes], SupportedAxes] = ["lat", "lon"],
+        axis: Union[List[SpatialAxis], SpatialAxis] = ["lat", "lon"],
         weights: Union[Literal["generate"], xr.DataArray] = "generate",
         lat_bounds: Optional[RegionAxisBounds] = None,
         lon_bounds: Optional[RegionAxisBounds] = None,
@@ -56,11 +56,11 @@ class XCDATAccessor:
         return obj.add_missing_bounds()
 
     @is_documented_by(BoundsAccessor.get_bounds)
-    def get_bounds(self, axis: Axis) -> xr.DataArray:
+    def get_bounds(self, axis: BoundsAxis) -> xr.DataArray:
         obj = BoundsAccessor(self._dataset)
         return obj.get_bounds(axis)
 
     @is_documented_by(BoundsAccessor.add_bounds)
-    def add_bounds(self, axis: Axis, width: float = 0.5) -> xr.Dataset:
+    def add_bounds(self, axis: BoundsAxis, width: float = 0.5) -> xr.Dataset:
         obj = BoundsAccessor(self._dataset)
         return obj.add_bounds(axis, width)


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #163 

Summary of Changes
- Add `GENERIC_AXES_MAP` for mapping CF compliant keys to their generic representations
- Add `_get_generic_axis_keys()` for proper indexing in spatial averaging methods
- Update bounds methods to use `GENERIC_AXES_MAP`
- Update incorrect axis refs to axis

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected) -- will include notes in next minor release instead
