### PR TITLE
Update `_get_weights()` method for `SpatialAccessor` and `TemporalAccessor`

### DIFF
--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -39,12 +39,184 @@ class TestAverage:
 
     def test_raises_error_if_data_var_not_in_dataset(self):
         with pytest.raises(KeyError):
-            self.ds.spatial.average(
-                "not_a_data_var",
-                axis=["Y", "incorrect_axis"],
-            )
+            self.ds.spatial.average("not_a_data_var", axis=["Y", "incorrect_axis"])
 
-    def test_spatial_average_for_lat_and_lon_region_using_custom_weights(self):
+    def test_raises_error_if_axis_list_contains_unsupported_axis(self):
+        with pytest.raises(ValueError):
+            self.ds.spatial.average("ts", axis=["Y", "incorrect_axis"])
+
+    def test_raises_error_if_lat_axis_does_not_exist(self):
+        ds = self.ds.copy()
+        ds.lat.attrs["axis"] = None
+        with pytest.raises(KeyError):
+            ds.spatial.average("ts", axis=["X", "Y"])
+
+    def test_raises_error_if_lon_axis_does_not_exist(self):
+        ds = self.ds.copy()
+        ds.lon.attrs["axis"] = None
+        with pytest.raises(KeyError):
+            ds.spatial.average("ts", axis=["X", "Y"])
+
+    def test_raises_error_if_bounds_type_is_not_a_tuple(self):
+        with pytest.raises(TypeError):
+            self.ds.spatial.average("ts", axis=["Y"], lat_bounds=[1, 1])
+
+        with pytest.raises(TypeError):
+            self.ds.spatial.average("ts", axis=["Y"], lat_bounds="str")
+
+    def test_raises_error_if_there_are_0_elements_in_the_bounds(self):
+        with pytest.raises(ValueError):
+            self.ds.spatial.average("ts", axis=["Y"], lat_bounds=())
+
+    def test_raises_error_if_there_are_more_than_two_elements_in_the_bounds(self):
+        with pytest.raises(ValueError):
+            self.ds.spatial.average("ts", axis=["Y"], lat_bounds=(1, 2, 3))
+
+    def test_raises_error_if_lower_bound_is_not_a_float_or_int(self):
+        with pytest.raises(TypeError):
+            self.ds.spatial.average("ts", axis=["Y"], lat_bounds=("invalid", 1))
+
+    def test_raises_error_if_upper_bound_is_not_a_float_or_int(self):
+        with pytest.raises(TypeError):
+            self.ds.spatial.average("ts", axis=["Y"], lat_bounds=(1, "invalid"))
+
+    def test_raises_error_if_lower_lat_bound_is_larger_than_upper(self):
+        with pytest.raises(ValueError):
+            self.ds.spatial.average("ts", axis=["Y"], lat_bounds=(2, 1))
+
+    def test_does_not_raise_error_if_lower_lon_bound_is_larger_than_upper(self):
+        self.ds.spatial.average("ts", axis=["X"], lon_bounds=(2, 1))
+
+    def test_raises_error_if_lat_axis_is_specified_but_lat_is_not_in_weights_dims(
+        self,
+    ):
+        weights = xr.DataArray(
+            data=np.ones(4), coords={"lon": self.ds.lon}, dims=["lon"]
+        )
+        with pytest.raises(KeyError):
+            self.ds.spatial.average("ts", axis=["X", "Y"], weights=weights)
+
+    def test_raises_error_if_lon_axis_is_specified_but_lon_is_not_in_weights_dims(
+        self,
+    ):
+        weights = xr.DataArray(
+            data=np.ones(4), coords={"lat": self.ds.lat}, dims=["lat"]
+        )
+        with pytest.raises(KeyError):
+            self.ds.spatial.average("ts", axis=["X", "Y"], weights=weights)
+
+    def test_raises_error_if_weights_lat_and_lon_dims_dont_align_with_data_var_dims(
+        self,
+    ):
+        # Get a slice of the dataset to reduce the size of the dimensions for
+        # simpler testing.
+        ds = self.ds.isel(lat=slice(0, 3), lon=slice(0, 3))
+        weights = xr.DataArray(
+            data=np.ones((3, 3)),
+            coords={"lat": ds.lat, "lon": ds.lon},
+            dims=["lat", "lon"],
+        )
+
+        with pytest.raises(ValueError):
+            self.ds.spatial.average("ts", axis=["X", "Y"], weights=weights)
+
+    def test_spatial_average_for_lat_region_and_keep_weights(self):
+        ds = self.ds.copy()
+
+        result = ds.spatial.average(
+            "ts", axis=["Y"], lat_bounds=(-5.0, 5), keep_weights=True
+        )
+
+        expected = self.ds.copy()
+        expected["ts"] = xr.DataArray(
+            data=np.array(
+                [[2.25, 2.25, 2.25, 2.25], [1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]]
+            ),
+            coords={"time": expected.time, "lon": expected.lon},
+            dims=["time", "lon"],
+        )
+        expected["lat_wts"] = xr.DataArray(
+            name="lat_wts",
+            data=np.array([0.0, 0.08715574, 0.08715574, 0.0]),
+            dims=["lat"],
+        )
+
+        xr.testing.assert_allclose(result, expected)
+
+    def test_spatial_average_for_lat_region(self):
+        ds = self.ds.copy()
+
+        # Specifying axis as a str instead of list of str.
+        result = ds.spatial.average("ts", axis=["Y"], lat_bounds=(-5.0, 5))
+
+        expected = self.ds.copy()
+        expected["ts"] = xr.DataArray(
+            data=np.array(
+                [[2.25, 2.25, 2.25, 2.25], [1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]]
+            ),
+            coords={"time": expected.time, "lon": expected.lon},
+            dims=["time", "lon"],
+        )
+
+        assert result.identical(expected)
+
+    @requires_dask
+    def test_spatial_average_for_lat_region_and_keep_weights_with_dask(self):
+        ds = self.ds.copy().chunk(2)
+
+        # Specifying axis as a str instead of list of str.
+        result = ds.spatial.average(
+            "ts", axis=["Y"], lat_bounds=(-5.0, 5), keep_weights=True
+        )
+
+        expected = self.ds.copy()
+        expected["ts"] = xr.DataArray(
+            data=np.array(
+                [[2.25, 2.25, 2.25, 2.25], [1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]]
+            ),
+            coords={"time": expected.time, "lon": expected.lon},
+            dims=["time", "lon"],
+        )
+        expected["lat_wts"] = xr.DataArray(
+            name="lat_wts",
+            data=np.array([0.0, 0.08715574, 0.08715574, 0.0]),
+            dims=["lat"],
+        )
+
+        xr.testing.assert_allclose(result, expected)
+
+    def test_spatial_average_for_lat_and_lon_region_and_keep_weights(self):
+        ds = self.ds.copy()
+        result = ds.spatial.average(
+            "ts",
+            axis=["X", "Y"],
+            lat_bounds=(-5.0, 5),
+            lon_bounds=(-170, -120.1),
+            keep_weights=True,
+        )
+
+        expected = self.ds.copy()
+        expected["ts"] = xr.DataArray(
+            data=np.array([2.25, 1.0, 1.0]),
+            coords={"time": expected.time},
+            dims="time",
+        )
+        expected["lat_lon_wts"] = xr.DataArray(
+            name="ts_weights",
+            data=np.array(
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 4.34907156, 4.34907156, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                ]
+            ),
+            dims=["lon", "lat"],
+        )
+
+        xr.testing.assert_allclose(result, expected)
+
+    def test_spatial_average_for_lat_and_lon_region_with_custom_weights(self):
         ds = self.ds.copy()
 
         weights = xr.DataArray(
@@ -69,183 +241,126 @@ class TestAverage:
 
         assert result.identical(expected)
 
-    def test_spatial_average_for_lat_and_lon_region(self):
-        ds = self.ds.copy()
-        result = ds.spatial.average(
-            "ts", axis=["X", "Y"], lat_bounds=(-5.0, 5), lon_bounds=(-170, -120.1)
-        )
 
-        expected = self.ds.copy()
-        expected["ts"] = xr.DataArray(
-            data=np.array([2.25, 1.0, 1.0]),
-            coords={"time": expected.time},
-            dims="time",
-        )
-
-        assert result.identical(expected)
-
-    def test_spatial_average_for_lat_region(self):
-        ds = self.ds.copy()
-
-        # Specifying axis as a str instead of list of str.
-        result = ds.spatial.average(
-            "ts", axis=["Y"], lat_bounds=(-5.0, 5), lon_bounds=(-170, -120.1)
-        )
-
-        expected = self.ds.copy()
-        expected["ts"] = xr.DataArray(
-            data=np.array(
-                [[2.25, 2.25, 2.25, 2.25], [1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]]
-            ),
-            coords={"time": expected.time, "lon": expected.lon},
-            dims=["time", "lon"],
-        )
-
-        assert result.identical(expected)
-
-    @requires_dask
-    def test_chunked_spatial_average_for_lat_region(self):
-        ds = self.ds.copy().chunk(2)
-
-        # Specifying axis as a str instead of list of str.
-        result = ds.spatial.average(
-            "ts", axis=["Y"], lat_bounds=(-5.0, 5), lon_bounds=(-170, -120.1)
-        )
-
-        expected = self.ds.copy()
-        expected["ts"] = xr.DataArray(
-            data=np.array(
-                [[2.25, 2.25, 2.25, 2.25], [1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]]
-            ),
-            coords={"time": expected.time, "lon": expected.lon},
-            dims=["time", "lon"],
-        )
-
-        assert result.identical(expected)
-
-
-class TestValidateAxisArg:
+class TestGetWeights:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
 
-    def test_raises_error_if_axis_list_contains_unsupported_axis(self):
-        with pytest.raises(ValueError):
-            self.ds.spatial._validate_axis_arg(axis=["Y", "incorrect_axis"])
-
-    def test_raises_error_if_lat_axis_does_not_exist(self):
+    def test_raises_error_if_domain_lower_bound_exceeds_upper_bound(self):
         ds = self.ds.copy()
-        ds.lat.attrs["axis"] = None
-        with pytest.raises(KeyError):
-            ds.spatial._validate_axis_arg(axis=["X", "Y"])
+        ds.lon_bnds.data[:] = np.array([[1, 0], [1, 2], [2, 3], [3, 4]])
 
-    def test_raises_error_if_lon_axis_does_not_exist(self):
-        ds = self.ds.copy()
-        ds.lon.attrs["axis"] = None
-        with pytest.raises(KeyError):
-            ds.spatial._validate_axis_arg(axis=["X", "Y"])
-
-
-class TestValidateRegionBounds:
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
-
-    def test_raises_error_if_bounds_type_is_not_a_tuple(self):
-        with pytest.raises(TypeError):
-            self.ds.spatial._validate_region_bounds("lon", [1, 1])
-
-        with pytest.raises(TypeError):
-            self.ds.spatial._validate_region_bounds("lon", "str")
-
-    def test_raises_error_if_there_are_0_elements_in_the_bounds(self):
         with pytest.raises(ValueError):
-            self.ds.spatial._validate_region_bounds("lon", ())
+            ds.spatial.get_weights(axis=["X"])
 
-    def test_raises_error_if_there_are_more_than_two_elements_in_the_bounds(self):
-        with pytest.raises(ValueError):
-            self.ds.spatial._validate_region_bounds("lon", (1, 1, 2))
-
-    def test_does_not_raise_error_if_lower_and_upper_bounds_are_floats_or_ints(self):
-        self.ds.spatial._validate_region_bounds("lon", (1, 1))
-        self.ds.spatial._validate_region_bounds("lon", (1, 1.2))
-
-    def test_raises_error_if_lower_bound_is_not_a_float_or_int(self):
-        with pytest.raises(TypeError):
-            self.ds.spatial._validate_region_bounds("Y", ("invalid", 1))
-
-    def test_raises_error_if_upper_bound_is_not_a_float_or_int(self):
-        with pytest.raises(TypeError):
-            self.ds.spatial._validate_region_bounds("X", (1, "invalid"))
-
-    def test_raises_error_if_lower_lat_bound_is_bigger_than_upper(self):
-        with pytest.raises(ValueError):
-            self.ds.spatial._validate_region_bounds("Y", (2, 1))
-
-    def test_does_not_raise_error_if_lon_lower_bound_is_larger_than_upper(self):
-        self.ds.spatial._validate_region_bounds("X", (2, 1))
-
-
-class TestValidateWeights:
-    def setup(self):
-        self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
-        self.weights = xr.DataArray(
-            data=np.ones((4, 4)),
+    def test_weights_for_region_in_lat_and_lon_domains(self):
+        result = self.ds.spatial.get_weights(
+            axis=["Y", "X"], lat_bounds=(-5, 5), lon_bounds=(-170, -120)
+        )
+        expected = xr.DataArray(
+            data=np.array(
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 4.35778714, 0.0],
+                    [0.0, 0.0, 4.35778714, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                ]
+            ),
             coords={"lat": self.ds.lat, "lon": self.ds.lon},
             dims=["lat", "lon"],
         )
 
-    def test_no_error_is_raised_when_spatial_dim_sizes_align_between_weights_and_data_var(
-        self,
-    ):
-        weights = xr.DataArray(
-            data=np.ones((4, 4)),
+        xr.testing.assert_allclose(result, expected)
+
+    def test_area_weights_for_region_in_lat_domain(self):
+        result = self.ds.spatial.get_weights(
+            axis=["Y", "X"], lat_bounds=(-5, 5), lon_bounds=None
+        )
+        expected = xr.DataArray(
+            data=np.array(
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.16341702, 15.52461668, 15.52461668, 0.16341702],
+                    [0.16341702, 15.52461668, 15.52461668, 0.16341702],
+                    [0.0, 0.0, 0.0, 0.0],
+                ]
+            ),
             coords={"lat": self.ds.lat, "lon": self.ds.lon},
             dims=["lat", "lon"],
         )
