### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -50,7 +50,7 @@ jobs:
                 shell: bash -l {0}
         strategy:
             matrix:
-                python-version: ["3.7", "3.8", "3.9"]
+                python-version: ["3.8", "3.9"]
         steps:
             - id: skip_check
               uses: fkirc/skip-duplicate-actions@master

--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
     # Base
     # ==================
-    - python
+    - python>=3.8
     - pip
     # Testing
     # ==================

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -13,7 +13,6 @@ dependencies:
     - netcdf4=1.5.8
     - numpy=1.21.4
     - pandas=1.3.4
-    - typing_extensions=4.0.1 # Required to make use of Python >=3.8 backported types
     - xarray=0.20.1
     # Quality Assurance
     # ==================

--- a/conda-env/readthedocs.yml
+++ b/conda-env/readthedocs.yml
@@ -8,7 +8,6 @@ dependencies:
     # ==================
     - python=3.9.7
     - pip=21.2.4
-    - typing_extensions=3.10.0.0 # Required to make use of Python >=3.8 backported types
     - netcdf4=1.5.7
     - xarray=0.19.0
     - cf_xarray=0.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ exclude =
     venv
 
 [mypy]
-python_version = 3.8
+python_version = 3.9
 check_untyped_defs = True
 ignore_missing_imports = True
 warn_unused_ignores = True

--- a/setup.py
+++ b/setup.py
@@ -19,25 +19,22 @@ install_requires: List[str] = [
     "netcdf4",
     "numpy",
     "pandas",
-    "typing_extensions",
     "xarray",
 ]
 test_requires = ["pytest>=3"]
 
 setup(
     author="XCDAT developers",
-    python_requires=">=3.5",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache-2.0 License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     description="Xarray Extended with Climate Data Analysis Tools",
     install_requires=install_requires,

--- a/xcdat/axis.py
+++ b/xcdat/axis.py
@@ -1,8 +1,6 @@
 """Axis module for utilities related to axes."""
 
-from typing import Dict
-
-from typing_extensions import Literal
+from typing import Dict, Literal
 
 # Mapping of CF compliant long and short axis keys to their generic
 # representations. This map is useful for indexing a Dataset/DataArray on

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -1,11 +1,10 @@
 """Bounds module for functions related to coordinate bounds."""
 import collections
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional
 
 import cf_xarray as cfxr  # noqa: F401
 import numpy as np
 import xarray as xr
-from typing_extensions import Literal
 
 from xcdat.axis import GENERIC_AXIS_MAP
 from xcdat.logger import setup_custom_logger

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -2,11 +2,10 @@
 import pathlib
 from functools import partial
 from glob import glob
-from typing import Any, Callable, Dict, Hashable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Hashable, List, Literal, Optional, Tuple, Union
 
 import pandas as pd
 import xarray as xr
-from typing_extensions import Literal
 
 from xcdat import bounds  # noqa: F401
 from xcdat.logger import setup_custom_logger

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -1,12 +1,21 @@
 """Averager module that contains functions related to geospatial averaging."""
 from functools import reduce
-from typing import Dict, Hashable, List, Optional, Tuple, Union
+from typing import (
+    Dict,
+    Hashable,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    TypedDict,
+    Union,
+    get_args,
+)
 
 import cf_xarray  # noqa: F401
 import numpy as np
 import xarray as xr
 from dask.array.core import Array
-from typing_extensions import Literal, TypedDict, get_args
 
 from xcdat.axis import GENERIC_AXIS_MAP, GenericAxis
 from xcdat.dataset import get_inferred_var

--- a/xcdat/xcdat.py
+++ b/xcdat/xcdat.py
@@ -1,8 +1,7 @@
 """Main xcdat module."""
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 import xarray as xr
-from typing_extensions import Literal
 
 from xcdat.bounds import BoundsAccessor, BoundsAxis
 from xcdat.spatial_avg import RegionAxisBounds, SpatialAverageAccessor, SpatialAxis


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #185 
 
Summary of Changes:
- Remove `typing_extensions` from `setup.py` and conda env dependencies
- Update imports from `typing_extensions` to `typing`
- Remove Python 3.7 from CI build matrix


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
