### PR TITLE
Update `swap_lon_axis` to ignore same systems

### DIFF
--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -143,6 +143,32 @@ class TestSwapLonAxis:
         with pytest.raises(ValueError):
             swap_lon_axis(ds_180, to=(0, 360))
 
+    def test_does_not_swap_if_desired_orientation_is_the_same_as_the_existing_orientation(
+        self,
+    ):
+        ds_360 = xr.Dataset(
+            coords={
+                "lon": xr.DataArray(
+                    name="lon",
+                    data=np.array([60, 150, 271]),
+                    dims=["lon"],
+                    attrs={"units": "degrees_east", "axis": "X", "bounds": "lon_bnds"},
+                )
+            },
+            data_vars={
+                "lon_bnds": xr.DataArray(
+                    name="lon_bnds",
+                    data=np.array([[0, 120], [120, 181], [181, 360]]),
+                    dims=["lon", "bnds"],
+                    attrs={"is_generated": "True"},
+                )
+            },
+        )
+
+        result = swap_lon_axis(ds_360, to=(0, 360))
+
+        assert result.identical(ds_360)
+
     def test_swap_from_360_to_180_and_sorts(self):
         ds_360 = xr.Dataset(
             coords={

--- a/xcdat/axis.py
+++ b/xcdat/axis.py
@@ -124,7 +124,7 @@ def swap_lon_axis(
                 "orientations."
             )
 
-    # If the current axis orientation is the same as the desired axis
+    # If the swapped axis orientation is the same as the existing axis
     # orientation, return the original Dataset.
     if new_lon.identical(lon):
         return dataset

--- a/xcdat/axis.py
+++ b/xcdat/axis.py
@@ -125,7 +125,7 @@ def swap_lon_axis(
             )
 
     # If the current axis orientation is the same as the desired axis
-    # orientation, `pass` and return the same dataset.
+    # orientation, return the original Dataset.
     if new_lon.identical(lon):
         return dataset
 

--- a/xcdat/axis.py
+++ b/xcdat/axis.py
@@ -107,7 +107,7 @@ def swap_lon_axis(
         if to == (-180, 180):
             new_lon = ((lon + 180) % 360) - 180
             new_lon_bounds = ((lon_bounds + 180) % 360) - 180
-            ds = _reassign_lon(ds, lon, lon_bounds)
+            ds = _reassign_lon(ds, new_lon, new_lon_bounds)
         elif to == (0, 360):
             new_lon = lon % 360
             new_lon_bounds = lon_bounds % 360
@@ -130,7 +130,7 @@ def swap_lon_axis(
         return dataset
 
     if sort_ascending:
-        ds = ds.sortby(lon.name, ascending=True)
+        ds = ds.sortby(new_lon.name, ascending=True)
 
     return ds
 


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #250 
- This fixes an issue when attempting to swap from (0, 360) to (0, 360) (same orientation), resulting in an additional coord point and lon bounds being added inadvertently. For example:
  1. We have bounds [0, 0.5625] for coordinate point 0
  2. It will convert to [359.4375, 0.5625], which is a prime meridian cell.
  3. Since a prime meridian cell exists, it will add another coordinate point for 360 and a lon bound of [359.4375, 360].
  4. This changes the shape of the lon coords and lon bounds by 1

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