-        self.ds.spatial._validate_weights(self.ds["ts"], axis=["Y"], weights=weights)
 
-    def test_error_is_raised_when_lat_axis_is_specified_but_lat_is_not_in_weights_dims(
-        self,
-    ):
-        weights = xr.DataArray(
-            data=np.ones(4), coords={"lon": self.ds.lon}, dims=["lon"]
-        )
-        with pytest.raises(KeyError):
-            self.ds.spatial._validate_weights(
-                self.ds["ts"], axis=["X", "Y"], weights=weights
-            )
+        xr.testing.assert_allclose(result, expected)
 
-    def test_error_is_raised_when_lon_axis_is_specified_but_lon_is_not_in_weights_dims(
-        self,
-    ):
-        weights = xr.DataArray(
-            data=np.ones(4), coords={"lat": self.ds.lat}, dims=["lat"]
-        )
-        with pytest.raises(KeyError):
-            self.ds.spatial._validate_weights(
-                self.ds["ts"], axis=["X", "Y"], weights=weights
-            )
-
-    def test_error_is_raised_when_weights_lat_and_lon_dims_dont_align_with_data_var_dims(
-        self,
-    ):
-        # Get a slice of the dataset to reduce the size of the dimensions for
-        # simpler testing.
-        ds = self.ds.isel(lat=slice(0, 3), lon=slice(0, 3))
-        weights = xr.DataArray(
-            data=np.ones((3, 3)),
-            coords={"lat": ds.lat, "lon": ds.lon},
+    def test_weights_for_region_in_lon_domain(self):
+        expected = xr.DataArray(
+            data=np.array(
+                [
+                    [0.0, 0.0, 0.00297475, 0.0],
+                    [0.0, 0.0, 49.99702525, 0.0],
+                    [0.0, 0.0, 49.99702525, 0.0],
+                    [0.0, 0.0, 0.00297475, 0.0],
+                ]
+            ),
+            coords={"lat": self.ds.lat, "lon": self.ds.lon},
             dims=["lat", "lon"],
         )
+        result = self.ds.spatial.get_weights(
+            axis=["Y", "X"], lat_bounds=None, lon_bounds=(-170, -120)
+        )
 
-        with pytest.raises(ValueError):
-            self.ds.spatial._validate_weights(
-                self.ds["ts"], axis=["X", "Y"], weights=weights
-            )
+        xr.testing.assert_allclose(result, expected)
+
+    def test_weights_for_region_in_lon_domain_with_region_spanning_p_meridian(self):
+        ds = self.ds.copy()
+
+        result = ds.spatial._get_longitude_weights(
+            domain_bounds=ds.lon_bnds,
+            # Region spans prime meridian.
+            region_bounds=np.array([359, 1]),
+        )
+        expected = xr.DataArray(
+            data=np.array([1.875, 0.0625, 0.0, 0.0625]),
+            coords={"lon": ds.lon},
+            dims=["lon"],
+        )
+
+        xr.testing.assert_allclose(result, expected)
+
+    def test_weights_all_longitudes_for_equal_region_bounds(self):
+        expected = xr.DataArray(
+            data=np.array(
+                [1.875, 178.125, 178.125, 1.875],
+            ),
+            coords={"lon": self.ds.lon},
+            dims=["lon"],
+        )
+        result = self.ds.spatial.get_weights(
+            axis=["X"],
+            lat_bounds=None,
+            lon_bounds=np.array([0.0, 360.0]),
+        )
+
+        xr.testing.assert_allclose(result, expected)
+
+    def test_weights_for_equal_region_bounds_representing_entire_lon_domain(self):
+        expected = xr.DataArray(
+            data=np.array(
+                [1.875, 178.125, 178.125, 1.875],
+            ),
+            coords={"lon": self.ds.lon},
+            dims=["lon"],
+        )
+        result = self.ds.spatial.get_weights(
+            axis=["X"], lat_bounds=None, lon_bounds=np.array([10.0, 10.0])
+        )
+
+        xr.testing.assert_allclose(result, expected)
 
 
-class TestSwapLonAxis:
+class Test_SwapLonAxis:
+    # NOTE: This private method is tested because we might want to consider
+    # converting it to a public method in the future.
     @pytest.fixture(autouse=True)
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
@@ -391,233 +506,9 @@ class TestSwapLonAxis:
         assert np.array_equal(result, expected)
 
 
-class TestGetWeights:
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
-
-    def test_weights_for_region_in_lat_and_lon_domains(self):
-        result = self.ds.spatial._get_weights(
-            axis=["Y", "X"], lat_bounds=(-5, 5), lon_bounds=(-170, -120)
-        )
-        expected = xr.DataArray(
-            data=np.array(
-                [
-                    [0.0, 0.0, 0.0, 0.0],
-                    [0.0, 0.0, 4.35778714, 0.0],
-                    [0.0, 0.0, 4.35778714, 0.0],
-                    [0.0, 0.0, 0.0, 0.0],
-                ]
-            ),
-            coords={"lat": self.ds.lat, "lon": self.ds.lon},
-            dims=["lat", "lon"],
-        )
-
-        xr.testing.assert_allclose(result, expected)
-
-    def test_area_weights_for_region_in_lat_domain(self):
-        result = self.ds.spatial._get_weights(
-            axis=["Y", "X"], lat_bounds=(-5, 5), lon_bounds=None
-        )
-        expected = xr.DataArray(
-            data=np.array(
-                [
-                    [0.0, 0.0, 0.0, 0.0],
-                    [0.16341702, 15.52461668, 15.52461668, 0.16341702],
-                    [0.16341702, 15.52461668, 15.52461668, 0.16341702],
-                    [0.0, 0.0, 0.0, 0.0],
-                ]
-            ),
-            coords={"lat": self.ds.lat, "lon": self.ds.lon},
-            dims=["lat", "lon"],
-        )
-
-        xr.testing.assert_allclose(result, expected)
-
-    def test_weights_for_region_in_lon_domain(self):
-        expected = xr.DataArray(
-            data=np.array(
-                [
-                    [0.0, 0.0, 0.00297475, 0.0],
-                    [0.0, 0.0, 49.99702525, 0.0],
-                    [0.0, 0.0, 49.99702525, 0.0],
-                    [0.0, 0.0, 0.00297475, 0.0],
-                ]
-            ),
-            coords={"lat": self.ds.lat, "lon": self.ds.lon},
-            dims=["lat", "lon"],
-        )
-        result = self.ds.spatial._get_weights(
-            axis=["Y", "X"], lat_bounds=None, lon_bounds=(-170, -120)
-        )
-
-        xr.testing.assert_allclose(result, expected)
-
-
-class TestGetLongitudeWeights:
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
-
-    def test_weights_for_region_in_lon_domain(self):
-        # Longitude axis orientation swaps from (-180, 180) to (0, 360).
-        result = self.ds.spatial._get_longitude_weights(
-            domain_bounds=self.ds.lon_bnds.copy(),
-            region_bounds=np.array([-170.0, -120.0]),
-        )
-        expected = xr.DataArray(
-            data=np.array([0.0, 0.0, 50.0, 0.0]),
-            coords={"lon": self.ds.lon},
-            dims=["lon"],
-        )
-
-        xr.testing.assert_allclose(result, expected)
-
-    def test_weights_for_region_in_lon_domain_with_both_spanning_p_meridian(self):
-        ds = self.ds.copy()
-        # Domain spans prime meridian.
-        ds.lon_bnds.data[:] = np.array([[359, 1], [1, 90], [90, 180], [180, 359]])
-
-        result = ds.spatial._get_longitude_weights(
-            domain_bounds=ds.lon_bnds,
-            # Region spans prime meridian.
-            region_bounds=np.array([359, 1]),
-        )
-        expected = xr.DataArray(
-            data=np.array([2.0, 0.0, 0.0, 0.0]),
-            coords={"lon": ds.lon},
-            dims=["lon"],
-        )
-
-        xr.testing.assert_allclose(result, expected)
-
-    def test_weights_for_region_in_lon_domain_with_domain_spanning_p_meridian(self):
-        ds = self.ds.copy()
-        # Domain spans prime meridian.
-        ds.lon_bnds.data[:] = np.array([[359, 1], [1, 90], [90, 180], [180, 359]])
-
-        # Longitude axis orientation swaps from (-180, 180) to (0, 360).
-        result = ds.spatial._get_longitude_weights(
-            domain_bounds=ds.lon_bnds,
-            region_bounds=np.array([-170.0, -120.0]),
-        )
-        expected = xr.DataArray(
-            data=np.array([0.0, 0.0, 0.0, 50.0]),
-            coords={"lon": ds.lon},
-            dims=["lon"],
-        )
-
-        xr.testing.assert_allclose(result, expected)
-
-    def test_weights_for_region_in_lon_domain_with_region_spanning_p_meridian(self):
-        ds = self.ds.copy()
-
-        result = ds.spatial._get_longitude_weights(
-            domain_bounds=ds.lon_bnds,
-            # Region spans prime meridian.
-            region_bounds=np.array([359, 1]),
-        )
-        expected = xr.DataArray(
-            data=np.array([1.875, 0.0625, 0.0, 0.0625]),
-            coords={"lon": ds.lon},
-            dims=["lon"],
-        )
-
-        xr.testing.assert_allclose(result, expected)
-
-    def test_weights_all_longitudes_for_equal_region_bounds(self):
-        expected = xr.DataArray(
-            data=np.array(
-                [1.875, 178.125, 178.125, 1.875],
-            ),
-            coords={"lon": self.ds.lon},
-            dims=["lon"],
-        )
-        result = self.ds.spatial._get_longitude_weights(
-            domain_bounds=self.ds.lon_bnds.copy(),
-            region_bounds=np.array([0.0, 360.0]),
-        )
-
-        xr.testing.assert_allclose(result, expected)
-
-    def test_weights_for_equal_region_bounds_representing_entire_lon_domain(self):
-        expected = xr.DataArray(
-            data=np.array(
-                [1.875, 178.125, 178.125, 1.875],
-            ),
-            coords={"lon": self.ds.lon},
-            dims=["lon"],
-        )
-        result = self.ds.spatial._get_longitude_weights(
-            domain_bounds=self.ds.lon_bnds.copy(), region_bounds=np.array([10.0, 10.0])
-        )
-
-        xr.testing.assert_allclose(result, expected)
-
-
-class TestGetLatitudeWeights:
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
-
-    def test_weights_for_region_in_lat_domain(self):
-        expected = xr.DataArray(
-            data=np.array([0.0, 0.087156, 0.087156, 0.0]),
-            coords={"lat": self.ds.lat},
-            dims=["lat"],
-        )
-        result = self.ds.spatial._get_latitude_weights(
-            domain_bounds=self.ds.lat_bnds, region_bounds=np.array([-5.0, 5.0])
-        )
-
-        xr.testing.assert_allclose(result, expected)
-
-
-class TestValidateDomainBounds:
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
-
-    def test_raises_error_if_low_bounds_exceeds_high_bound(self):
-        domain_bounds = xr.DataArray(
-            name="lon_bnds",
-            data=np.array([[1, 0], [1, 2], [2, 3], [3, 4]]),
-            dims=["lon", "bnds"],
-        )
-        with pytest.raises(ValueError):
-            self.ds.spatial._validate_domain_bounds(domain_bounds)
-
-
-class TestCalculateWeights:
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
-
-    def test_returns_weights_as_the_absolute_difference_of_upper_and_lower_bounds(self):
-        lat = xr.DataArray(
-            name="lat",
-            data=np.array([-90.0, -88.75, 88.75, 90.0]),
-            coords={"lat": np.array([-90.0, -88.75, 88.75, 90.0])},
-            dims=["lat"],
-        )
-        lat_bounds = xr.DataArray(
-            data=np.array(
-                [[-90.0, -89.375], [-89.375, 0.0], [0.0, 89.375], [89.375, 90.0]]
-            ),
-            coords={"lat": lat},
-            dims=["lat", "bnds"],
-        )
-
-        result = self.ds.spatial._calculate_weights(lat_bounds)
-        expected = xr.DataArray(
-            data=np.array([0.625, 89.375, 89.375, 0.625]),
-            coords={"lat": lat},
-            dims=["lat"],
-        )
-        assert result.identical(expected)
-
-
-class TestScaleDimToRegion:
+class Test_ScaleDimToRegion:
+    # NOTE: This private method is tested because this is an in-house algorithm
+    # that has edge cases with some complexities.
     @pytest.fixture(autouse=True)
     def setup(self):
         self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
@@ -763,118 +654,6 @@ class TestScaleDimToRegion:
             ),
             coords={"lat": self.ds.lat},
             dims=["lat", "bnds"],
