### PR TITLE
Bugfix/278 cannot generate bounds

### DIFF
--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -65,6 +65,16 @@ class TestAddMissingBounds:
         result = ds.bounds.add_missing_bounds()
         assert result.identical(self.ds_with_bnds)
 
+    def test_adds_bounds_to_the_dataset_skips_nondimensional_axes(self):
+        ds = generate_dataset(cf_compliant=True, has_bounds=True)
+        ds = ds.assign_coords({"height": 2})
+
+        dsm = ds.drop_vars(["lat_bnds", "lon_bnds"]).copy()
+
+        result = dsm.bounds.add_missing_bounds()
+
+        assert result.identical(ds)
+
 
 class TestGetBounds:
     @pytest.fixture(autouse=True)

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -66,13 +66,18 @@ class TestAddMissingBounds:
         assert result.identical(self.ds_with_bnds)
 
     def test_adds_bounds_to_the_dataset_skips_nondimensional_axes(self):
+        # generate dataset with height coordinate
         ds = generate_dataset(cf_compliant=True, has_bounds=True)
         ds = ds.assign_coords({"height": 2})
 
+        # drop bounds
         dsm = ds.drop_vars(["lat_bnds", "lon_bnds"]).copy()
 
+        # test bounds re-generation
         result = dsm.bounds.add_missing_bounds()
 
+        # dataset with missing bounds added should match dataset with bounds
+        # and added height coordinate
         assert result.identical(ds)
 
 

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -133,8 +133,6 @@ class BoundsAccessor:
         axes = CF_NAME_MAP.keys()
 
         for axis in axes:
-
-            CF_NAME_MAP[axis]
             coord_var = None
 
             try:

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -133,6 +133,14 @@ class BoundsAccessor:
         axes = CF_NAME_MAP.keys()
 
         for axis in axes:
+
+            # determine if the axis is also a dimension by determining
+            # if there is overlap between the CF axis names and the dimension
+            # names. If not, skip over axis for validation.
+            if len(set(CF_NAME_MAP[axis]) & set(self._dataset.dims.keys())) == 0:
+                continue
+
+            CF_NAME_MAP[axis]
             coord_var = None
 
             try:

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -134,12 +134,6 @@ class BoundsAccessor:
 
         for axis in axes:
 
-            # determine if the axis is also a dimension by determining
-            # if there is overlap between the CF axis names and the dimension
-            # names. If not, skip over axis for validation.
-            if len(set(CF_NAME_MAP[axis]) & set(self._dataset.dims.keys())) == 0:
-                continue
-
             CF_NAME_MAP[axis]
             coord_var = None
 
@@ -147,6 +141,12 @@ class BoundsAccessor:
                 coord_var = get_axis_coord(self._dataset, axis)
             except KeyError:
                 pass
+
+            # determine if the axis is also a dimension by determining
+            # if there is overlap between the CF axis names and the dimension
+            # names. If not, skip over axis for validation.
+            if len(set(CF_NAME_MAP[axis]) & set(self._dataset.dims.keys())) == 0:
+                continue
 
             if coord_var is not None:
                 try:


### PR DESCRIPTION
## Description
This fixes an issue for datasets that have a singleton coordinate value (e.g., height = 2m), but not a corresponding dimension. When xcdat tries to add bounds, it hits an error, because the dimension is singleton. 

- Closes #278 
## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules

If applicable:

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass with my changes (locally and CI/CD build)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
