### PR TITLE
Fix `add_bounds()` breaking when time coords are `cftime` objects

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -264,7 +264,7 @@ class TestOpenMfDataset:
         assert result.identical(expected)
 
 
-class TestHasCFCompliantTime:
+class Test_HasCFCompliantTime:
     @pytest.fixture(autouse=True)
     def setUp(self, tmp_path):
         # Create temporary directory to save files.
@@ -668,7 +668,7 @@ class TestDecodeNonCFTimeUnits:
         assert result.time_bnds.encoding == expected.time_bnds.encoding
 
 
-class TestPostProcessDataset:
+class Test_PostProcessDataset:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
@@ -868,7 +868,7 @@ class TestPostProcessDataset:
             _postprocess_dataset(ds, lon_orient=(0, 360))
 
 
-class TestKeepSingleVar:
+class Test_KeepSingleVar:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
@@ -909,7 +909,7 @@ class TestKeepSingleVar:
         assert ds.get("time_bnds") is not None
 
 
-class TestPreProcessNonCFDataset:
+class Test_PreProcessNonCFDataset:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.ds = generate_dataset(cf_compliant=False, has_bounds=True)
@@ -944,7 +944,7 @@ class TestPreProcessNonCFDataset:
         assert result.identical(expected)
 
 
-class TestSplitTimeUnitsAttr:
+class Test_SplitTimeUnitsAttr:
     def test_raises_error_if_units_attr_is_none(self):
         with pytest.raises(KeyError):
             _split_time_units_attr(None)  # type: ignore

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1584,7 +1584,7 @@ class TestCenterTimes:
         ds = ds.drop_dims("time")
 
         with pytest.raises(KeyError):
-            ds.temporal.center_times(ds)
+            ds.temporal.center_times()
 
     def test_gets_time_as_the_midpoint_between_time_bounds(self):
         ds = self.ds.copy()
@@ -1658,7 +1658,7 @@ class TestCenterTimes:
         time_bounds["time"] = expected.time
         expected["time_bnds"] = time_bounds
 
-        result = ds.temporal.center_times(ds)
+        result = ds.temporal.center_times()
         assert result.identical(expected)
 
 

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -4,6 +4,7 @@ import warnings
 from typing import Dict, List, Literal, Optional
 
 import cf_xarray as cfxr  # noqa: F401
+import cftime
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -264,10 +265,12 @@ class BoundsAccessor:
         # `cftime` objects instead of `datetime` objects. `cftime` objects only
         # support arithmetic using `timedelta` objects, so the values of `diffs`
         # must be casted from `dtype="timedelta64[ns]"` to `timedelta`.
-        if da_coord.name in ("T", "time"):
+        if da_coord.name in ("T", "time") and issubclass(
+            type(da_coord.values[0]), cftime.datetime
+        ):
             diffs = pd.to_timedelta(diffs)
 
-        # FIXME: These line produces the warning: `PerformanceWarning:
+        # FIXME: These lines produces the warning: `PerformanceWarning:
         # Adding/subtracting object-dtype array to TimedeltaArray not
         # vectorized` after converting diffs to `timedelta`. I (Tom) was not
         # able to find an alternative, vectorized solution at the time of this

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -1,9 +1,11 @@
 """Bounds module for functions related to coordinate bounds."""
 import collections
+import warnings
 from typing import Dict, List, Literal, Optional
 
 import cf_xarray as cfxr  # noqa: F401
 import numpy as np
+import pandas as pd
 import xarray as xr
 
 from xcdat.axis import GENERIC_AXIS_MAP
@@ -253,13 +255,28 @@ class BoundsAccessor:
         diffs = da_coord.diff(dim).values
 
         # Add beginning and end points to account for lower and upper bounds.
+        # np.array of string values with `dtype="timedelta64[ns]"`
         diffs = np.insert(diffs, 0, diffs[0])
         diffs = np.append(diffs, diffs[-1])
 