-        )
-
-        assert result.identical(expected)
-
-
-class TestCombineWeights:
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
-        self.axis_weights = {
-            "lat": xr.DataArray(
-                name="lat_wts",
-                data=np.array([1, 2, 3, 4]),
-                coords={"lat": self.ds.lat},
-                dims=["lat"],
-            ),
-            "lon": xr.DataArray(
-                name="lon_wts",
-                data=np.array([1, 2, 3, 4]),
-                coords={"lon": self.ds.lon},
-                dims=["lon"],
-            ),
-        }
-
-    def test_weights_for_single_axis_are_identical(self):
-        axis_weights = self.axis_weights
-        del axis_weights["lon"]
-
-        result = self.ds.spatial._combine_weights(axis_weights=self.axis_weights)
-        expected = self.axis_weights["lat"]
-
-        assert result.identical(expected)
-
-    def test_weights_for_multiple_axis_is_the_product_of_matrix_multiplication(self):
-        result = self.ds.spatial._combine_weights(axis_weights=self.axis_weights)
-        expected = xr.DataArray(
-            data=np.array([[1, 2, 3, 4], [2, 4, 6, 8], [3, 6, 9, 12], [4, 8, 12, 16]]),
-            coords={"lat": self.ds.lat, "lon": self.ds.lon},
-            dims=["lat", "lon"],
-        )
-
-        assert result.identical(expected)
-
-
-class TestAverager:
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.ds = generate_dataset(cf_compliant=True, has_bounds=True)
-
-    @requires_dask
-    def test_chunked_weighted_avg_over_lat_and_lon_axes(self):
-        ds = self.ds.copy().chunk(2)
-
-        weights = xr.DataArray(
-            data=np.array([[1, 2, 3, 4], [2, 4, 6, 8], [3, 6, 9, 12], [4, 8, 12, 16]]),
-            coords={"lat": ds.lat, "lon": ds.lon},
-            dims=["lat", "lon"],
-        )
-
-        result = ds.spatial._averager(ds.ts, axis=["X", "Y"], weights=weights)
-        expected = xr.DataArray(
-            name="ts", data=np.ones(15), coords={"time": ds.time}, dims=["time"]
-        )
-
-        assert result.identical(expected)
-
-    def test_weighted_avg_over_lat_axis(self):
-        weights = xr.DataArray(
-            name="lat_wts",
-            data=np.array([1, 2, 3, 4]),
-            coords={"lat": self.ds.lat},
-            dims=["lat"],
-        )
-
-        result = self.ds.spatial._averager(self.ds.ts, axis=["Y"], weights=weights)
-        expected = xr.DataArray(
-            name="ts",
-            data=np.ones((15, 4)),
-            coords={"time": self.ds.time, "lon": self.ds.lon},
-            dims=["time", "lon"],
-        )
-
-        assert result.identical(expected)
-
-    def test_weighted_avg_over_lon_axis(self):
-        weights = xr.DataArray(
-            name="lon_wts",
-            data=np.array([1, 2, 3, 4]),
-            coords={"lon": self.ds.lon},
-            dims=["lon"],
-        )
-
-        result = self.ds.spatial._averager(self.ds.ts, axis=["X"], weights=weights)
-        expected = xr.DataArray(
-            name="ts",
-            data=np.ones((15, 4)),
-            coords={"time": self.ds.time, "lat": self.ds.lat},
-            dims=["time", "lat"],
-        )
-
-        assert result.identical(expected)
-
-    def test_weighted_avg_over_lat_and_lon_axis(self):
-        weights = xr.DataArray(
-            data=np.array([[1, 2, 3, 4], [2, 4, 6, 8], [3, 6, 9, 12], [4, 8, 12, 16]]),
-            coords={"lat": self.ds.lat, "lon": self.ds.lon},
-            dims=["lat", "lon"],
-        )
-
-        result = self.ds.spatial._averager(self.ds.ts, axis=["X", "Y"], weights=weights)
-        expected = xr.DataArray(
-            name="ts", data=np.ones(15), coords={"time": self.ds.time}, dims=["time"]
         )
 
         assert result.identical(expected)

