### PR TITLE
Pin `numba=0.55.2` in dev env and constrain `numba>=0.55.2` in ci env

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -13,7 +13,7 @@ dependencies:
     - dask
     - esmpy
     - netcdf4
-    - numba >=0.55.2
+    - numba >=0.55.2 # TODO: Remove this pin once `numba` is properly patched with `numpy` compatability.
     - numpy
     - pandas
     - xarray

--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -6,13 +6,14 @@ channels:
 dependencies:
     # Base
     # ==================
-    - python>=3.8
+    - python >=3.8
     - pip
     - cf_xarray
     - cftime
     - dask
     - esmpy
     - netcdf4
+    - numba >=0.55.2
     - numpy
     - pandas
     - xarray

--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -13,7 +13,6 @@ dependencies:
     - dask
     - esmpy
     - netcdf4
-    - numba # TODO: Remove `numba` once it is included in the `xesmf` feedstock.
     - numpy
     - pandas
     - xarray

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -16,7 +16,7 @@ dependencies:
     - numpy=1.23.0
     - pandas=1.4.3
     - xarray=2022.3.0
-    - xesmf=0.6.2
+    - xesmf=0.6.3
     # Quality Assurance
     # ==================
     # If versions are updated, also update 'rev' in `.pre-commit.config.yaml`

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -13,8 +13,8 @@ dependencies:
     - dask=2022.6.1
     - esmpy=8.2.0
     - netcdf4=1.5.8
-    - numpy=1.22.4
     - numba=0.55.2 # TODO: Remove this pin once `numba` is properly patched with `numpy` compatability.
+    - numpy=1.22.4
     - pandas=1.4.3
     - xarray=2022.3.0
     - xesmf=0.6.3

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -13,8 +13,7 @@ dependencies:
     - dask=2022.6.1
     - esmpy=8.2.0
     - netcdf4=1.5.8
-    - numba=0.55.2 # TODO: Remove `numba` once it is included in the `xesmf` feedstock.
-    - numpy=1.22.4 # TODO: Update to >=1.23 once numba is removed
+    - numpy=1.23.0
     - pandas=1.4.3
     - xarray=2022.3.0
     - xesmf=0.6.2

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -13,7 +13,8 @@ dependencies:
     - dask=2022.6.1
     - esmpy=8.2.0
     - netcdf4=1.5.8
-    - numpy=1.23.0
+    - numpy=1.22.4
+    - numba=0.55.2 # TODO: Remove this pin once `numba` is properly patched with `numpy` compatability.
     - pandas=1.4.3
     - xarray=2022.3.0
     - xesmf=0.6.3

--- a/conda-env/readthedocs.yml
+++ b/conda-env/readthedocs.yml
@@ -13,7 +13,8 @@ dependencies:
     - dask=2022.6.1
     - esmpy=8.2.0
     - netcdf4=1.5.8
-    - numpy=1.23.0
+    - numba=0.55.2
+    - numpy=1.22.4
     - pandas=1.4.3
     - xarray=2022.3.0
     - xesmf=0.6.3

--- a/conda-env/readthedocs.yml
+++ b/conda-env/readthedocs.yml
@@ -16,7 +16,7 @@ dependencies:
     - numpy=1.23.0
     - pandas=1.4.3
     - xarray=2022.3.0
-    - xesmf=0.6.2
+    - xesmf=0.6.3
     # Documentation
     # ==================
     - sphinx=4.5.0

--- a/conda-env/readthedocs.yml
+++ b/conda-env/readthedocs.yml
@@ -13,7 +13,7 @@ dependencies:
     - dask=2022.6.1
     - esmpy=8.2.0
     - netcdf4=1.5.8
-    - numba=0.55.2
+    - numba=0.55.2 # TODO: Remove this pin once `numba` is properly patched with `numpy` compatability.
     - numpy=1.22.4
     - pandas=1.4.3
     - xarray=2022.3.0

--- a/conda-env/readthedocs.yml
+++ b/conda-env/readthedocs.yml
@@ -13,8 +13,7 @@ dependencies:
     - dask=2022.6.1
     - esmpy=8.2.0
     - netcdf4=1.5.8
-    - numba=0.55.2 # TODO: Remove `numba` once it is included in the `xesmf` feedstock.
-    - numpy=1.22.4 # TODO: Update to >=1.23 once numba is removed
+    - numpy=1.23.0
     - pandas=1.4.3
     - xarray=2022.3.0
     - xesmf=0.6.2


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #279
- This is done to avoid incompatible versions with `numpy>=1.22`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
