### PR TITLE
Bugfix/282 out of bounds datetime

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,4 +35,10 @@ repos:
           - id: mypy
             args: ["--config=setup.cfg"]
             additional_dependencies:
-                [dask==2022.6.1, numpy==1.23.0, pandas==1.4.3, xarray==2022.3.0]
+                [
+                    dask==2022.6.1,
+                    numpy==1.22.4,
+                    pandas==1.4.3,
+                    xarray==2022.3.0,
+                    types-python-dateutil==2.8.2,
+                ]

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -17,7 +17,8 @@ dependencies:
     - numpy=1.22.4
     - pandas=1.4.3
     - xarray=2022.3.0
-    - xesmf=0.6.3
+    - python-dateutil=2.8.2
+    - types-python-dateutil=2.8.19
     # Quality Assurance
     # ==================
     # If versions are updated, also update 'rev' in `.pre-commit.config.yaml`

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,6 +1,7 @@
 import pathlib
 import warnings
 
+import cftime
 import numpy as np
 import pytest
 import xarray as xr
@@ -55,59 +56,86 @@ class TestOpenDataset:
 
         # Generate an expected dataset with decoded non-CF compliant time units.
         expected = generate_dataset(cf_compliant=True, has_bounds=True)
-        expected_time_data = np.array(
-            [
-                "2000-01-01T00:00:00.000000000",
-                "2000-02-01T00:00:00.000000000",
-                "2000-03-01T00:00:00.000000000",
-                "2000-04-01T00:00:00.000000000",
-                "2000-05-01T00:00:00.000000000",
-                "2000-06-01T00:00:00.000000000",
-                "2000-07-01T00:00:00.000000000",
-                "2000-08-01T00:00:00.000000000",
-                "2000-09-01T00:00:00.000000000",
-                "2000-10-01T00:00:00.000000000",
-                "2000-11-01T00:00:00.000000000",
-                "2000-12-01T00:00:00.000000000",
-                "2001-01-01T00:00:00.000000000",
-                "2001-02-01T00:00:00.000000000",
-                "2001-03-01T00:00:00.000000000",
-            ],
-            dtype="datetime64[ns]",
-        )
         expected["time"] = xr.DataArray(
             name="time",
-            data=expected_time_data,
+            data=np.array(
+                [
+                    cftime.datetime(2000, 1, 1),
+                    cftime.datetime(2000, 2, 1),
+                    cftime.datetime(2000, 3, 1),
+                    cftime.datetime(2000, 4, 1),
+                    cftime.datetime(2000, 5, 1),
+                    cftime.datetime(2000, 6, 1),
+                    cftime.datetime(2000, 7, 1),
+                    cftime.datetime(2000, 8, 1),
+                    cftime.datetime(2000, 9, 1),
+                    cftime.datetime(2000, 10, 1),
+                    cftime.datetime(2000, 11, 1),
+                    cftime.datetime(2000, 12, 1),
+                    cftime.datetime(2001, 1, 1),
+                    cftime.datetime(2001, 2, 1),
+                    cftime.datetime(2001, 3, 1),
+                ],
+            ),
             dims="time",
-            attrs={
-                "units": "months since 2000-01-01",
-                "calendar": "standard",
-                "axis": "T",
-                "long_name": "time",
-                "standard_name": "time",
-                "bounds": "time_bnds",
-            },
         )