--- a/xcdat/axis.py
+++ b/xcdat/axis.py
@@ -350,6 +350,6 @@ def _get_coord_var(dataset: xr.Dataset, axis: GenericAxis):
         raise KeyError(
             f"A '{axis}' coordinate variable was found in the dataset. Make sure "
             "the coordinate variable exists in the Dataset, and its 'axis' attribute "
-            "is set to '{axis}'."
+            f"is set to '{axis}'."
         )
     return coord_var

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -144,6 +144,7 @@ class TemporalAccessor:
 
     def __init__(self, dataset: xr.Dataset):
         self._dataset: xr.Dataset = dataset
+        
         self._dim_name = _get_coord_var(self._dataset, "T").name
 
         self._time_bounds = self._dataset.bounds.get_bounds("time").copy()

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -146,10 +146,9 @@ class TemporalAccessor:
         self._dataset: xr.Dataset = dataset
         self._dim_name = _get_coord_var(self._dataset, "T").name
 
-        # The weights for time coordinates, which are based on a chosen frequency.
-        self._weights: Optional[xr.DataArray] = None
+        self._time_bounds = self._dataset.bounds.get_bounds("time").copy()
 
-    def average(self, data_var: str, weighted: bool = True):
+    def average(self, data_var: str, weighted: bool = True, keep_weights: bool = False):
         """
         Returns a Dataset with the average of a data variable and the time
         dimension removed.
@@ -176,6 +175,9 @@ class TemporalAccessor:
 
             The weight of masked (missing) data is excluded when averages are
             taken. This is the same as giving them a weight of 0.
+        keep_weights : bool, optional
+            If calculating averages using weights, keep the weights in the
+            final dataset output, by default False.
 
         Returns
         -------
@@ -193,41 +195,14 @@ class TemporalAccessor:
         """
         freq = self._infer_freq()
 