-        # Get lower and upper bounds by using the width relative to nearest point.
-        # Transpose both bound arrays into a 2D array.
-        lower_bounds = da_coord - diffs[:-1] * width
-        upper_bounds = da_coord + diffs[1:] * (1 - width)
+        # In xarray and xCDAT, time coordinates with non-CF compliant calendars
+        # (360-day, noleap) and/or units ("months", "years") are decoded using
+        # `cftime` objects instead of `datetime` objects. `cftime` objects only
+        # support arithmetic using `timedelta` objects, so the values of `diffs`
+        # must be casted from `dtype="timedelta64[ns]"` to `timedelta`.
+        if da_coord.name in ("T", "time"):
+            diffs = pd.to_timedelta(diffs)
+
+        # FIXME: These line produces the warning: `PerformanceWarning:
+        # Adding/subtracting object-dtype array to TimedeltaArray not
+        # vectorized` after converting diffs to `timedelta`. I (Tom) was not
+        # able to find an alternative, vectorized solution at the time of this
+        # implementation.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=pd.errors.PerformanceWarning)
+            lower_bounds = da_coord - diffs[:-1] * width
+            upper_bounds = da_coord + diffs[1:] * (1 - width)
+
         bounds = np.array([lower_bounds, upper_bounds]).transpose()
 
         # Clip latitude bounds at (-90, 90)

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -277,9 +277,11 @@ class BoundsAccessor:
         # implementation.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=pd.errors.PerformanceWarning)
+            # Get lower and upper bounds by using the width relative to nearest point.
             lower_bounds = da_coord - diffs[:-1] * width
             upper_bounds = da_coord + diffs[1:] * (1 - width)
 
+        # Transpose both bound arrays into a 2D array.
         bounds = np.array([lower_bounds, upper_bounds]).transpose()
 
         # Clip latitude bounds at (-90, 90)

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -457,7 +457,7 @@ def _postprocess_dataset(
 
     if center_times:
         if dataset.cf.dims.get("T") is not None:
-            dataset = dataset.temporal.center_times(dataset)
+            dataset = dataset.temporal.center_times()
         else:
             raise ValueError("This dataset does not have a time coordinates to center.")
 

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1390,14 +1390,14 @@ class TemporalAccessor:
                 self._time_bounds[:, 1] - self._time_bounds[:, 0]
             )
 
-        # Must be convert dtype from timedelta64[ns] to float64, specifically
-        # when chunking DataArrays using Dask. Otherwise, the numpy warning
-        # below is thrown: `DeprecationWarning: The `dtype` and `signature`
-        # arguments to ufuncs only select the general DType and not details such
-        # as the byte order or time unit (with rare exceptions see release
-        # notes). To avoid this warning please use the scalar types
-        # `np.float64`, or string notation.`
+        # Must be cast dtype from "timedelta64[ns]" to "float64", specifically
+        # when using Dask arrays. Otherwise, the numpy warning below is thrown:
+        # `DeprecationWarning: The `dtype` and `signature` arguments to ufuncs
+        # only select the general DType and not details such as the byte order
+        # or time unit (with rare exceptions see release notes). To avoid this
+        # warning please use the scalar types `np.float64`, or string notation.`
         time_lengths = time_lengths.astype(np.float64)
+
         grouped_time_lengths = self._group_data(time_lengths)
         weights: xr.DataArray = grouped_time_lengths / grouped_time_lengths.sum()  # type: ignore
 

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -677,7 +677,7 @@ class TemporalAccessor:
 
         return ds_departs
 
-    def center_times(self, dataset: xr.Dataset) -> xr.Dataset:
+    def center_times(self) -> xr.Dataset:
         """Centers the time coordinates using the midpoint between time bounds.
 
         Time coordinates can be recorded using different intervals, including
@@ -695,12 +695,9 @@ class TemporalAccessor:
         xr.Dataset
             The Dataset with centered time coordinates.
         """
-        ds = dataset.copy()
+        ds = self._dataset.copy()
+        time_bounds = ds.bounds.get_bounds("time")
 
-        if hasattr(self, "_time_bounds") is False:
-            self._time_bounds = ds.bounds.get_bounds("time")
-
-        time_bounds = self._time_bounds.copy()
         lower_bounds, upper_bounds = (time_bounds[:, 0].data, time_bounds[:, 1].data)
         bounds_diffs: np.timedelta64 = (upper_bounds - lower_bounds) / 2
         bounds_mids: np.ndarray = lower_bounds + bounds_diffs
@@ -842,7 +839,7 @@ class TemporalAccessor:
         ds = self._dataset.copy()
 
         if self._center_times:
-            ds = self.center_times(ds)
+            ds = self.center_times()
 
         if (
             self._freq == "season"


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #240 

Summary of Changes
- Fix `add_bounds()` breaking when time coords are `cftime` objects
- Remove `ds` as a keyword arg for `TemporalAccessor.center_times()` to allow for standalone usage
- Update tests in `test_temporal.py` with masked data

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings -- **I added a warning filter for a `pd.PerformanceWarning`. There is a `#FIXME` comment to address this in the future.**
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
