### PR TITLE
Add matrix testing and ci specific conda env

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -9,73 +9,92 @@ on:
 
     workflow_dispatch:
 
+env:
+    CANCEL_OTHERS: true
+    PATHS_IGNORE: '["**/README.rst", "**/docs/**", "**/ISSUE_TEMPLATE/**", "**/pull_request_template.md", "**/.vscode/**"]'
+
 jobs:
-    check-jobs-to-skip:
+    pre-commit-hooks:
         runs-on: ubuntu-latest
-        outputs:
-            should_skip: ${{ steps.skip_check.outputs.should_skip }}
+        timeout-minutes: 2
         steps:
             - id: skip_check
               uses: fkirc/skip-duplicate-actions@master
               with:
-                  cancel_others: true
-                  paths_ignore: '["**/README.rst", "**/docs/**", "**/ISSUE_TEMPLATE/**", "**/pull_request_template.md", "**/.vscode/**"]'
+                  cancel_others: ${{ env.CANCEL_OTHERS }}
+                  paths_ignore: ${{ env.PATHS_IGNORE }}
 
-    pre-commit-hooks:
-        needs: check-jobs-to-skip
-        if: ${{ needs.check-jobs-to-skip.outputs.should_skip != 'true'}} || ${{ github.event_name == 'push' }}
-        runs-on: ubuntu-latest
-        timeout-minutes: 2
-        steps:
-            - name: Checkout Code Repository
+            - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+              name: Checkout Code Repository
               uses: actions/checkout@v2
 
-            - name: Set up Python 3.9
+            - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+              name: Set up Python 3.9
               uses: actions/setup-python@v2
               with:
                   python-version: 3.9
 
-            # Run all pre-commit hooks on all the files.
-            # Getting only staged files can be tricky in case a new PR is opened
-            # since the action is run on a branch in detached head state
-            - name: Install and Run Pre-commit
+            - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+              # Run all pre-commit hooks on all the files.
+              # Getting only staged files can be tricky in case a new PR is opened
+              # since the action is run on a branch in detached head state
+              name: Install and Run Pre-commit
               uses: pre-commit/action@v2.0.3
 
     build:
-        needs: check-jobs-to-skip
-        if: ${{ needs.check-jobs-to-skip.outputs.should_skip != 'true'}} || ${{ github.event_name == 'push' }}
-        runs-on: ubuntu-latest
+        name: Build (Python ${{ matrix.python-version }})
+        runs-on: "ubuntu-latest"
+        timeout-minutes: 10
         defaults:
             run:
                 shell: bash -l {0}
-        timeout-minutes: 5
+        strategy:
+            matrix:
+                python-version: ["3.7", "3.8", "3.9"]
         steps:
-            - uses: actions/checkout@v2
+            - id: skip_check
+              uses: fkirc/skip-duplicate-actions@master
+              with:
+                  cancel_others: ${{ env.CANCEL_OTHERS }}
+                  paths_ignore: ${{ env.PATHS_IGNORE }}
 
-            - name: Cache Conda
+            - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+              uses: actions/checkout@v2
+
+            - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+              name: Cache Conda
               uses: actions/cache@v2
               env:
-                  # Increase this value to reset cache if conda/dev.yml has not changed in the workflow
+                  # Increase this value to reset cache if conda-env/ci.yml has not changed in the workflow
                   CACHE_NUMBER: 0
               with:
                   path: ~/conda_pkgs_dir
-                  key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-publish
+                  key: ${{ runner.os }}-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}
 
-            - name: Set up Conda Environment
+            - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+              name: Set up Conda Environment
               uses: conda-incubator/setup-miniconda@v2
               with:
-                  activate-environment: "xcdat_dev"
-                  environment-file: conda-env/dev.yml
+                  activate-environment: "xcdat_ci"
+                  environment-file: conda-env/ci.yml
                   channel-priority: strict
                   auto-update-conda: true
                   # IMPORTANT: This needs to be set for caching to work properly!
                   use-only-tar-bz2: true
+                  python-version: ${{ matrix.python-version }}
 
-            - name: Run Tests
+            - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+              name: Install xcdat
+              run: |
+                  python -m pip install .
+
+            - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+              name: Run Tests
               run: |
                   pytest
 
-            - name: Upload Coverage Report
+            - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+              name: Upload Coverage Report
               uses: codecov/codecov-action@v1
               with:
                   file: "tests_coverage_reports/coverage.xml"

--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -1,0 +1,15 @@
+# Conda xcdat CI/CD environment (used in GH Actions)
+name: xcdat_ci
+channels:
+    - conda-forge
+    - defaults
+dependencies:
+    # Base
+    # ==================
+    - python
+    - pip
+    # Testing
+    # ==================
+    - pytest=6.2.5
+    - pytest-cov=3.0.0
+prefix: /opt/miniconda3/envs/xcdat_ci

--- a/docs/project_maintenance.rst
+++ b/docs/project_maintenance.rst
@@ -41,4 +41,4 @@ This workflow is triggered by Git ``pull_request`` and ``push`` (merging PRs) ev
 
 Jobs:
     1. Run ``pre-commit`` for formatting, linting, and type checking
-    2. Build conda development environment and run test suite
+    2. Build conda CI/CD environment with different Python versions, install package, and run test suite


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #110 

This should reduce the anaconda env build time while properly testing the xcdat build with different python versions.
Note, there is a lack of support for matrix testing using an individual job for skipping. Each job must have a step for skipping other steps (https://github.com/fkirc/skip-duplicate-actions/issues/56).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