-        return self._averager(data_var, "average", freq, weighted)
-
-    def _infer_freq(self) -> Frequency:
-        """Infers the time frequency from the coordinates.
-
-        This method infers the time frequency from the coordinates by
-        calculating the minimum delta and comparing it against a set of
-        conditionals.
-
-        The native ``xr.infer_freq()`` method does not work for all cases
-        because the frequency can be irregular (e.g., different hour
-        measurements), which ends up returning None.
-
-        Returns
-        -------
-        Frequency
-            The time frequency.
-        """
-        time_coords = self._dataset[self._dim_name]
-        min_delta = pd.to_timedelta(np.diff(time_coords).min(), unit="ns")
-
-        if min_delta < pd.Timedelta(days=1):
-            return "hour"
-        elif min_delta >= pd.Timedelta(days=1) and min_delta < pd.Timedelta(days=28):
-            return "day"
-        elif min_delta >= pd.Timedelta(days=28) and min_delta < pd.Timedelta(days=365):
-            return "month"
-        else:
-            return "year"
+        return self._averager(data_var, "average", freq, weighted, keep_weights)
 
     def group_average(
         self,
         data_var: str,
         freq: Frequency,
         weighted: bool = True,
+        keep_weights: bool = False,
         season_config: SeasonConfigInput = DEFAULT_SEASON_CONFIG,
     ):
         """Returns a Dataset with average of a data variable by time group.
@@ -256,6 +231,9 @@ class TemporalAccessor:
 
             The weight of masked (missing) data is excluded when averages are
             calculated. This is the same as giving them a weight of 0.
+        keep_weights : bool, optional
+            If calculating averages using weights, keep the weights in the
+            final dataset output, by default False.
         season_config: SeasonConfigInput, optional
             A dictionary for "season" frequency configurations. If configs for
             predefined seasons are passed, configs for custom seasons are
@@ -350,13 +328,16 @@ class TemporalAccessor:
             'drop_incomplete_djf': 'False'
         }
         """