-        expected.time_bnds.data[:] = np.array(
-            [
-                ["1999-12-16T12:00:00.000000000", "2000-01-16T12:00:00.000000000"],
-                ["2000-01-16T12:00:00.000000000", "2000-02-15T12:00:00.000000000"],
-                ["2000-02-15T12:00:00.000000000", "2000-03-16T12:00:00.000000000"],
-                ["2000-03-16T12:00:00.000000000", "2000-04-16T00:00:00.000000000"],
-                ["2000-04-16T00:00:00.000000000", "2000-05-16T12:00:00.000000000"],
-                ["2000-05-16T12:00:00.000000000", "2000-06-16T00:00:00.000000000"],
-                ["2000-06-16T00:00:00.000000000", "2000-07-16T12:00:00.000000000"],
-                ["2000-07-16T12:00:00.000000000", "2000-08-16T12:00:00.000000000"],
-                ["2000-08-16T12:00:00.000000000", "2000-09-16T00:00:00.000000000"],
-                ["2000-09-16T00:00:00.000000000", "2000-10-16T12:00:00.000000000"],
-                ["2000-10-16T12:00:00.000000000", "2000-11-16T00:00:00.000000000"],
-                ["2000-11-16T00:00:00.000000000", "2000-12-16T12:00:00.000000000"],
-                ["2000-12-16T12:00:00.000000000", "2001-01-16T12:00:00.000000000"],
-                ["2001-01-16T12:00:00.000000000", "2001-02-15T00:00:00.000000000"],
-                ["2001-02-15T00:00:00.000000000", "2001-03-15T00:00:00.000000000"],
-            ],
-            dtype="datetime64[ns]",
+        expected["time_bnds"] = xr.DataArray(
+            name="time_bnds",
+            data=np.array(
+                [
+                    [
+                        cftime.datetime(1999, 12, 16, 12),
+                        cftime.datetime(2000, 1, 16, 12),
+                    ],
+                    [
+                        cftime.datetime(2000, 1, 16, 12),
+                        cftime.datetime(2000, 2, 15, 12),
+                    ],
+                    [
+                        cftime.datetime(2000, 2, 15, 12),
+                        cftime.datetime(2000, 3, 16, 12),
+                    ],
+                    [cftime.datetime(2000, 3, 16, 12), cftime.datetime(2000, 4, 16, 0)],
+                    [cftime.datetime(2000, 4, 16, 0), cftime.datetime(2000, 5, 16, 12)],
+                    [cftime.datetime(2000, 5, 16, 12), cftime.datetime(2000, 6, 16, 0)],
+                    [cftime.datetime(2000, 6, 16, 0), cftime.datetime(2000, 7, 16, 12)],
+                    [
+                        cftime.datetime(2000, 7, 16, 12),
+                        cftime.datetime(2000, 8, 16, 12),
+                    ],
+                    [cftime.datetime(2000, 8, 16, 12), cftime.datetime(2000, 9, 16, 0)],
+                    [
+                        cftime.datetime(2000, 9, 16, 0),
+                        cftime.datetime(2000, 10, 16, 12),
+                    ],
+                    [
+                        cftime.datetime(2000, 10, 16, 12),
+                        cftime.datetime(2000, 11, 16, 0),
+                    ],
+                    [
+                        cftime.datetime(2000, 11, 16, 0),
+                        cftime.datetime(2000, 12, 16, 12),
+                    ],
+                    [
+                        cftime.datetime(2000, 12, 16, 12),
+                        cftime.datetime(2001, 1, 16, 12),
+                    ],
+                    [cftime.datetime(2001, 1, 16, 12), cftime.datetime(2001, 2, 15, 0)],
+                    [cftime.datetime(2001, 2, 15, 0), cftime.datetime(2001, 3, 15, 0)],
+                ]
+            ),
+            dims=["time", "bnds"],
+            attrs={"xcdat_bounds": "True"},
         )
+
+        expected.time.attrs = {
+            "units": "months since 2000-01-01",
+            "calendar": "standard",
+            "axis": "T",
+            "long_name": "time",
+            "standard_name": "time",
+            "bounds": "time_bnds",
+        }
         expected.time.encoding = {
             # Set source as result source because it changes every test run.
             "source": result.time.encoding["source"],
@@ -182,67 +210,91 @@ class TestOpenMfDataset:
         ds1.to_netcdf(self.file_path1)
         ds2.to_netcdf(self.file_path2)
 
-        result = open_mfdataset(
-            [self.file_path1, self.file_path2],
-            data_var="ts",
-        )
+        result = open_mfdataset([self.file_path1, self.file_path2], data_var="ts")
 
-        # Generate an expected dataset, which is a combination of both datasets
-        # with decoded time units and coordinate bounds.
+        # Generate an expected dataset with decoded non-CF compliant time units.
         expected = generate_dataset(cf_compliant=True, has_bounds=True)
-        expected_time_data = np.array(
-            [
-                "2000-01-01T00:00:00.000000000",
-                "2000-02-01T00:00:00.000000000",
-                "2000-03-01T00:00:00.000000000",
-                "2000-04-01T00:00:00.000000000",
-                "2000-05-01T00:00:00.000000000",
-                "2000-06-01T00:00:00.000000000",
-                "2000-07-01T00:00:00.000000000",
-                "2000-08-01T00:00:00.000000000",
-                "2000-09-01T00:00:00.000000000",
-                "2000-10-01T00:00:00.000000000",
-                "2000-11-01T00:00:00.000000000",
-                "2000-12-01T00:00:00.000000000",
-                "2001-01-01T00:00:00.000000000",
-                "2001-02-01T00:00:00.000000000",
-                "2001-03-01T00:00:00.000000000",
-            ],
-            dtype="datetime64[ns]",
-        )
+
         expected["time"] = xr.DataArray(
             name="time",
-            data=expected_time_data,
+            data=np.array(
+                [
+                    cftime.datetime(2000, 1, 1),
+                    cftime.datetime(2000, 2, 1),
+                    cftime.datetime(2000, 3, 1),
+                    cftime.datetime(2000, 4, 1),
+                    cftime.datetime(2000, 5, 1),
+                    cftime.datetime(2000, 6, 1),
+                    cftime.datetime(2000, 7, 1),
+                    cftime.datetime(2000, 8, 1),
+                    cftime.datetime(2000, 9, 1),
+                    cftime.datetime(2000, 10, 1),
+                    cftime.datetime(2000, 11, 1),
+                    cftime.datetime(2000, 12, 1),
+                    cftime.datetime(2001, 1, 1),
+                    cftime.datetime(2001, 2, 1),
+                    cftime.datetime(2001, 3, 1),
+                ],
+            ),
             dims="time",
-            attrs={
-                "units": "months since 2000-01-01",
-                "calendar": "standard",
-                "axis": "T",
-                "long_name": "time",
-                "standard_name": "time",
-                "bounds": "time_bnds",
-            },
         )
-        expected.time_bnds.data[:] = np.array(
-            [
-                ["1999-12-16T12:00:00.000000000", "2000-01-16T12:00:00.000000000"],
-                ["2000-01-16T12:00:00.000000000", "2000-02-15T12:00:00.000000000"],
-                ["2000-02-15T12:00:00.000000000", "2000-03-16T12:00:00.000000000"],
-                ["2000-03-16T12:00:00.000000000", "2000-04-16T00:00:00.000000000"],
-                ["2000-04-16T00:00:00.000000000", "2000-05-16T12:00:00.000000000"],
-                ["2000-05-16T12:00:00.000000000", "2000-06-16T00:00:00.000000000"],
-                ["2000-06-16T00:00:00.000000000", "2000-07-16T12:00:00.000000000"],
-                ["2000-07-16T12:00:00.000000000", "2000-08-16T12:00:00.000000000"],
-                ["2000-08-16T12:00:00.000000000", "2000-09-16T00:00:00.000000000"],
-                ["2000-09-16T00:00:00.000000000", "2000-10-16T12:00:00.000000000"],
-                ["2000-10-16T12:00:00.000000000", "2000-11-16T00:00:00.000000000"],
-                ["2000-11-16T00:00:00.000000000", "2000-12-16T12:00:00.000000000"],
-                ["2000-12-16T12:00:00.000000000", "2001-01-16T12:00:00.000000000"],
-                ["2001-01-16T12:00:00.000000000", "2001-02-15T00:00:00.000000000"],
-                ["2001-02-15T00:00:00.000000000", "2001-03-15T00:00:00.000000000"],
-            ],
-            dtype="datetime64[ns]",
+        expected["time_bnds"] = xr.DataArray(
+            name="time_bnds",
+            data=np.array(
+                [
+                    [
+                        cftime.datetime(1999, 12, 16, 12),
+                        cftime.datetime(2000, 1, 16, 12),
+                    ],
+                    [
+                        cftime.datetime(2000, 1, 16, 12),
+                        cftime.datetime(2000, 2, 15, 12),
+                    ],
+                    [
+                        cftime.datetime(2000, 2, 15, 12),
+                        cftime.datetime(2000, 3, 16, 12),
+                    ],
+                    [cftime.datetime(2000, 3, 16, 12), cftime.datetime(2000, 4, 16, 0)],
+                    [cftime.datetime(2000, 4, 16, 0), cftime.datetime(2000, 5, 16, 12)],
+                    [cftime.datetime(2000, 5, 16, 12), cftime.datetime(2000, 6, 16, 0)],
+                    [cftime.datetime(2000, 6, 16, 0), cftime.datetime(2000, 7, 16, 12)],
+                    [
+                        cftime.datetime(2000, 7, 16, 12),
+                        cftime.datetime(2000, 8, 16, 12),
+                    ],
+                    [cftime.datetime(2000, 8, 16, 12), cftime.datetime(2000, 9, 16, 0)],
+                    [
+                        cftime.datetime(2000, 9, 16, 0),
+                        cftime.datetime(2000, 10, 16, 12),
+                    ],
+                    [
+                        cftime.datetime(2000, 10, 16, 12),
+                        cftime.datetime(2000, 11, 16, 0),
+                    ],
+                    [
+                        cftime.datetime(2000, 11, 16, 0),
+                        cftime.datetime(2000, 12, 16, 12),
+                    ],
+                    [
+                        cftime.datetime(2000, 12, 16, 12),
+                        cftime.datetime(2001, 1, 16, 12),
+                    ],
+                    [cftime.datetime(2001, 1, 16, 12), cftime.datetime(2001, 2, 15, 0)],
+                    [cftime.datetime(2001, 2, 15, 0), cftime.datetime(2001, 3, 15, 0)],
+                ]
+            ),
+            dims=["time", "bnds"],
+            attrs={"xcdat_bounds": "True"},
         )
+
+        expected.time.attrs = {
+            "units": "months since 2000-01-01",
+            "calendar": "standard",
+            "axis": "T",
+            "long_name": "time",
+            "standard_name": "time",
+            "bounds": "time_bnds",
+        }
         expected.time.encoding = {
             # Set source as result source because it changes every test run.
             "source": result.time.encoding["source"],
@@ -383,7 +435,7 @@ class TestDecodeNonCFTimeUnits:
                 "axis": "T",
                 "long_name": "time",
                 "standard_name": "time",
-                "calendar": "noleap",
+                # calendar attr is specified by test.
             },
         )
         time_bnds = xr.DataArray(
@@ -414,6 +466,8 @@ class TestDecodeNonCFTimeUnits:
 
     def test_decodes_months_with_a_reference_date_at_the_start_of_the_month(self):
         ds = self.ds.copy()
+        calendar = "standard"
+        ds.time.attrs["calendar"] = calendar
         ds.time.attrs["units"] = "months since 2000-01-01"
 
         result = decode_non_cf_time(ds)
@@ -422,8 +476,11 @@ class TestDecodeNonCFTimeUnits:
                 "time": xr.DataArray(
                     name="time",
                     data=np.array(
-                        ["2000-02-01", "2000-03-01", "2000-04-01"],
-                        dtype="datetime64",
+                        [
+                            cftime.datetime(2000, 2, 1, calendar=calendar),
+                            cftime.datetime(2000, 3, 1, calendar=calendar),
+                            cftime.datetime(2000, 4, 1, calendar=calendar),
+                        ],
                     ),
                     dims=["time"],
                     attrs=ds.time.attrs,
@@ -432,11 +489,19 @@ class TestDecodeNonCFTimeUnits:
                     name="time_bnds",
                     data=np.array(
                         [
-                            ["2000-01-01", "2000-02-01"],
-                            ["2000-02-01", "2000-03-01"],
-                            ["2000-03-01", "2000-04-01"],
+                            [
+                                cftime.datetime(2000, 1, 1, calendar=calendar),
+                                cftime.datetime(2000, 2, 1, calendar=calendar),
+                            ],
+                            [
+                                cftime.datetime(2000, 2, 1, calendar=calendar),
+                                cftime.datetime(2000, 3, 1, calendar=calendar),
+                            ],
+                            [
+                                cftime.datetime(2000, 3, 1, calendar=calendar),
+                                cftime.datetime(2000, 4, 1, calendar=calendar),
+                            ],
                         ],
-                        dtype="datetime64",
                     ),
                     dims=["time", "bnds"],
                     attrs=ds.time_bnds.attrs,
@@ -450,7 +515,7 @@ class TestDecodeNonCFTimeUnits:
             "dtype": np.dtype(np.int64),
             "original_shape": expected.time.data.shape,
             "units": ds.time.attrs["units"],
-            "calendar": ds.time.attrs["calendar"],
+            "calendar": calendar,
         }
         expected.time_bnds.encoding = ds.time_bnds.encoding
         assert result.time.encoding == expected.time.encoding
@@ -458,6 +523,8 @@ class TestDecodeNonCFTimeUnits:
 
     def test_decodes_months_with_a_reference_date_at_the_middle_of_the_month(self):
         ds = self.ds.copy()
+        calendar = "standard"
+        ds.time.attrs["calendar"] = calendar
         ds.time.attrs["units"] = "months since 2000-01-15"
 
         result = decode_non_cf_time(ds)
@@ -466,8 +533,11 @@ class TestDecodeNonCFTimeUnits:
                 "time": xr.DataArray(
                     name="time",
                     data=np.array(
-                        ["2000-02-15", "2000-03-15", "2000-04-15"],
-                        dtype="datetime64",
+                        [
+                            cftime.datetime(2000, 2, 15, calendar=calendar),
+                            cftime.datetime(2000, 3, 15, calendar=calendar),
+                            cftime.datetime(2000, 4, 15, calendar=calendar),
+                        ],
                     ),
                     dims=["time"],
                     attrs=ds.time.attrs,
@@ -476,11 +546,19 @@ class TestDecodeNonCFTimeUnits:
                     name="time_bnds",
                     data=np.array(
                         [
-                            ["2000-01-15", "2000-02-15"],
-                            ["2000-02-15", "2000-03-15"],
-                            ["2000-03-15", "2000-04-15"],
+                            [
+                                cftime.datetime(2000, 1, 15, calendar=calendar),
+                                cftime.datetime(2000, 2, 15, calendar=calendar),
+                            ],
+                            [
+                                cftime.datetime(2000, 2, 15, calendar=calendar),
+                                cftime.datetime(2000, 3, 15, calendar=calendar),
+                            ],
+                            [
+                                cftime.datetime(2000, 3, 15, calendar=calendar),
+                                cftime.datetime(2000, 4, 15, calendar=calendar),
+                            ],
                         ],
-                        dtype="datetime64",
                     ),
                     dims=["time", "bnds"],
                     attrs=ds.time_bnds.attrs,
@@ -502,6 +580,8 @@ class TestDecodeNonCFTimeUnits:
 
     def test_decodes_months_with_a_reference_date_at_the_end_of_the_month(self):
         ds = self.ds.copy()
+        calendar = "standard"
+        ds.time.attrs["calendar"] = calendar
         ds.time.attrs["units"] = "months since 1999-12-31"
 
         result = decode_non_cf_time(ds)
@@ -510,8 +590,11 @@ class TestDecodeNonCFTimeUnits:
                 "time": xr.DataArray(
                     name="time",
                     data=np.array(
-                        ["2000-01-31", "2000-02-29", "2000-03-31"],
-                        dtype="datetime64",
+                        [
+                            cftime.datetime(2000, 1, 31, calendar=calendar),
+                            cftime.datetime(2000, 2, 29, calendar=calendar),
+                            cftime.datetime(2000, 3, 31, calendar=calendar),
+                        ],
                     ),
                     dims=["time"],
                     attrs=ds.time.attrs,
@@ -520,11 +603,19 @@ class TestDecodeNonCFTimeUnits:
                     name="time_bnds",
                     data=np.array(
                         [
-                            ["1999-12-31", "2000-01-31"],
-                            ["2000-01-31", "2000-02-29"],
-                            ["2000-02-29", "2000-03-31"],
+                            [
+                                cftime.datetime(1999, 12, 31, calendar=calendar),
+                                cftime.datetime(2000, 1, 31, calendar=calendar),
+                            ],
+                            [
+                                cftime.datetime(2000, 1, 31, calendar=calendar),
+                                cftime.datetime(2000, 2, 29, calendar=calendar),
+                            ],
+                            [
+                                cftime.datetime(2000, 2, 29, calendar=calendar),
+                                cftime.datetime(2000, 3, 31, calendar=calendar),
+                            ],
                         ],
-                        dtype="datetime64",
                     ),
                     dims=["time", "bnds"],
                     attrs=ds.time_bnds.attrs,
@@ -546,16 +637,22 @@ class TestDecodeNonCFTimeUnits:
 
     def test_decodes_months_with_a_reference_date_on_a_leap_year(self):
         ds = self.ds.copy()
+        calendar = "standard"
+        ds.time.attrs["calendar"] = calendar
         ds.time.attrs["units"] = "months since 2000-02-29"
 
         result = decode_non_cf_time(ds)
+
         expected = xr.Dataset(
             {
                 "time": xr.DataArray(
                     name="time",
                     data=np.array(
-                        ["2000-03-29", "2000-04-29", "2000-05-29"],
-                        dtype="datetime64",
+                        [
+                            cftime.datetime(2000, 3, 29, calendar=calendar),
+                            cftime.datetime(2000, 4, 29, calendar=calendar),
+                            cftime.datetime(2000, 5, 29, calendar=calendar),
+                        ],
                     ),
                     dims=["time"],
                     attrs=ds.time.attrs,
@@ -564,11 +661,19 @@ class TestDecodeNonCFTimeUnits:
                     name="time_bnds",
                     data=np.array(
                         [
-                            ["2000-02-29", "2000-03-29"],
-                            ["2000-03-29", "2000-04-29"],
-                            ["2000-04-29", "2000-05-29"],
+                            [
+                                cftime.datetime(2000, 2, 29, calendar=calendar),
+                                cftime.datetime(2000, 3, 29, calendar=calendar),
+                            ],
+                            [
+                                cftime.datetime(2000, 3, 29, calendar=calendar),
+                                cftime.datetime(2000, 4, 29, calendar=calendar),
+                            ],
+                            [
+                                cftime.datetime(2000, 4, 29, calendar=calendar),
+                                cftime.datetime(2000, 5, 29, calendar=calendar),
+                            ],
                         ],
-                        dtype="datetime64",
                     ),
                     dims=["time", "bnds"],
                     attrs=ds.time_bnds.attrs,
@@ -590,16 +695,23 @@ class TestDecodeNonCFTimeUnits:
 
     def test_decodes_years_with_a_reference_date_at_the_middle_of_the_year(self):
         ds = self.ds.copy()
+
+        calendar = "standard"
+        ds.time.attrs["calendar"] = calendar
         ds.time.attrs["units"] = "years since 2000-06-01"
 
         result = decode_non_cf_time(ds)
+
         expected = xr.Dataset(
             {
                 "time": xr.DataArray(
                     name="time",
                     data=np.array(
-                        ["2001-06-01", "2002-06-01", "2003-06-01"],
-                        dtype="datetime64",
+                        [
+                            cftime.datetime(2001, 6, 1, calendar=calendar),
+                            cftime.datetime(2002, 6, 1, calendar=calendar),
+                            cftime.datetime(2003, 6, 1, calendar=calendar),
+                        ],
                     ),
                     dims=["time"],
                     attrs=ds.time.attrs,
@@ -608,11 +720,19 @@ class TestDecodeNonCFTimeUnits:
                     name="time_bnds",
                     data=np.array(
                         [
-                            ["2000-06-01", "2001-06-01"],
-                            ["2001-06-01", "2002-06-01"],
-                            ["2002-06-01", "2003-06-01"],
+                            [
+                                cftime.datetime(2000, 6, 1, calendar=calendar),
+                                cftime.datetime(2001, 6, 1, calendar=calendar),
+                            ],
+                            [
+                                cftime.datetime(2001, 6, 1, calendar=calendar),
+                                cftime.datetime(2002, 6, 1, calendar=calendar),
+                            ],
+                            [
+                                cftime.datetime(2002, 6, 1, calendar=calendar),
+                                cftime.datetime(2003, 6, 1, calendar=calendar),
+                            ],
                         ],
-                        dtype="datetime64",
                     ),
                     dims=["time", "bnds"],
                     attrs=ds.time_bnds.attrs,
@@ -634,36 +754,50 @@ class TestDecodeNonCFTimeUnits:
 
     def test_decodes_years_with_a_reference_date_on_a_leap_year(self):
         ds = self.ds.copy()
+
+        calendar = "standard"
+        ds.time.attrs["calendar"] = calendar
         ds.time.attrs["units"] = "years since 2000-02-29"
 
         result = decode_non_cf_time(ds)
+
         expected = xr.Dataset(
             {
                 "time": xr.DataArray(
                     name="time",
-                    data=[
-                        np.datetime64("2001-02-28"),
-                        np.datetime64("2002-02-28"),
-                        np.datetime64("2003-02-28"),
-                    ],
+                    data=np.array(
+                        [
+                            cftime.datetime(2001, 2, 28, calendar=calendar),
+                            cftime.datetime(2002, 2, 28, calendar=calendar),
+                            cftime.datetime(2003, 2, 28, calendar=calendar),
+                        ],
+                    ),
                     dims=["time"],
+                    attrs=ds.time.attrs,
                 ),
                 "time_bnds": xr.DataArray(
                     name="time_bnds",
                     data=np.array(
                         [
-                            ["2000-02-29", "2001-02-28"],
-                            ["2001-02-28", "2002-02-28"],
-                            ["2002-02-28", "2003-02-28"],
+                            [
+                                cftime.datetime(2000, 2, 29, calendar=calendar),
+                                cftime.datetime(2001, 2, 28, calendar=calendar),
+                            ],
+                            [
+                                cftime.datetime(2001, 2, 28, calendar=calendar),
+                                cftime.datetime(2002, 2, 28, calendar=calendar),
+                            ],
+                            [
+                                cftime.datetime(2002, 2, 28, calendar=calendar),
+                                cftime.datetime(2003, 2, 28, calendar=calendar),
+                            ],
                         ],
-                        dtype="datetime64",
                     ),
                     dims=["time", "bnds"],
                     attrs=ds.time_bnds.attrs,
                 ),
             }
         )
-        expected.time.attrs = ds.time.attrs
         assert result.identical(expected)
 
         expected.time.encoding = {
@@ -934,23 +1068,27 @@ class Test_PreProcessNonCFDataset:
         expected = ds.copy().isel(time=slice(0, 1))
         expected["time"] = xr.DataArray(
             name="time",
-            data=np.array(
-                ["2000-01-01"],
-                dtype="datetime64",
-            ),
+            data=np.array([cftime.datetime(2000, 1, 1)]),
             dims=["time"],
         )
         expected["time_bnds"] = xr.DataArray(
             name="time_bnds",
             data=np.array(
-                [["1999-12-01", "2000-01-01"]],
-                dtype="datetime64",
+                [[cftime.datetime(1999, 12, 1), cftime.datetime(2000, 1, 1)]],
             ),
             dims=["time", "bnds"],
         )
+        expected.time.attrs = {
+            "units": "months since 2000-01-01",
+            "calendar": "standard",
+            "axis": "T",
+            "long_name": "time",
+            "standard_name": "time",
+            "bounds": "time_bnds",
+        }
 
-        expected.time.attrs = ds.time.attrs
-        expected.time_bnds.attrs = ds.time_bnds.attrs
+        expected.time_bnds.attrs = {"xcdat_bounds": "True"}
+
         assert result.identical(expected)
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 import warnings
 
@@ -38,7 +39,10 @@ class TestOpenDataset:
         expected = generate_dataset(cf_compliant=False, has_bounds=True)
         assert result.identical(expected)
 
-    def test_non_cf_compliant_and_unsupported_time_is_not_decoded(self):
+    def test_non_cf_compliant_and_unsupported_time_is_not_decoded(self, caplog):
+        # Update logger level to silence the logger warning during test runs.
+        caplog.set_level(logging.ERROR)
+
         ds = generate_dataset(cf_compliant=False, has_bounds=True, unsupported=True)
         ds.to_netcdf(self.file_path)
 
@@ -456,7 +460,10 @@ class TestDecodeNonCFTimeUnits:
         }
         self.ds = xr.Dataset({"time": time, "time_bnds": time_bnds})
 
-    def test_returns_original_dataset_if_calendar_attr_is_not_set(self):
+    def test_returns_original_dataset_if_calendar_attr_is_not_set(self, caplog):
+        # Update logger level to silence the logger warning during test runs.
+        caplog.set_level(logging.ERROR)
+
         ds = generate_dataset(cf_compliant=False, has_bounds=True)
 
         del ds.time.attrs["calendar"]
@@ -464,7 +471,10 @@ class TestDecodeNonCFTimeUnits:
         result = decode_non_cf_time(ds)
         assert ds.identical(result)
 
-    def test_returns_original_dataset_if_units_attr_is_not_set(self):
+    def test_returns_original_dataset_if_units_attr_is_not_set(self, caplog):
+        # Update logger level to silence the logger warning during test runs.
+        caplog.set_level(logging.ERROR)
+
         ds = generate_dataset(cf_compliant=False, has_bounds=True)
 
         del ds.time.attrs["units"]
@@ -472,7 +482,12 @@ class TestDecodeNonCFTimeUnits:
         result = decode_non_cf_time(ds)
         assert ds.identical(result)
 
-    def test_returns_original_dataset_if_units_attr_is_in_an_unsupported_format(self):
+    def test_returns_original_dataset_if_units_attr_is_in_an_unsupported_format(
+        self, caplog
+    ):
+        # Update logger level to silence the logger warning during test runs.
+        caplog.set_level(logging.ERROR)
+
         ds = generate_dataset(cf_compliant=False, has_bounds=True)
 
         ds.time.attrs["units"] = "year AD"

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -346,7 +346,7 @@ def decode_non_cf_time(dataset: xr.Dataset) -> xr.Dataset:
         units, ref_date = _split_time_units_attr(units_attr)
     except ValueError:
         logger.warning(
-            f"This dataset's 'units' attributes is ('{units_attr}') is not in a "
+            f"This dataset's 'units' attribute ('{units_attr}') is not in a "
             "supported format ('months since...' or 'years since...'), so the time "
             "coordinates could not be decoded."
         )
@@ -710,7 +710,7 @@ def _get_cftime_coords(
     ref_datetime: datetime = parser.parse(ref_date, default=datetime(2000, 1, 1))
     offsets = np.array(
         [ref_datetime + rd.relativedelta(**{units: offset}) for offset in offsets],
-        dtype="datetime64",
+        dtype="object",
     )
 
     # Convert the array of `datetime` objects into `cftime` objects based on

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 import cftime
 import xarray as xr
 from dateutil import relativedelta as rd
+from dateutil import parser
 
 from xcdat import bounds  # noqa: F401
 from xcdat.axis import center_times as center_times_func

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -339,9 +339,7 @@ def decode_non_cf_time(dataset: xr.Dataset) -> xr.Dataset:
     # `rd.relativedelta`.
     ref_dt_obj = parser.parse(ref_date, default=datetime(2000, 1, 1))
     data = [ref_dt_obj + rd.relativedelta(**{units: offset}) for offset in time.data]
-    data = [
-        cf_calendar_type(t.year, t.month, t.day, calendar=calendar_attr) for t in data
-    ]
+    data = [cf_calendar_type(t.year, t.month, t.day) for t in data]
 
     decoded_time = xr.DataArray(
         name=time.name,
@@ -370,12 +368,8 @@ def decode_non_cf_time(dataset: xr.Dataset) -> xr.Dataset:
 
         data_bounds = [
             [
-                cf_calendar_type(
-                    lower.year, lower.month, lower.day, calendar=calendar_attr
-                ),
-                cf_calendar_type(
-                    upper.year, upper.month, upper.day, calendar=calendar_attr
-                ),
+                cf_calendar_type(lower.year, lower.month, lower.day),
+                cf_calendar_type(upper.year, upper.month, upper.day),
             ]
             for [lower, upper] in data_bounds
         ]

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -337,7 +337,7 @@ def decode_non_cf_time(dataset: xr.Dataset) -> xr.Dataset:
     except KeyError:
         logger.warning(
             "This dataset's time coordinates do not have a 'units' attribute set, "
-            "so the time coordinates could not be decoded. Set the 'units' attribute"
+            "so the time coordinates could not be decoded. Set the 'units' attribute "
             "and try decoding the time coordinates again."
         )
         return ds

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -7,8 +7,8 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 import cftime
 import xarray as xr
-from dateutil import relativedelta as rd
 from dateutil import parser
+from dateutil import relativedelta as rd
 
 from xcdat import bounds  # noqa: F401
 from xcdat.axis import center_times as center_times_func
@@ -336,7 +336,7 @@ def decode_non_cf_time(dataset: xr.Dataset) -> xr.Dataset:
     # to create `cftime.datetime` objects. Note, the reference date object type
     # must start as `datetime` because `cftime` does not support arithmetic with
     # `rd.relativedelta`.
-    ref_dt_obj = parser.parse(ref_date, default=datetime.datetime(2000, 1, 1))
+    ref_dt_obj = parser.parse(ref_date, default=datetime(2000, 1, 1))
     data = [ref_dt_obj + rd.relativedelta(**{units: offset}) for offset in time.data]
     data = [
         cftime.datetime(t.year, t.month, t.day, calendar=calendar_attr) for t in data

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -336,7 +336,7 @@ def decode_non_cf_time(dataset: xr.Dataset) -> xr.Dataset:
     # to create `cftime.datetime` objects. Note, the reference date object type
     # must start as `datetime` because `cftime` does not support arithmetic with
     # `rd.relativedelta`.
-    ref_dt_obj = datetime.strptime(ref_date, "%Y-%m-%d")
+    ref_dt_obj = parser.parse(ref_date, default=datetime.datetime(2000, 1, 1))
     data = [ref_dt_obj + rd.relativedelta(**{units: offset}) for offset in time.data]
     data = [
         cftime.datetime(t.year, t.month, t.day, calendar=calendar_attr) for t in data


### PR DESCRIPTION
## Description

This PR is intended to address an issue in which datasets with non-cf-compliant times will not open if they go too far into the future.

- Closes #282

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
