### PR TITLE
Remove data variable inference API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,8 +14,6 @@ Top-level API
     dataset.has_cf_compliant_time
     dataset.decode_non_cf_time
     dataset.swap_lon_axis
-    dataset.infer_or_keep_var
-    dataset.get_inferred_var
 
 .. currentmodule:: xarray
 

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -69,26 +69,7 @@ class TestSpatialAvg:
 
         assert result.identical(expected)
 
-    def test_spatial_average_for_lat_and_lon_region_for_an_inferred_data_var(self):
-        ds = self.ds.copy()
-        ds.attrs["xcdat_infer"] = "ts"
-
-        # `data_var` kwarg is not specified, so an inference is attempted
-        result = ds.spatial.spatial_avg(
-            axis=["lat", "lon"], lat_bounds=(-5.0, 5), lon_bounds=(-170, -120.1)
-        )
-
-        expected = self.ds.copy()
-        expected.attrs["xcdat_infer"] = "ts"
-        expected["ts"] = xr.DataArray(
-            data=np.array([2.25, 1.0, 1.0]),
-            coords={"time": expected.time},
-            dims="time",
-        )
-
-        assert result.identical(expected)
-
-    def test_spatial_average_for_lat_and_lon_region_for_explicit_data_var(
+    def test_spatial_average_for_lat_and_lon_region(
         self,
     ):
         ds = self.ds.copy()

--- a/tests/test_spatial_avg.py
+++ b/tests/test_spatial_avg.py
@@ -69,9 +69,7 @@ class TestSpatialAvg:
 
         assert result.identical(expected)
 
-    def test_spatial_average_for_lat_and_lon_region(
-        self,
-    ):
+    def test_spatial_average_for_lat_and_lon_region(self):
         ds = self.ds.copy()
         result = ds.spatial.spatial_avg(
             "ts", axis=["lat", "lon"], lat_bounds=(-5.0, 5), lon_bounds=(-170, -120.1)

--- a/xcdat/__init__.py
+++ b/xcdat/__init__.py
@@ -3,9 +3,7 @@ from xcdat.axis import swap_lon_axis  # noqa: F401
 from xcdat.bounds import BoundsAccessor  # noqa: F401
 from xcdat.dataset import (  # noqa: F401
     decode_non_cf_time,
-    get_inferred_var,
     has_cf_compliant_time,
-    infer_or_keep_var,
     open_dataset,
     open_mfdataset,
 )

--- a/xcdat/spatial_avg.py
+++ b/xcdat/spatial_avg.py
@@ -23,7 +23,6 @@ from xcdat.axis import (
     _align_lon_bounds_to_360,
     _get_prime_meridian_index,
 )
-from xcdat.dataset import get_inferred_var
 
 #: Type alias for a dictionary of axis keys mapped to their bounds.
 AxisWeights = Dict[Hashable, xr.DataArray]
@@ -43,7 +42,7 @@ class SpatialAverageAccessor:
 
     def spatial_avg(
         self,
-        data_var: Optional[str] = None,
+        data_var: str,
         axis: Union[List[SpatialAxis], SpatialAxis] = ["lat", "lon"],
         weights: Union[Literal["generate"], xr.DataArray] = "generate",
         lat_bounds: Optional[RegionAxisBounds] = None,
@@ -64,11 +63,9 @@ class SpatialAverageAccessor:
 
         Parameters
         ----------
-        data_var: Optional[str], optional
+        data_var: str
             The name of the data variable inside the dataset to spatially
-            average. If None, an inference to the desired data variable is
-            attempted with the Dataset's "xcdat_infer" attr and
-            ``get_inferred_var()``, by default None.
+            average.
         axis : Union[List[SpatialAxis], SpatialAxis]
             List of axis dimensions or single axis dimension to average over.
             For example, ["lat", "lon"]  or "lat", by default ["lat", "lon"].
@@ -137,15 +134,11 @@ class SpatialAverageAccessor:
         >>>     weights=weights)["tas"]
         """
         dataset = self._dataset.copy()
-
-        if data_var is None:
-            dv = get_inferred_var(dataset)
-        else:
-            dv = dataset.get(data_var, None)
-            if dv is None:
-                raise KeyError(
-                    f"The data variable '{data_var}' does not exist in the dataset."
-                )
+        dv = dataset.get(data_var, None)
+        if dv is None:
+            raise KeyError(
+                f"The data variable '{data_var}' does not exist in the dataset."
+            )
 
         axis = self._validate_axis(dv, axis)
 

--- a/xcdat/xcdat.py
+++ b/xcdat/xcdat.py
@@ -34,7 +34,7 @@ class XCDATAccessor:
     @is_documented_by(SpatialAverageAccessor.spatial_avg)
     def spatial_avg(
         self,
-        data_var: Optional[str] = None,
+        data_var: str,
         axis: Union[List[SpatialAxis], SpatialAxis] = ["lat", "lon"],
         weights: Union[Literal["generate"], xr.DataArray] = "generate",
         lat_bounds: Optional[RegionAxisBounds] = None,


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #194 

* It seems to be adding feature bloat and an unnecessary overhead when working with the API.
* By explicitly referencing the data var key, the API behavior remains consistent, predictable, and controllable.
  * For example, API behaves the same even if the dataset was opened via xarray or XCDAT, or if a single or multiple data vars exist
  * It might be redundant with a dataset that starts out with a single data variable, but if we add more data variables via agg methods (tas_climo), API behavior isn’t straightforward
- It cleans up our tests by eliminating the need to test the APIs with inferred data variables.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
