### PR TITLE
Extract method `_postprocess_dataset()` and make bounds generation optional

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -46,7 +46,8 @@ Attributes
    :toctree: generated/
    :template: autosummary/accessor_attribute.rst
 
-    Dataset.bounds.bounds
+    Dataset.bounds.map
+    Dataset.bounds.keys
 
 .. _dsmeth_1:
 

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -19,7 +19,7 @@ class TestBoundsAccessor:
     def test_decorator_call(self):
         assert self.ds.bounds._dataset.identical(self.ds)
 
-    def test_bounds_property_returns_map_of_axis_and_coordinate_keys_to_bounds_dataarray(
+    def test_map_property_returns_map_of_axis_and_coordinate_keys_to_bounds_dataarray(
         self,
     ):
         ds = self.ds_with_bnds.copy()

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -19,7 +19,9 @@ class TestBoundsAccessor:
     def test_decorator_call(self):
         assert self.ds.bounds._dataset.identical(self.ds)
 
-    def test_bounds_property_returns_map_of_coordinate_key_to_bounds_dataarray(self):
+    def test_bounds_property_returns_map_of_axis_and_coordinate_keys_to_bounds_dataarray(
+        self,
+    ):
         ds = self.ds_with_bnds.copy()
         expected = {
             "T": ds.time_bnds,
@@ -32,13 +34,13 @@ class TestBoundsAccessor:
             "time": ds.time_bnds,
         }
 
-        result = ds.bounds.bounds
+        result = ds.bounds.map
 
         for key in expected.keys():
             assert result[key].identical(expected[key])
 
-    def test_names_property_returns_a_list_of_sorted_bounds_names(self):
-        result = self.ds_with_bnds.bounds.names
+    def test_names_property_returns_a_list_of_sorted_bounds_keys(self):
+        result = self.ds_with_bnds.bounds.keys
         expected = ["lat_bnds", "lon_bnds", "time_bnds"]
 
         assert result == expected

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -39,7 +39,7 @@ class TestBoundsAccessor:
         for key in expected.keys():
             assert result[key].identical(expected[key])
 
-    def test_names_property_returns_a_list_of_sorted_bounds_keys(self):
+    def test_keys_property_returns_a_list_of_sorted_bounds_keys(self):
         result = self.ds_with_bnds.bounds.keys
         expected = ["lat_bnds", "lon_bnds", "time_bnds"]
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -773,7 +773,7 @@ class TestPostProcessDataset:
         ds = generate_dataset(cf_compliant=True, has_bounds=False)
         ds = ds.drop_dims("time")
 
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             _postprocess_dataset(ds, center_times=True)
 
     def test_adds_missing_lat_and_lon_bounds(self):
@@ -859,7 +859,7 @@ class TestPostProcessDataset:
 
         ds = ds.drop_dims("lon")
 
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             _postprocess_dataset(ds, lon_orient=(0, 360))
 
 
@@ -875,19 +875,19 @@ class TestKeepSingleVar:
         ds = self.ds.copy()
         ds = ds.drop_vars("ts")
 
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             _keep_single_var(ds, key="ts")
 
     def test_raises_error_if_specified_data_var_does_not_exist(self):
         ds = self.ds_mod.copy()
 
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             _keep_single_var(ds, key="nonexistent")
 
     def test_raises_error_if_specified_data_var_is_a_bounds_var(self):
         ds = self.ds_mod.copy()
 
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             _keep_single_var(ds, key="lat_bnds")
 
     def test_returns_dataset_with_specified_data_var(self):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -244,7 +244,7 @@ class TestOpenMfDataset:
         assert result.identical(expected)
         assert result.time.encoding == expected.time.encoding
 
-    def test_only_keeps_specified_var(self):
+    def test_keeps_specified_var(self):
         ds1 = generate_dataset(cf_compliant=True, has_bounds=True)
         ds2 = generate_dataset(cf_compliant=True, has_bounds=True)
         ds2 = ds2.rename_vars({"ts": "tas"})

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -131,7 +131,11 @@ class TestOpenDataset:
         ds_mod = ds.copy()
         ds_mod["tas"] = ds_mod.ts.copy()
 
-        ds_mod.to_netcdf(self.file_path)
+        # Suppress UserWarning regarding missing time.encoding "units" because
+        # it is not relevant to this test.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ds_mod.to_netcdf(self.file_path)
 
         result = open_dataset(self.file_path, data_var="ts")
         expected = ds.copy()

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -185,7 +185,7 @@ class BoundsAccessor:
         return dataset
 
     def _add_bounds(self, axis: BoundsAxis, width: float = 0.5) -> xr.Dataset:
-        """Add bounds for an axis using the midpoints of each coordinate point.
+        """Add bounds for an axis using its coordinate points.
 
         Parameters
         ----------

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -80,7 +80,7 @@ class BoundsAccessor:
         Returns
         -------
         List[str]
-            A list of sorted bounds data variable names.
+            A list of sorted bounds data variable keys.
         """
         return sorted(
             list(

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -154,7 +154,7 @@ class BoundsAccessor:
         return bounds
 
     def add_bounds(self, axis: BoundsAxis, width: float = 0.5) -> xr.Dataset:
-        """Add bounds for an axis using the midpoints of each coordinate point.
+        """Add bounds for an axis using its coordinate points.
 
         Parameters
         ----------

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -25,9 +25,13 @@ class BoundsAccessor:
 
     >>> from xcdat import bounds
 
-    Return dictionary of coordinate keys mapped to bounds DataArrays:
+    Return dictionary of axis and coordinate keys mapped to bounds:
 
-    >>> ds.bounds.bounds
+    >>> ds.bounds.map
+
+    Return list of keys for bounds data variables:
+
+    >>> ds.bounds.keys
 
     Add missing coordinate bounds for supported axes in the Dataset:
 
@@ -48,8 +52,8 @@ class BoundsAccessor:
         self._dataset: xr.Dataset = dataset
 
     @property
-    def bounds(self) -> Dict[str, Optional[xr.DataArray]]:
-        """Returns a mapping of axis and coordinates keys to their bounds.
+    def map(self) -> Dict[str, Optional[xr.DataArray]]:
+        """Returns a map of axis and coordinates keys to their bounds.
 
         The dictionary provides all valid CF compliant keys for axis and
         coordinates. For example, latitude will includes keys for "lat",
@@ -58,20 +62,20 @@ class BoundsAccessor:
         Returns
         -------
         Dict[str, Optional[xr.DataArray]]
-            Dictionary mapping coordinate keys to their bounds.
+            Dictionary mapping axis and coordinate keys to their bounds.
         """
         ds = self._dataset
 
         bounds: Dict[str, Optional[xr.DataArray]] = {}
-        for axis, bounds_name in ds.cf.bounds.items():
-            bound = ds.get(bounds_name[0], None)
+        for axis, bounds_keys in ds.cf.bounds.items():
+            bound = ds.get(bounds_keys[0], None)
             bounds[axis] = bound
 
         return collections.OrderedDict(sorted(bounds.items()))
 
     @property
-    def names(self) -> List[str]:
-        """Returns a list of names for the bounds data variables in the Dataset.
+    def keys(self) -> List[str]:
+        """Returns a list of keys for the bounds data variables in the Dataset.
 
         Returns
         -------
@@ -81,9 +85,9 @@ class BoundsAccessor:
         return sorted(
             list(
                 {
-                    name
-                    for bound_names in self._dataset.cf.bounds.values()
-                    for name in bound_names
+                    key
+                    for bound_keys in self._dataset.cf.bounds.values()
+                    for key in bound_keys
                 }
             )
         )

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -76,7 +76,7 @@ class BoundsAccessor:
         Returns
         -------
         List[str]
-            A list of sorted dounds data variable names.
+            A list of sorted bounds data variable names.
         """
         return sorted(
             list(
@@ -90,6 +90,10 @@ class BoundsAccessor:
 
     def add_missing_bounds(self) -> xr.Dataset:
         """Adds missing coordinate bounds for supported axes in the Dataset.
+
+        This function loops through the Dataset's axes and adds bounds for an
+        axis if it doesn't exist. Currently, the supported axes are T (time), X
+        (longitude), and Y (latitude).
 
         Returns
         -------
@@ -146,9 +150,7 @@ class BoundsAccessor:
         return bounds
 
     def add_bounds(self, axis: BoundsAxis, width: float = 0.5) -> xr.Dataset:
-        """Add bounds for axis coordinates using coordinate data points.
-
-        If bounds already exist, they must be dropped first.
+        """Add bounds for an axis using the midpoints of each coordinate point.
 
         Parameters
         ----------
@@ -179,7 +181,7 @@ class BoundsAccessor:
         return dataset
 
     def _add_bounds(self, axis: BoundsAxis, width: float = 0.5) -> xr.Dataset:
-        """Add bounds for axis coordinates using coordinate data points.
+        """Add bounds for an axis using the midpoints of each coordinate point.
 
         Parameters
         ----------

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -502,7 +502,7 @@ def _keep_single_var(dataset: xr.Dataset, key: str) -> xr.Dataset:
         If specified key matches a bounds data variable.
     """
     all_vars = dataset.data_vars.keys()
-    bounds_vars = dataset.bounds.names
+    bounds_vars = dataset.bounds.keys
     non_bounds_vars = sorted(list(set(all_vars) ^ set(bounds_vars)))
 
     if len(non_bounds_vars) == 0:

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -148,7 +148,7 @@ def open_mfdataset(
     data_vars: Union[Literal["minimal", "different", "all"], List[str]], optional
         These data variables will be concatenated together:
           * "minimal": Only data variables in which the dimension already
-            appears are included, default value.
+            appears are included, the default value.
           * "different": Data variables which are not equal (ignoring
             attributes) across all datasets are also concatenated (as well as
             all for which dimension already appears). Beware: this option may

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -469,9 +469,9 @@ def _postprocess_dataset(
 
     Raises
     ------
-    KeyError
+    ValueError
         If ``center_times==True`` but there are no time coordinates.
-    KeyError
+    ValueError
         If ``lon_orient is not None`` but there are no longitude coordinates.
     """
     if data_var is not None:
@@ -481,7 +481,7 @@ def _postprocess_dataset(
         if dataset.cf.dims.get("T") is not None:
             dataset = dataset.temporal.center_times(dataset)
         else:
-            raise KeyError("This dataset does not have a time coordinates to center.")
+            raise ValueError("This dataset does not have a time coordinates to center.")
 
     if add_bounds:
         dataset = dataset.bounds.add_missing_bounds()
@@ -490,7 +490,7 @@ def _postprocess_dataset(
         if dataset.cf.dims.get("X") is not None:
             dataset = swap_lon_axis(dataset, to=lon_orient, sort_ascending=True)
         else:
-            raise KeyError(
+            raise ValueError(
                 "This dataset does not have longitude coordinates to reorient."
             )
 
@@ -518,23 +518,25 @@ def _keep_single_var(dataset: xr.Dataset, key: str) -> xr.Dataset:
 
     Raises
     ------
-    KeyError
-        If the specified data variable is not found in the Dataset.
-    KeyError
-        If the user specifies a bounds variable to keep.
+    ValueError
+        If the dataset only contains bounds data variables.
+    ValueError
+        If specified key a does not exist in the dataset.
+    ValueError
+        If specified key matches a bounds data variable.
     """
     all_vars = dataset.data_vars.keys()
     bounds_vars = dataset.bounds.names
     non_bounds_vars = sorted(list(set(all_vars) ^ set(bounds_vars)))
 
     if len(non_bounds_vars) == 0:
-        raise KeyError("This dataset only contains bounds data variables.")
+        raise ValueError("This dataset only contains bounds data variables.")
 
     if key not in all_vars:
-        raise KeyError(f"The data variable '{key}' does not exist in the dataset.")
+        raise ValueError(f"The data variable '{key}' does not exist in the dataset.")
 
     if key in bounds_vars:
-        raise KeyError("Please specify a non-bounds data variable.")
+        raise ValueError("Please specify a non-bounds data variable.")
 
     return dataset[[key] + bounds_vars]
 

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -477,8 +477,8 @@ def _keep_single_var(dataset: xr.Dataset, key: str) -> xr.Dataset:
     """Keeps a single non-bounds data variable in the Dataset.
 
     This function checks if the ``data_var`` key exists in the Dataset and
-    if it is non-bounds. If those checks pass, it will subset the Dataset to
-    retain that non-bounds ``data_var`` and all bounds data vars.
+    it is not related to bounds. If those checks pass, it will subset the 
+    Dataset to retain that non-bounds ``data_var`` and all bounds data vars.
 
     Parameters
     ----------
@@ -497,9 +497,9 @@ def _keep_single_var(dataset: xr.Dataset, key: str) -> xr.Dataset:
     ValueError
         If the dataset only contains bounds data variables.
     ValueError
-        If specified key a does not exist in the dataset.
+        If the specified key does not exist in the dataset.
     ValueError
-        If specified key matches a bounds data variable.
+        If the specified key matches a bounds data variable.
     """
     all_vars = dataset.data_vars.keys()
     bounds_vars = dataset.bounds.keys

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -76,18 +76,6 @@ def open_dataset(
     ----------
 
     .. [1] https://xarray.pydata.org/en/stable/generated/xarray.open_dataset.html
-
-    Examples
-    --------
-    Import and call module:
-
-    >>> from xcdat.dataset import open_dataset
-    >>> ds = open_dataset("file_path")
-
-    Keep a single variable in the Dataset:
-
-    >>> from xcdat.dataset import open_dataset
-    >>> ds = open_dataset("file_path", data_var="tas")
     """
     if decode_times:
         cf_compliant_time: Optional[bool] = has_cf_compliant_time(path)
@@ -202,18 +190,6 @@ def open_mfdataset(
     ----------
 
     .. [2] https://xarray.pydata.org/en/stable/generated/xarray.open_mfdataset.html
-
-    Examples
-    --------
-    Import and call module:
-
-    >>> from xcdat.dataset import open_mfdataset
-    >>> ds = open_mfdataset(["file_path1", "file_path2"])
-
-    Keep a single variable in the Dataset:
-
-    >>> from xcdat.dataset import open_mfdataset
-    >>> ds = open_mfdataset(["file_path1", "file_path2"], data_var="tas")
     """
     if decode_times:
         cf_compliant_time: Optional[bool] = has_cf_compliant_time(paths)

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -477,7 +477,7 @@ def _keep_single_var(dataset: xr.Dataset, key: str) -> xr.Dataset:
     """Keeps a single non-bounds data variable in the Dataset.
 
     This function checks if the ``data_var`` key exists in the Dataset and
-    it is not related to bounds. If those checks pass, it will subset the 
+    it is not related to bounds. If those checks pass, it will subset the
     Dataset to retain that non-bounds ``data_var`` and all bounds data vars.
 
     Parameters


### PR DESCRIPTION
This PR extracts the `_postprocess_dataset()` function from `xcdat.open_dataset()` and `xcdat.open_mfdataset()` to reduce code duplication.

It also adds the optional boolean kwarg `add_bounds` (defaults to `False`) to both dataset opening functions, since generating missing bounds might not be desired in some cases. If the user ends up needing to generate bounds, they can either call `ds.bounds.add_missing_bounds()` to generate bounds that are missing for all supported axis (time, lat, lon), or `ds.bounds.add_bounds("key_of_coords")` for a specific axis.

Summary of Changes
- Add boolean kwarg  `add_bounds` for adding bounds to dataset opening functions, defaults to `False`.
- Update docstrings to reduce redundancy and increase conciseness
- Update variable names for clarity
- Update reference to "regular" data vars to "non-bounds" data vars
- Update optional function arg `data_var` to required arg `key`
- Update line spacing and make sure there is a line break with return statements
- Update `BoundsAccessor` property names for clarity

## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #220 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
