### PR TITLE
better handling of non-cf-compliant time data

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -52,7 +52,15 @@ time_non_cf = xr.DataArray(
         "standard_name": "time",
     },
 )
-
+time_non_cf_unsupported = xr.DataArray(
+    data=np.arange(1850 + 1 / 24.0, 1851 + 3 / 12.0, 1 / 12.0),
+    dims=["time"],
+    attrs={
+        "units": "year A.D.",
+        "long_name": "time",
+        "standard_name": "time",
+    },
+)
 time_bnds = xr.DataArray(
     name="time_bnds",
     data=np.array(
@@ -103,6 +111,16 @@ time_bnds_non_cf = xr.DataArray(
     coords={"time": time_non_cf},
     dims=["time", "bnds"],
     attrs={"xcdat_bounds": "True"},
+)
+tb = []
+for t in time_non_cf_unsupported:
+    tb.append([t - 1 / 24.0, t + 1 / 24.0])
+time_bnds_non_cf_unsupported = xr.DataArray(
+    name="time_bnds",
+    data=tb,
+    coords={"time": time_non_cf_unsupported},
+    dims=["time", "bnds"],
+    attrs={"is_generated": "True"},
 )
 
 # LATITUDE
@@ -159,7 +177,9 @@ ts_non_cf = xr.DataArray(
 )
 
 
-def generate_dataset(cf_compliant: bool, has_bounds: bool) -> xr.Dataset:
+def generate_dataset(
+    cf_compliant: bool, has_bounds: bool, unsupported=False
+) -> xr.Dataset:
     """Generates a dataset using coordinate and data variable fixtures.
 
     Parameters
@@ -189,8 +209,12 @@ def generate_dataset(cf_compliant: bool, has_bounds: bool) -> xr.Dataset:
             ds.coords["time"] = time_cf.copy()
             ds["time_bnds"] = time_bnds.copy()
         elif not cf_compliant:
-            ds.coords["time"] = time_non_cf.copy()
-            ds["time_bnds"] = time_bnds_non_cf.copy()
+            if unsupported:
+                ds.coords["time"] = time_non_cf_unsupported.copy()
+                ds["time_bnds"] = time_bnds_non_cf_unsupported.copy()
+            else:
+                ds.coords["time"] = time_non_cf.copy()
+                ds["time_bnds"] = time_bnds_non_cf.copy()
 
         # If the "bounds" attribute is included in an existing DataArray and
         # added to a new Dataset, it will get dropped. Therefore, it needs to be

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -178,7 +178,7 @@ ts_non_cf = xr.DataArray(
 
 
 def generate_dataset(
-    cf_compliant: bool, has_bounds: bool, unsupported=False
+    cf_compliant: bool, has_bounds: bool, unsupported: bool = False
 ) -> xr.Dataset:
     """Generates a dataset using coordinate and data variable fixtures.
 
@@ -189,12 +189,22 @@ def generate_dataset(
     has_bounds : bool, optional
         Include bounds for coordinates. This also adds the "bounds" attribute
         to existing coordinates to link them to their respective bounds.
+    unsupported : bool, optional
+        Create time units that are unsupported and cannot be decoded.
+        Note that cf_compliant must be set to False.
 
     Returns
     -------
     xr.Dataset
         Test dataset.
     """
+
+    if unsupported & cf_compliant:
+        raise ValueError(
+            "Cannot set cf_compliant=True and unsupported=True. \n"
+            "Set cf_compliant=False."
+        )
+
     if has_bounds:
         ds = xr.Dataset(
             data_vars={

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -43,9 +43,9 @@ class TestOpenDataset:
 
         # even though decode_times=True, it should fail to decode unsupported time axis
         result = open_dataset(self.file_path, decode_times=True)
-        expected_times = np.arange(1850 + 1 / 24.0, 1851 + 3 / 12.0, 1 / 12.0)
+        expected = ds
 
-        assert np.all(expected_times == result.time.values)
+        assert result.identical(expected)
 
     def test_non_cf_compliant_time_is_decoded(self):
         ds = generate_dataset(cf_compliant=False, has_bounds=False)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -37,6 +37,16 @@ class TestOpenDataset:
         expected = generate_dataset(cf_compliant=False, has_bounds=True)
         assert result.identical(expected)
 
+    def test_non_cf_compliant_and_unsupported_time_is_not_decoded(self):
+        ds = generate_dataset(cf_compliant=False, has_bounds=True, unsupported=True)
+        ds.to_netcdf(self.file_path)
+
+        # even though decode_times=True, it should fail to decode unsupported time axis
+        result = open_dataset(self.file_path, decode_times=True)
+        expected_times = np.arange(1850 + 1 / 24.0, 1851 + 3 / 12.0, 1 / 12.0)
+
+        assert np.all(expected_times == result.time.values)
+
     def test_non_cf_compliant_time_is_decoded(self):
         ds = generate_dataset(cf_compliant=False, has_bounds=False)
         ds.to_netcdf(self.file_path)

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -41,9 +41,10 @@ def open_dataset(
         the Dataset, by default True. Bounds are required for many xCDAT
         features.
     decode_times: bool, optional
-        If True, decode times encoded in the standard NetCDF datetime format
-        into datetime objects. Otherwise, leave them encoded as numbers.
-        This keyword may not be supported by all the backends, by default True.
+        If True, attempt to decode times encoded in the standard NetCDF
+        datetime format into datetime objects. Otherwise, leave them encoded
+        as numbers. This keyword may not be supported by all the backends,
+        by default True.
     center_times: bool, optional
         If True, center time coordinates using the midpoint between its upper
         and lower bounds. Otherwise, use the provided time coordinates, by
@@ -232,7 +233,8 @@ def decode_non_cf_time(dataset: xr.Dataset) -> xr.Dataset:
     ----------
     dataset : xr.Dataset
         Dataset with numerically encoded time coordinates and time bounds (if
-        they exist).
+        they exist). If the time coordinates cannot be decoded then the original
+        dataset is returned.
 
     Returns
     -------
@@ -619,6 +621,11 @@ def _split_time_units_attr(units_attr: str) -> Tuple[str, str]:
     Tuple[str, str]
         The units (e.g, "months") and the reference date (e.g., "1800-01-01").
         If the units attribute doesn't exist for the time coordinates.
+
+    Raises
+    ------
+    ValueError
+        If the time units attribute is not of the form `X since Y`.
     """
     if units_attr is None:
         raise KeyError("No 'units' attribute found for the dataset's time coordinates.")


### PR DESCRIPTION
## Description

xcdat can decode some non-cf compliant data, but it cannot handle every case. This update makes it so that xcdat attempts to decode non-cf-compliant data and if it fails it returns a non-decoded dataset (instead of raising a ValueError).

- Closes #261 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
