### PR TITLE
Add `requires_dask` decorator for tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,3 +61,7 @@ test = pytest
 junit_family=xunit2
 addopts = --cov=xcdat --cov-report term --cov-report html:tests_coverage_reports/htmlcov --cov-report xml:tests_coverage_reports/coverage.xml -s
 python_files = tests.py test_*.py
+# These markers are defined in `xarray.tests` and must be included to avoid warnings when importing from this module.
+markers =
+    flaky
+    network

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,4 @@
 """Unit test package for xcdat."""
-import uuid
-
 from xarray.core.options import set_options
 
 set_options(warn_for_unclosed_files=False)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,6 @@
 """Unit test package for xcdat."""
+import uuid
+
+from xarray.core.options import set_options
+
+set_options(warn_for_unclosed_files=False)

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import xarray as xr
+from xarray.tests import requires_dask
 
 from tests.fixtures import generate_dataset
 from xcdat.spatial_avg import SpatialAverageAccessor
@@ -100,6 +101,7 @@ class TestSpatialAvg:
 
         assert result.identical(expected)
 
+    @requires_dask
     def test_chunked_weighted_spatial_average_for_lat_region(self):
         ds = self.ds.copy().chunk(2)
 
@@ -262,6 +264,7 @@ class TestSwapLonAxis:
         with pytest.raises(ValueError):
             self.ds.spatial._swap_lon_axis(domain, to=9000)
 
+    @requires_dask
     def test_swap_chunked_domain_dataarray_from_180_to_360(self):
         domain = xr.DataArray(
             name="lon_bnds",
@@ -280,6 +283,7 @@ class TestSwapLonAxis:
 
         assert result.identical(expected)
 
+    @requires_dask
     def test_swap_chunked_domain_dataarray_from_360_to_180(self):
         domain = xr.DataArray(
             name="lon_bnds",
@@ -707,6 +711,7 @@ class TestScaleDimToRegion:
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
 
+    @requires_dask
     def test_scales_chunked_lat_bounds_when_not_wrapping_around_prime_meridian(self):
         domain_bounds = xr.DataArray(
             name="lat_bnds",
@@ -729,6 +734,7 @@ class TestScaleDimToRegion:
 
         assert result.identical(expected)
 
+    @requires_dask
     def test_scales_chunked_lon_bounds_when_not_wrapping_around_prime_meridian(self):
         domain_bounds = xr.DataArray(
             name="lon_bnds",
@@ -895,6 +901,7 @@ class TestAverager:
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
 
+    @requires_dask
     def test_chunked_weighted_avg_over_lat_and_lon_axes(self):
         ds = self.ds.copy().chunk(2)
 


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #144 

Additional Changes
- Disable xarray `warn_for_unclosed_files` setting, which gets enabled when importing from `xarray.tests`
- Refactor tests in `test_dataset.py`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
