### PR TITLE
Filters safe warnings.

### DIFF
--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -136,6 +136,7 @@ class TestRegrid2Regridder:
             }
         )
 
+    @pytest.mark.filterwarnings("ignore:.*invalid value.*true_divide.*:RuntimeWarning")
     def test_output_bounds(self):
         ds = fixtures.generate_dataset(cf_compliant=True, has_bounds=True)
 
@@ -615,6 +616,7 @@ class TestAccessor:
         ):
             self.ac.horizontal("ts", mock.MagicMock(), "test")  # type: ignore
 
+    @pytest.mark.filterwarnings("ignore:.*invalid value.*true_divide.*:RuntimeWarning")
     def test_convenience_methods(self):
         ds = fixtures.generate_dataset(cf_compliant=True, has_bounds=True)
 


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
Filters some safe to ignore warnings.

Two test methods raised `RuntimeWarning: invalid value encountered in true_divide`.

These warnings will still appear in user code as they may be significant outside of testing.

- Closes #264 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
