### PR TITLE
simple proposed fix for #289

### DIFF
--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -7,6 +7,7 @@ import cftime
 import numpy as np
 import pandas as pd
 import xarray as xr
+from dask.array.core import Array
 from xarray.core.groupby import DataArrayGroupBy
 
 from xcdat import bounds  # noqa: F401
@@ -968,6 +969,8 @@ class TemporalAccessor:
         # only select the general DType and not details such as the byte order
         # or time unit (with rare exceptions see release notes). To avoid this
         # warning please use the scalar types `np.float64`, or string notation.`
+        if type(time_lengths.values == Array):
+            time_lengths.load()
         time_lengths = time_lengths.astype(np.float64)
 
         grouped_time_lengths = self._group_data(time_lengths)


### PR DESCRIPTION
## Description
This PR represents a simple proposed fix for #289. We just need to use `.load()` when handling `time_lengths` (used to make temporal weights. We had to do this for spatial averaging, too (e.g., [here](https://github.com/xCDAT/xcdat/blob/main/xcdat/spatial.py#L579)).

- Closes #289.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
