### PR TITLE
Rename spatial file and class

### DIFF
--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -4,17 +4,17 @@ import xarray as xr
 
 from tests import requires_dask
 from tests.fixtures import generate_dataset
-from xcdat.spatial_avg import SpatialAverageAccessor
+from xcdat.spatial import SpatialAccessor
 
 
-class TestSpatialAverageAcccessor:
+class TestSpatialAccessor:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
 
     def test__init__(self):
         ds = self.ds.copy()
-        obj = SpatialAverageAccessor(ds)
+        obj = SpatialAccessor(ds)
 
         assert obj._dataset.identical(ds)
 

--- a/xcdat/__init__.py
+++ b/xcdat/__init__.py
@@ -7,7 +7,7 @@ from xcdat.dataset import (  # noqa: F401
     open_dataset,
     open_mfdataset,
 )
-from xcdat.spatial_avg import SpatialAverageAccessor  # noqa: F401
+from xcdat.spatial import SpatialAccessor  # noqa: F401
 from xcdat.temporal import TemporalAccessor  # noqa: F401
 from xcdat.utils import compare_datasets  # noqa: F401
 from xcdat.xcdat import XCDATAccessor  # noqa: F401

--- a/xcdat/spatial.py
+++ b/xcdat/spatial.py
@@ -27,7 +27,7 @@ from xcdat.dataset import get_data_var
 
 #: Type alias for a dictionary of axis keys mapped to their bounds.
 AxisWeights = Dict[Hashable, xr.DataArray]
-#: Type alias for supported axis keys for spatial averaging.
+#: Type alias for supported spatial axis keys.
 SpatialAxis = Literal["lat", "lon"]
 SPATIAL_AXES: Tuple[SpatialAxis, ...] = get_args(SpatialAxis)
 #: Type alias for a tuple of floats/ints for the regional selection bounds.
@@ -35,8 +35,8 @@ RegionAxisBounds = Tuple[float, float]
 
 
 @xr.register_dataset_accessor("spatial")
-class SpatialAverageAccessor:
-    """A class to represent the SpatialAverageAccessor."""
+class SpatialAccessor:
+    """A class to represent the SpatialAccessor."""
 
     def __init__(self, dataset: xr.Dataset):
         self._dataset: xr.Dataset = dataset
@@ -100,7 +100,7 @@ class SpatialAverageAccessor:
 
         Examples
         --------
-        Import spatial averaging functionality:
+        Import spatial accessor:
 
         >>> import xcdat
 
@@ -108,7 +108,7 @@ class SpatialAverageAccessor:
 
         >>> ds = xcdat.open_dataset("path/to/file.nc", var="tas")
 
-        Access spatial averaging method:
+        Call spatial averaging method:
 
         >>> # First option
         >>> ds.spatial.spatial_avg(...)

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -207,11 +207,11 @@ class TemporalAccessor:
 
         Examples
         --------
-        Import temporal averaging functionality:
+        Import temporal accessor:
 
         >>> import xcdat
 
-        Access temporal averaging method:
+        Call temporal averaging method:
 
         >>> # First option
         >>> ds.temporal.temporal_avg(...)

--- a/xcdat/xcdat.py
+++ b/xcdat/xcdat.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Literal, Optional, Union
 import xarray as xr
 
 from xcdat.bounds import BoundsAccessor, BoundsAxis
-from xcdat.spatial_avg import RegionAxisBounds, SpatialAverageAccessor, SpatialAxis
+from xcdat.spatial import RegionAxisBounds, SpatialAccessor, SpatialAxis
 from xcdat.temporal import Frequency, Mode, SeasonConfig, TemporalAccessor
 from xcdat.utils import is_documented_by
 
@@ -32,7 +32,7 @@ class XCDATAccessor:
     def __init__(self, dataset: xr.Dataset):
         self._dataset: xr.Dataset = dataset
 
-    @is_documented_by(SpatialAverageAccessor.spatial_avg)
+    @is_documented_by(SpatialAccessor.spatial_avg)
     def spatial_avg(
         self,
         data_var: str,
@@ -41,7 +41,7 @@ class XCDATAccessor:
         lat_bounds: Optional[RegionAxisBounds] = None,
         lon_bounds: Optional[RegionAxisBounds] = None,
     ) -> xr.Dataset:
-        obj = SpatialAverageAccessor(self._dataset)
+        obj = SpatialAccessor(self._dataset)
         return obj.spatial_avg(data_var, axis, weights, lat_bounds, lon_bounds)
 
     @is_documented_by(TemporalAccessor.temporal_avg)


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #206 
- Rename `spatial_avg.py` to `spatial.py`
- Rename `SpatialAverageAccessor` to `SpatialAccessor`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)  -- won't release a new major version since the package is still in beta stage