-        return self._averager(data_var, "group_average", freq, weighted, season_config)
+        return self._averager(
+            data_var, "group_average", freq, weighted, keep_weights, season_config
+        )
 
     def climatology(
         self,
         data_var: str,
         freq: Frequency,
         weighted: bool = True,
+        keep_weights: bool = False,
         season_config: SeasonConfigInput = DEFAULT_SEASON_CONFIG,
     ):
         """Returns a Dataset with the climatology of a data variable.
@@ -383,6 +364,9 @@ class TemporalAccessor:
 
             The weight of masked (missing) data is excluded when averages are
             taken. This is the same as giving them a weight of 0.
+        keep_weights : bool, optional
+            If calculating averages using weights, keep the weights in the
+            final dataset output, by default False.
         season_config: SeasonConfigInput, optional
             A dictionary for "season" frequency configurations. If configs for
             predefined seasons are passed, configs for custom seasons are
@@ -477,13 +461,16 @@ class TemporalAccessor:
             'drop_incomplete_djf': 'False'
         }
         """
-        return self._averager(data_var, "climatology", freq, weighted, season_config)
+        return self._averager(
+            data_var, "climatology", freq, weighted, keep_weights, season_config
+        )
 
     def departures(
         self,
         data_var: str,
         freq: Frequency,
         weighted: bool = True,
+        keep_weights: bool = False,
         season_config: SeasonConfigInput = DEFAULT_SEASON_CONFIG,
     ) -> xr.Dataset:
         """
@@ -530,6 +517,9 @@ class TemporalAccessor:
 
             The weight of masked (missing) data is excluded when averages are
             taken. This is the same as giving them a weight of 0.
+        keep_weights : bool, optional
+            If calculating averages using weights, keep the weights in the
+            final dataset output, by default False.
         season_config: SeasonConfigInput, optional
             A dictionary for "season" frequency configurations. If configs for
             predefined seasons are passed, configs for custom seasons are
@@ -601,18 +591,18 @@ class TemporalAccessor:
             'drop_incomplete_djf': 'False'
         }
         """
-        self._set_obj_attrs("departures", freq, weighted, season_config)
-
         ds = self._dataset.copy()
+        self._set_obj_attrs("departures", freq, weighted, season_config)
 
         # Group the observation data variable.
         dv_obs = _get_data_var(ds, data_var)
         dv_obs_grouped = self._group_data(dv_obs)
 
         # Calculate the climatology of the data variable.
-        dv_climo = ds.temporal.climatology(data_var, freq, weighted, season_config)[
-            data_var
-        ]
+        ds_climo = ds.temporal.climatology(
+            data_var, freq, weighted, keep_weights, season_config
+        )
+        dv_climo = ds_climo[data_var]
 
         # Rename the time dimension using the name from the grouped observation
         # data. The dimension names must align for xarray's grouped arithmetic
@@ -633,7 +623,39 @@ class TemporalAccessor:
             # are no longer required.
             ds_departs = ds_departs.drop_vars(self._labeled_time.name)
 
+        if weighted and keep_weights:
+            self._weights = ds_climo.time_wts
+            ds_departs = self._keep_weights(ds_departs)
+
         return ds_departs
+
+    def _infer_freq(self) -> Frequency:
+        """Infers the time frequency from the coordinates.
+
+        This method infers the time frequency from the coordinates by
+        calculating the minimum delta and comparing it against a set of
+        conditionals.
+
+        The native ``xr.infer_freq()`` method does not work for all cases
+        because the frequency can be irregular (e.g., different hour
+        measurements), which ends up returning None.
+
+        Returns
+        -------
+        Frequency
+            The time frequency.
+        """
+        time_coords = self._dataset[self._dim_name]
+        min_delta = pd.to_timedelta(np.diff(time_coords).min(), unit="ns")
+
+        if min_delta < pd.Timedelta(days=1):
+            return "hour"
+        elif min_delta >= pd.Timedelta(days=1) and min_delta < pd.Timedelta(days=28):
+            return "day"
+        elif min_delta >= pd.Timedelta(days=28) and min_delta < pd.Timedelta(days=365):
+            return "month"
+        else:
+            return "year"
 
     def _averager(
         self,
@@ -641,6 +663,7 @@ class TemporalAccessor:
         mode: Mode,
         freq: Frequency,
         weighted: bool = True,
+        keep_weights: bool = False,
         season_config: SeasonConfigInput = DEFAULT_SEASON_CONFIG,
     ) -> xr.Dataset:
         """Averages a data variable based on the averaging mode and frequency."""
@@ -660,12 +683,15 @@ class TemporalAccessor:
         elif self._mode in ["group_average", "climatology", "departures"]:
             dv = self._group_average(dv)
 
-        # The original time dimension is dropped from the Dataset because
-        # it becomes obsolete after the data variable is averaged. A new time
-        # dimension will be added to the Dataset when adding the averaged
-        # data variable.
+        # The original time dimension is dropped from the dataset because
+        # it becomes obsolete after the data variable is averaged. When the
+        # averaged data variable is added to the dataset, the new time dimension
+        # and its associated coordinates are also added.
         ds = ds.drop_dims("time")
         ds[dv.name] = dv
+
+        if keep_weights:
+            ds = self._keep_weights(ds)
 
         return ds
 
@@ -714,7 +740,6 @@ class TemporalAccessor:
                 f"include: {list(freq_keys)}."
             )
 
-        self._time_bounds = self._dataset.bounds.get_bounds("time").copy()
         self._mode = mode
         self._freq = freq
         self._weighted = weighted
@@ -878,7 +903,6 @@ class TemporalAccessor:
 
         if self._weighted:
             self._weights = self._get_weights()
-
             dv *= self._weights
             dv = self._group_data(dv).sum()  # type: ignore
         else:
@@ -902,6 +926,86 @@ class TemporalAccessor:
         dv = self._add_operation_attrs(dv)
 
         return dv
+
+    def _get_weights(self) -> xr.DataArray:
+        """Calculates weights for a data variable using time bounds.
+
+        This method gets the length of time for each coordinate point by using
+        the difference in the upper and lower time bounds. This approach ensures
+        that the correct time lengths are calculated regardless of how time
+        coordinates are recorded (e.g., monthly, daily, hourly) and the calendar
+        type used.
+
+        The time lengths are labeled and grouped, then each time length is
+        divided by the total sum of the time lengths in its group to get its
+        corresponding weight.
+
+        The sum of the weights for each group is validated to ensure it equals
+        1.0.
+
+        Returns
+        -------
+        xr.DataArray
+            The weights based on a specified frequency.
+
+        Notes
+        -----
+        Refer to [5]_ for the supported CF convention calendar types.
+
+        References
+        ----------
+        .. [5] https://cfconventions.org/cf-conventions/cf-conventions.html#calendar
+        """
+        with xr.set_options(keep_attrs=True):
+            time_lengths: xr.DataArray = (
+                self._time_bounds[:, 1] - self._time_bounds[:, 0]
+            )
+
+        # Must be cast dtype from "timedelta64[ns]" to "float64", specifically
+        # when using Dask arrays. Otherwise, the numpy warning below is thrown:
+        # `DeprecationWarning: The `dtype` and `signature` arguments to ufuncs
+        # only select the general DType and not details such as the byte order
+        # or time unit (with rare exceptions see release notes). To avoid this
+        # warning please use the scalar types `np.float64`, or string notation.`
+        time_lengths = time_lengths.astype(np.float64)
+
+        grouped_time_lengths = self._group_data(time_lengths)
+        weights: xr.DataArray = grouped_time_lengths / grouped_time_lengths.sum()  # type: ignore
+        weights.name = f"{self._dim_name}_wts"
+
+        # Validate the sum of weights for each group is 1.0.
+        actual_sum = self._group_data(weights).sum().values  # type: ignore
+        expected_sum = np.ones(len(grouped_time_lengths.groups))
+        np.testing.assert_allclose(actual_sum, expected_sum)
+
+        return weights
+
+    def _group_data(self, data_var: xr.DataArray) -> DataArrayGroupBy:
+        """Groups a data variable.
+
+        This method groups a data variable by a single datetime component for
+        the "average" mode or labeled time coordinates for all other modes.
+
+        Parameters
+        ----------
+        data_var : xr.DataArray
+            A data variable.
+
+        Returns
+        -------
+        DataArrayGroupBy
+            A data variable grouped by label.
+        """
+        dv = data_var.copy()
+
+        if self._mode == "average":
+            dv_gb = dv.groupby(f"{self._dim_name}.{self._freq}")
+        else:
+            self._labeled_time = self._label_time_coords(dv[self._dim_name])
+            dv.coords[self._labeled_time.name] = self._labeled_time
+            dv_gb = dv.groupby(self._labeled_time.name)
+
+        return dv_gb
 
     def _label_time_coords(self, time_coords: xr.DataArray) -> xr.DataArray:
         """Labels time coordinates with a group for grouping.
@@ -1251,97 +1355,40 @@ class TemporalAccessor:
 
         return np.array(dates)
 
-    def _get_weights(self) -> xr.DataArray:
-        """Calculates weights for a data variable using time bounds.
+    def _keep_weights(self, ds: xr.Dataset) -> xr.Dataset:
+        """Keep the weights in the dataset.
 
-        This method gets the length of time for each coordinate point by using
-        the difference in the upper and lower time bounds. This approach ensures
-        that the correct time lengths are calculated regardless of how time
-        coordinates are recorded (e.g., monthly, daily, hourly) and the calendar
-        type used.
-
-        The time lengths are labeled and grouped, then each time length is
-        divided by the total sum of the time lengths in its group to get its
-        corresponding weight.
-
-        The sum of the weights for each group is validated to ensure it equals
-        1.0.
+        Parameters
+        ----------
+        ds : xr.Dataset
+            The dataset.
 
         Returns
         -------
-        xr.DataArray
-            The weights based on a specified frequency.
-
-        Notes
-        -----
-        Refer to [5]_ for the supported CF convention calendar types.
-
-        References
-        ----------
-        .. [5] https://cfconventions.org/cf-conventions/cf-conventions.html#calendar
+        xr.Dataset
+            The dataset with the weights used for averaging.
         """
-        with xr.set_options(keep_attrs=True):
-            time_lengths: xr.DataArray = (
-                self._time_bounds[:, 1] - self._time_bounds[:, 0]
+        # Append "_original" to the name of the weights` time coordinates to
+        # avoid conflict with the grouped time coordinates in the Dataset (can
+        # have a different shape).
+        if self._mode in ["group_average", "climatology"]:
+            self._weights = self._weights.rename(
+                {self._dim_name: f"{self._dim_name}_original"}
+            )
+            # Only keep the original time coordinates, not the ones labeled
+            # by group.
+            self._weights = self._weights.drop_vars(self._labeled_time.name)
+        # Strip "_original" from the name of the weights` time coordinates
+        # because the final departures Dataset has the original time coordinates
+        # restored after performing grouped subtraction.
+        elif self._mode == "departures":
+            self._weights = self._weights.rename(
+                {f"{self._dim_name}_original": self._dim_name}
             )
 
-        # Must be cast dtype from "timedelta64[ns]" to "float64", specifically
-        # when using Dask arrays. Otherwise, the numpy warning below is thrown:
-        # `DeprecationWarning: The `dtype` and `signature` arguments to ufuncs
-        # only select the general DType and not details such as the byte order
-        # or time unit (with rare exceptions see release notes). To avoid this
-        # warning please use the scalar types `np.float64`, or string notation.`
-        time_lengths = time_lengths.astype(np.float64)
+        ds[self._weights.name] = self._weights
 
-        grouped_time_lengths = self._group_data(time_lengths)
-        weights: xr.DataArray = grouped_time_lengths / grouped_time_lengths.sum()  # type: ignore
-
-        num_groups = len(grouped_time_lengths.groups)
-        self._validate_weights(weights, num_groups)
-
-        return weights
-
-    def _validate_weights(self, weights: xr.DataArray, num_groups: int):
-        """Validates that the sum of the weights for each group equals 1.0.
-
-        Parameters
-        ----------
-        weights : xr.DataArray
-            The weights for the time coordinates.
-        num_groups : int
-            The number of groups.
-        """
-        actual_sum = self._group_data(weights).sum().values  # type: ignore
-        expected_sum = np.ones(num_groups)
-
-        np.testing.assert_allclose(actual_sum, expected_sum)
-
-    def _group_data(self, data_var: xr.DataArray) -> DataArrayGroupBy:
-        """Groups a data variable.
-
-        This method groups a data variable by a single datetime component for
-        the "average" mode or labeled time coordinates for all other modes.
-
-        Parameters
-        ----------
-        data_var : xr.DataArray
-            A data variable.
-
-        Returns
-        -------
-        DataArrayGroupBy
-            A data variable grouped by label.
-        """
-        dv = data_var.copy()
-
-        if self._mode == "average":
-            dv_gb = dv.groupby(f"{self._dim_name}.{self._freq}")
-        else:
-            self._labeled_time = self._label_time_coords(dv[self._dim_name])
-            dv.coords[self._labeled_time.name] = self._labeled_time
-            dv_gb = dv.groupby(self._labeled_time.name)
-
-        return dv_gb
+        return ds
 
     def _add_operation_attrs(self, data_var: xr.DataArray) -> xr.DataArray:
         """Adds attributes to the data variable describing the operation.

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -144,7 +144,7 @@ class TemporalAccessor:
 
     def __init__(self, dataset: xr.Dataset):
         self._dataset: xr.Dataset = dataset
-        
+
         self._dim_name = _get_coord_var(self._dataset, "T").name
 
         self._time_bounds = self._dataset.bounds.get_bounds("time").copy()


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

Summary of Changes
- Closes #251 
  - Related to #114
- Add default `None` value for `lat_bounds` and `lon_bounds` keyword args to `SpatialAccessor.get_weights()`
- Add kwarg `keep_weights` to both methods
- Make `_get_weights()` a public method for `SpatialAccessor`
- Delete redundant tests for private methods (related to #242)
- Delete faulty tests with domain bounds

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
