### PR TITLE
Use cftime for temporal averaging operations

### DIFF
--- a/.vscode/xcdat.code-workspace
+++ b/.vscode/xcdat.code-workspace
@@ -43,6 +43,7 @@
         // Extension settings
         // ===================
         "jupyter.notebookFileRoot": "${workspaceFolder}",
+        "jupyter.runStartupCommands": ["%load_ext autoreload", "%autoreload 2"],
         "autoDocstring.docstringFormat": "numpy"
     }
 }

--- a/.vscode/xcdat.code-workspace
+++ b/.vscode/xcdat.code-workspace
@@ -43,7 +43,6 @@
         // Extension settings
         // ===================
         "jupyter.notebookFileRoot": "${workspaceFolder}",
-        "jupyter.runStartupCommands": ["%load_ext autoreload", "%autoreload 2"],
         "autoDocstring.docstringFormat": "numpy"
     }
 }

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -41,17 +41,26 @@ time_cf = xr.DataArray(
         "standard_name": "time",
     },
 )
+# NOTE: With `decode_times=True`, the "calendar" and "units" attributes are
+# stored in `.encoding`.
+time_cf.encoding["calendar"] = "standard"
+time_cf.encoding["units"] = "days since 2000-01-01"
+
+
+# NOTE: With `decode_times=False`, the "calendar" and "units" attributes are
+# stored in `.attrs`.
 time_non_cf = xr.DataArray(
     data=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
     dims=["time"],
     attrs={
-        "units": "months since 2000-01-01",
-        "calendar": "standard",
         "axis": "T",
         "long_name": "time",
         "standard_name": "time",
+        "calendar": "standard",
+        "units": "months since 2000-01-01",
     },
 )
+
 time_non_cf_unsupported = xr.DataArray(
     data=np.arange(1850 + 1 / 24.0, 1851 + 3 / 12.0, 1 / 12.0),
     dims=["time"],

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -64,22 +64,53 @@ class TestOpenDataset:
             name="time",
             data=np.array(
                 [
-                    cftime.datetime(2000, 1, 1),
-                    cftime.datetime(2000, 2, 1),
-                    cftime.datetime(2000, 3, 1),
-                    cftime.datetime(2000, 4, 1),
-                    cftime.datetime(2000, 5, 1),
-                    cftime.datetime(2000, 6, 1),
-                    cftime.datetime(2000, 7, 1),
-                    cftime.datetime(2000, 8, 1),
-                    cftime.datetime(2000, 9, 1),
-                    cftime.datetime(2000, 10, 1),
-                    cftime.datetime(2000, 11, 1),
-                    cftime.datetime(2000, 12, 1),
-                    cftime.datetime(2001, 1, 1),
-                    cftime.datetime(2001, 2, 1),
-                    cftime.datetime(2001, 3, 1),
+                    cftime.DatetimeGregorian(
+                        2000, 1, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 2, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 3, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 4, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 5, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 6, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 7, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 8, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 9, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 10, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 11, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 12, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2001, 1, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2001, 2, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2001, 3, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
                 ],
+                dtype="object",
             ),
             dims="time",
         )
@@ -88,53 +119,133 @@ class TestOpenDataset:
             data=np.array(
                 [
                     [
-                        cftime.datetime(1999, 12, 16, 12),
-                        cftime.datetime(2000, 1, 16, 12),
+                        cftime.DatetimeGregorian(
+                            1999, 12, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 1, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
                     ],
                     [
-                        cftime.datetime(2000, 1, 16, 12),
-                        cftime.datetime(2000, 2, 15, 12),
+                        cftime.DatetimeGregorian(
+                            2000, 1, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 2, 15, 12, 0, 0, 0, has_year_zero=False
+                        ),
                     ],
                     [
-                        cftime.datetime(2000, 2, 15, 12),
-                        cftime.datetime(2000, 3, 16, 12),
-                    ],
-                    [cftime.datetime(2000, 3, 16, 12), cftime.datetime(2000, 4, 16, 0)],
-                    [cftime.datetime(2000, 4, 16, 0), cftime.datetime(2000, 5, 16, 12)],
-                    [cftime.datetime(2000, 5, 16, 12), cftime.datetime(2000, 6, 16, 0)],
-                    [cftime.datetime(2000, 6, 16, 0), cftime.datetime(2000, 7, 16, 12)],
-                    [
-                        cftime.datetime(2000, 7, 16, 12),
-                        cftime.datetime(2000, 8, 16, 12),
-                    ],
-                    [cftime.datetime(2000, 8, 16, 12), cftime.datetime(2000, 9, 16, 0)],
-                    [
-                        cftime.datetime(2000, 9, 16, 0),
-                        cftime.datetime(2000, 10, 16, 12),
+                        cftime.DatetimeGregorian(
+                            2000, 2, 15, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 3, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
                     ],
                     [
-                        cftime.datetime(2000, 10, 16, 12),
-                        cftime.datetime(2000, 11, 16, 0),
+                        cftime.DatetimeGregorian(
+                            2000, 3, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 4, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
                     ],
                     [
-                        cftime.datetime(2000, 11, 16, 0),
-                        cftime.datetime(2000, 12, 16, 12),
+                        cftime.DatetimeGregorian(
+                            2000, 4, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 5, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
                     ],
                     [
-                        cftime.datetime(2000, 12, 16, 12),
-                        cftime.datetime(2001, 1, 16, 12),
+                        cftime.DatetimeGregorian(
+                            2000, 5, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 6, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
                     ],
-                    [cftime.datetime(2001, 1, 16, 12), cftime.datetime(2001, 2, 15, 0)],
-                    [cftime.datetime(2001, 2, 15, 0), cftime.datetime(2001, 3, 15, 0)],
-                ]
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 6, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 7, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 7, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 8, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 8, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 9, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 9, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 10, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 10, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 11, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 11, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 12, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 12, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2001, 1, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2001, 1, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2001, 2, 15, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2001, 2, 15, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2001, 3, 15, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                ],
+                dtype="object",
             ),
             dims=["time", "bnds"],
             attrs={"xcdat_bounds": "True"},
         )
 
         expected.time.attrs = {
-            "units": "months since 2000-01-01",
-            "calendar": "standard",
             "axis": "T",
             "long_name": "time",
             "standard_name": "time",
@@ -218,27 +329,57 @@ class TestOpenMfDataset:
 
         # Generate an expected dataset with decoded non-CF compliant time units.
         expected = generate_dataset(cf_compliant=True, has_bounds=True)
-
         expected["time"] = xr.DataArray(
             name="time",
             data=np.array(
                 [
-                    cftime.datetime(2000, 1, 1),
-                    cftime.datetime(2000, 2, 1),
-                    cftime.datetime(2000, 3, 1),
-                    cftime.datetime(2000, 4, 1),
-                    cftime.datetime(2000, 5, 1),
-                    cftime.datetime(2000, 6, 1),
-                    cftime.datetime(2000, 7, 1),
-                    cftime.datetime(2000, 8, 1),
-                    cftime.datetime(2000, 9, 1),
-                    cftime.datetime(2000, 10, 1),
-                    cftime.datetime(2000, 11, 1),
-                    cftime.datetime(2000, 12, 1),
-                    cftime.datetime(2001, 1, 1),
-                    cftime.datetime(2001, 2, 1),
-                    cftime.datetime(2001, 3, 1),
+                    cftime.DatetimeGregorian(
+                        2000, 1, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 2, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 3, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 4, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 5, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 6, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 7, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 8, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 9, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 10, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 11, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2000, 12, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2001, 1, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2001, 2, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
+                    cftime.DatetimeGregorian(
+                        2001, 3, 1, 0, 0, 0, 0, has_year_zero=False
+                    ),
                 ],
+                dtype="object",
             ),
             dims="time",
         )
@@ -247,53 +388,133 @@ class TestOpenMfDataset:
             data=np.array(
                 [
                     [
-                        cftime.datetime(1999, 12, 16, 12),
-                        cftime.datetime(2000, 1, 16, 12),
+                        cftime.DatetimeGregorian(
+                            1999, 12, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 1, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
                     ],
                     [
-                        cftime.datetime(2000, 1, 16, 12),
-                        cftime.datetime(2000, 2, 15, 12),
+                        cftime.DatetimeGregorian(
+                            2000, 1, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 2, 15, 12, 0, 0, 0, has_year_zero=False
+                        ),
                     ],
                     [
-                        cftime.datetime(2000, 2, 15, 12),
-                        cftime.datetime(2000, 3, 16, 12),
-                    ],
-                    [cftime.datetime(2000, 3, 16, 12), cftime.datetime(2000, 4, 16, 0)],
-                    [cftime.datetime(2000, 4, 16, 0), cftime.datetime(2000, 5, 16, 12)],
-                    [cftime.datetime(2000, 5, 16, 12), cftime.datetime(2000, 6, 16, 0)],
-                    [cftime.datetime(2000, 6, 16, 0), cftime.datetime(2000, 7, 16, 12)],
-                    [
-                        cftime.datetime(2000, 7, 16, 12),
-                        cftime.datetime(2000, 8, 16, 12),
-                    ],
-                    [cftime.datetime(2000, 8, 16, 12), cftime.datetime(2000, 9, 16, 0)],
-                    [
-                        cftime.datetime(2000, 9, 16, 0),
-                        cftime.datetime(2000, 10, 16, 12),
+                        cftime.DatetimeGregorian(
+                            2000, 2, 15, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 3, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
                     ],
                     [
-                        cftime.datetime(2000, 10, 16, 12),
-                        cftime.datetime(2000, 11, 16, 0),
+                        cftime.DatetimeGregorian(
+                            2000, 3, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 4, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
                     ],
                     [
-                        cftime.datetime(2000, 11, 16, 0),
-                        cftime.datetime(2000, 12, 16, 12),
+                        cftime.DatetimeGregorian(
+                            2000, 4, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 5, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
                     ],
                     [
-                        cftime.datetime(2000, 12, 16, 12),
-                        cftime.datetime(2001, 1, 16, 12),
+                        cftime.DatetimeGregorian(
+                            2000, 5, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 6, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
                     ],
-                    [cftime.datetime(2001, 1, 16, 12), cftime.datetime(2001, 2, 15, 0)],
-                    [cftime.datetime(2001, 2, 15, 0), cftime.datetime(2001, 3, 15, 0)],
-                ]
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 6, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 7, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 7, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 8, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 8, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 9, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 9, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 10, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 10, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 11, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 11, 16, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 12, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 12, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2001, 1, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2001, 1, 16, 12, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2001, 2, 15, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2001, 2, 15, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2001, 3, 15, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                ],
+                dtype="object",
             ),
             dims=["time", "bnds"],
             attrs={"xcdat_bounds": "True"},
         )
 
         expected.time.attrs = {
-            "units": "months since 2000-01-01",
-            "calendar": "standard",
             "axis": "T",
             "long_name": "time",
             "standard_name": "time",
@@ -439,7 +660,7 @@ class TestDecodeNonCFTimeUnits:
                 "axis": "T",
                 "long_name": "time",
                 "standard_name": "time",
-                # calendar attr is specified by test.
+                # calendar attr and units is specified by test.
             },
         )
         time_bnds = xr.DataArray(
@@ -508,31 +729,56 @@ class TestDecodeNonCFTimeUnits:
                     name="time",
                     data=np.array(
                         [
-                            cftime.datetime(2000, 2, 1, calendar=calendar),
-                            cftime.datetime(2000, 3, 1, calendar=calendar),
-                            cftime.datetime(2000, 4, 1, calendar=calendar),
+                            cftime.DatetimeGregorian(
+                                2000, 2, 1, 0, 0, 0, 0, has_year_zero=False
+                            ),
+                            cftime.DatetimeGregorian(
+                                2000, 3, 1, 0, 0, 0, 0, has_year_zero=False
+                            ),
+                            cftime.DatetimeGregorian(
+                                2000, 4, 1, 0, 0, 0, 0, has_year_zero=False
+                            ),
                         ],
+                        dtype="object",
                     ),
                     dims=["time"],
-                    attrs=ds.time.attrs,
+                    attrs={
+                        "bounds": "time_bnds",
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                    },
                 ),
                 "time_bnds": xr.DataArray(
                     name="time_bnds",
                     data=np.array(
                         [
                             [
-                                cftime.datetime(2000, 1, 1, calendar=calendar),
-                                cftime.datetime(2000, 2, 1, calendar=calendar),
+                                cftime.DatetimeGregorian(
+                                    2000, 1, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
+                                cftime.DatetimeGregorian(
+                                    2000, 2, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
                             ],
                             [
-                                cftime.datetime(2000, 2, 1, calendar=calendar),
-                                cftime.datetime(2000, 3, 1, calendar=calendar),
+                                cftime.DatetimeGregorian(
+                                    2000, 2, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
+                                cftime.DatetimeGregorian(
+                                    2000, 3, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
                             ],
                             [
-                                cftime.datetime(2000, 3, 1, calendar=calendar),
-                                cftime.datetime(2000, 4, 1, calendar=calendar),
+                                cftime.DatetimeGregorian(
+                                    2000, 3, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
+                                cftime.DatetimeGregorian(
+                                    2000, 4, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
                             ],
                         ],
+                        dtype="object",
                     ),
                     dims=["time", "bnds"],
                     attrs=ds.time_bnds.attrs,
@@ -571,7 +817,12 @@ class TestDecodeNonCFTimeUnits:
                         ],
                     ),
                     dims=["time"],
-                    attrs=ds.time.attrs,
+                    attrs={
+                        "bounds": "time_bnds",
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                    },
                 ),
                 "time_bnds": xr.DataArray(
                     name="time_bnds",
@@ -628,7 +879,12 @@ class TestDecodeNonCFTimeUnits:
                         ],
                     ),
                     dims=["time"],
-                    attrs=ds.time.attrs,
+                    attrs={
+                        "bounds": "time_bnds",
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                    },
                 ),
                 "time_bnds": xr.DataArray(
                     name="time_bnds",
@@ -686,7 +942,12 @@ class TestDecodeNonCFTimeUnits:
                         ],
                     ),
                     dims=["time"],
-                    attrs=ds.time.attrs,
+                    attrs={
+                        "bounds": "time_bnds",
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                    },
                 ),
                 "time_bnds": xr.DataArray(
                     name="time_bnds",
@@ -745,7 +1006,12 @@ class TestDecodeNonCFTimeUnits:
                         ],
                     ),
                     dims=["time"],
-                    attrs=ds.time.attrs,
+                    attrs={
+                        "bounds": "time_bnds",
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                    },
                 ),
                 "time_bnds": xr.DataArray(
                     name="time_bnds",
@@ -804,7 +1070,12 @@ class TestDecodeNonCFTimeUnits:
                         ],
                     ),
                     dims=["time"],
-                    attrs=ds.time.attrs,
+                    attrs={
+                        "bounds": "time_bnds",
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                    },
                 ),
                 "time_bnds": xr.DataArray(
                     name="time_bnds",
@@ -1110,8 +1381,6 @@ class Test_PreProcessNonCFDataset:
             dims=["time", "bnds"],
         )
         expected.time.attrs = {
-            "units": "months since 2000-01-01",
-            "calendar": "standard",
             "axis": "T",
             "long_name": "time",
             "standard_name": "time",

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -390,7 +390,7 @@ class TestGroupAverage:
         )
         time.encoding = {"calendar": "standard"}
         time_bnds = xr.DataArray(
-            name="time_bndsZ",
+            name="time_bnds",
             data=np.array(
                 [
                     ["2000-01-01T00:00:00.000000000", "2000-02-01T00:00:00.000000000"],

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -419,19 +419,11 @@ class TestGroupAverage:
                 "lon": expected.lon,
                 "time": xr.DataArray(
                     data=np.array(
-                        [
-                            "2000-01-01T00:00:00.000000000",
-                            "2001-01-01T00:00:00.000000000",
-                        ],
-                        dtype="datetime64[ns]",
+                        [cftime.datetime(2000, 1, 1), cftime.datetime(2001, 1, 1)],
                     ),
                     coords={
                         "time": np.array(
-                            [
-                                "2000-01-01T00:00:00.000000000",
-                                "2001-01-01T00:00:00.000000000",
-                            ],
-                            dtype="datetime64[ns]",
+                            [cftime.datetime(2000, 1, 1), cftime.datetime(2001, 1, 1)],
                         )
                     },
                     dims=["time"],
@@ -470,19 +462,11 @@ class TestGroupAverage:
                 "lon": expected.lon,
                 "time": xr.DataArray(
                     data=np.array(
-                        [
-                            "2000-01-01T00:00:00.000000000",
-                            "2001-01-01T00:00:00.000000000",
-                        ],
-                        dtype="datetime64[ns]",
+                        [cftime.datetime(2000, 1, 1), cftime.datetime(2001, 1, 1)],
                     ),
                     coords={
                         "time": np.array(
-                            [
-                                "2000-01-01T00:00:00.000000000",
-                                "2001-01-01T00:00:00.000000000",
-                            ],
-                            dtype="datetime64[ns]",
+                            [cftime.datetime(2000, 1, 1), cftime.datetime(2001, 1, 1)],
                         )
                     },
                     dims=["time"],
@@ -527,12 +511,11 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            "2000-04-01T00:00:00.000000000",
-                            "2000-07-01T00:00:00.000000000",
-                            "2000-10-01T00:00:00.000000000",
-                            "2001-01-01T00:00:00.000000000",
+                            cftime.datetime(2000, 4, 1),
+                            cftime.datetime(2000, 7, 1),
+                            cftime.datetime(2000, 10, 1),
+                            cftime.datetime(2001, 1, 1),
                         ],
-                        dtype="datetime64[ns]",
                     ),
                     dims=["time"],
                     attrs={
@@ -577,13 +560,12 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            "2000-01-01T00:00:00.000000000",
-                            "2000-04-01T00:00:00.000000000",
-                            "2000-07-01T00:00:00.000000000",
-                            "2000-10-01T00:00:00.000000000",
-                            "2001-01-01T00:00:00.000000000",
+                            cftime.datetime(2000, 1, 1),
+                            cftime.datetime(2000, 4, 1),
+                            cftime.datetime(2000, 7, 1),
+                            cftime.datetime(2000, 10, 1),
+                            cftime.datetime(2001, 1, 1),
                         ],
-                        dtype="datetime64[ns]",
                     ),
                     dims=["time"],
                     attrs={
@@ -626,24 +608,22 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            "2000-01-01T00:00:00.000000000",
-                            "2000-04-01T00:00:00.000000000",
-                            "2000-07-01T00:00:00.000000000",
-                            "2000-10-01T00:00:00.000000000",
-                            "2001-01-01T00:00:00.000000000",
+                            cftime.datetime(2000, 1, 1),
+                            cftime.datetime(2000, 4, 1),
+                            cftime.datetime(2000, 7, 1),
+                            cftime.datetime(2000, 10, 1),
+                            cftime.datetime(2001, 1, 1),
                         ],
-                        dtype="datetime64[ns]",
                     ),
                     coords={
                         "time": np.array(
                             [
-                                "2000-01-01T00:00:00.000000000",
-                                "2000-04-01T00:00:00.000000000",
-                                "2000-07-01T00:00:00.000000000",
-                                "2000-10-01T00:00:00.000000000",
-                                "2001-01-01T00:00:00.000000000",
+                                cftime.datetime(2000, 1, 1),
+                                cftime.datetime(2000, 4, 1),
+                                cftime.datetime(2000, 7, 1),
+                                cftime.datetime(2000, 10, 1),
+                                cftime.datetime(2001, 1, 1),
                             ],
-                            dtype="datetime64[ns]",
                         )
                     },
                     dims=["time"],
@@ -692,12 +672,11 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            "2000-02-01T00:00:00.000000000",
-                            "2000-05-01T00:00:00.000000000",
-                            "2000-08-01T00:00:00.000000000",
-                            "2001-02-01T00:00:00.000000000",
+                            cftime.datetime(2000, 2, 1),
+                            cftime.datetime(2000, 5, 1),
+                            cftime.datetime(2000, 8, 1),
+                            cftime.datetime(2001, 2, 1),
                         ],
-                        dtype="datetime64[ns]",
                     ),
                     dims=["time"],
                     attrs={
@@ -783,13 +762,12 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            "2000-01-01T00:00:00.000000000",
-                            "2000-03-01T00:00:00.000000000",
-                            "2000-06-01T00:00:00.000000000",
-                            "2000-09-01T00:00:00.000000000",
-                            "2001-02-01T00:00:00.000000000",
+                            cftime.datetime(2000, 1, 1),
+                            cftime.datetime(2000, 3, 1),
+                            cftime.datetime(2000, 6, 1),
+                            cftime.datetime(2000, 9, 1),
+                            cftime.datetime(2001, 2, 1),
                         ],
-                        dtype="datetime64[ns]",
                     ),
                     dims=["time"],
                     attrs={
@@ -833,13 +811,12 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            "2000-01-01T00:00:00.000000000",
-                            "2000-03-01T00:00:00.000000000",
-                            "2000-06-01T00:00:00.000000000",
-                            "2000-09-01T00:00:00.000000000",
-                            "2001-02-01T00:00:00.000000000",
+                            cftime.datetime(2000, 1, 1),
+                            cftime.datetime(2000, 3, 1),
+                            cftime.datetime(2000, 6, 1),
+                            cftime.datetime(2000, 9, 1),
+                            cftime.datetime(2001, 2, 1),
                         ],
-                        dtype="datetime64[ns]",
                     ),
                     dims=["time"],
                     attrs={
@@ -876,13 +853,12 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            "2000-01-16T00:00:00.000000000",
-                            "2000-03-16T00:00:00.000000000",
-                            "2000-06-16T00:00:00.000000000",
-                            "2000-09-16T00:00:00.000000000",
-                            "2001-02-15T00:00:00.000000000",
+                            cftime.datetime(2000, 1, 16),
+                            cftime.datetime(2000, 3, 16),
+                            cftime.datetime(2000, 6, 16),
+                            cftime.datetime(2000, 9, 16),
+                            cftime.datetime(2001, 2, 15),
                         ],
-                        dtype="datetime64[ns]",
                     ),
                     dims=["time"],
                     attrs={
@@ -917,7 +893,24 @@ class TestGroupAverage:
             coords={
                 "lat": expected.lat,
                 "lon": expected.lon,
-                "time": ds.time,
+                "time": xr.DataArray(
+                    data=np.array(
+                        [
+                            cftime.datetime(2000, 1, 16, 12),
+                            cftime.datetime(2000, 3, 16, 12),
+                            cftime.datetime(2000, 6, 16, 0),
+                            cftime.datetime(2000, 9, 16, 0),
+                            cftime.datetime(2001, 2, 15, 12),
+                        ],
+                    ),
+                    dims=["time"],
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
+                    },
+                ),
             },
             dims=["time", "lat", "lon"],
             attrs={

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -19,6 +19,13 @@ class TestTemporalAccessor:
         obj = ds.temporal
         assert obj._dataset.identical(ds)
 
+    def test_raises_error_if_calendar_encoding_attr_is_not_set(self):
+        ds: xr.Dataset = generate_dataset(cf_compliant=True, has_bounds=True)
+        ds.time.encoding = {}
+
+        with pytest.raises(KeyError):
+            TemporalAccessor(ds)
+
 
 class TestAverage:
     def test_averages_for_yearly_time_series(self):
@@ -47,6 +54,7 @@ class TestAverage:
                 ),
             }
         )
+        ds.time.encoding = {"calendar": "standard"}
         ds["time_bnds"] = xr.DataArray(
             name="time_bnds",
             data=np.array(
@@ -132,6 +140,8 @@ class TestAverage:
                 ),
             }
         )
+        ds.time.encoding = {"calendar": "standard"}
+
         ds["time_bnds"] = xr.DataArray(
             name="time_bnds",
             data=np.array(
@@ -215,6 +225,8 @@ class TestAverage:
                 ),
             }
         )
+        ds.time.encoding = {"calendar": "standard"}
+
         ds["time_bnds"] = xr.DataArray(
             name="time_bnds",
             data=np.array(
@@ -298,6 +310,8 @@ class TestAverage:
                 ),
             }
         )
+        ds.time.encoding = {"calendar": "standard"}
+
         ds["time_bnds"] = xr.DataArray(
             name="time_bnds",
             data=np.array(
@@ -374,8 +388,9 @@ class TestGroupAverage:
             dims=["time"],
             attrs={"axis": "T", "long_name": "time", "standard_name": "time"},
         )
+        time.encoding = {"calendar": "standard"}
         time_bnds = xr.DataArray(
-            name="time_bnds",
+            name="time_bndsZ",
             data=np.array(
                 [
                     ["2000-01-01T00:00:00.000000000", "2000-02-01T00:00:00.000000000"],
@@ -419,11 +434,17 @@ class TestGroupAverage:
                 "lon": expected.lon,
                 "time": xr.DataArray(
                     data=np.array(
-                        [cftime.datetime(2000, 1, 1), cftime.datetime(2001, 1, 1)],
+                        [
+                            cftime.DatetimeGregorian(2000, 1, 1),
+                            cftime.DatetimeGregorian(2001, 1, 1),
+                        ],
                     ),
                     coords={
                         "time": np.array(
-                            [cftime.datetime(2000, 1, 1), cftime.datetime(2001, 1, 1)],
+                            [
+                                cftime.DatetimeGregorian(2000, 1, 1),
+                                cftime.DatetimeGregorian(2001, 1, 1),
+                            ],
                         )
                     },
                     dims=["time"],
@@ -462,11 +483,17 @@ class TestGroupAverage:
                 "lon": expected.lon,
                 "time": xr.DataArray(
                     data=np.array(
-                        [cftime.datetime(2000, 1, 1), cftime.datetime(2001, 1, 1)],
+                        [
+                            cftime.DatetimeGregorian(2000, 1, 1),
+                            cftime.DatetimeGregorian(2001, 1, 1),
+                        ],
                     ),
                     coords={
                         "time": np.array(
-                            [cftime.datetime(2000, 1, 1), cftime.datetime(2001, 1, 1)],
+                            [
+                                cftime.DatetimeGregorian(2000, 1, 1),
+                                cftime.DatetimeGregorian(2001, 1, 1),
+                            ],
                         )
                     },
                     dims=["time"],
@@ -511,10 +538,10 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            cftime.datetime(2000, 4, 1),
-                            cftime.datetime(2000, 7, 1),
-                            cftime.datetime(2000, 10, 1),
-                            cftime.datetime(2001, 1, 1),
+                            cftime.DatetimeGregorian(2000, 4, 1),
+                            cftime.DatetimeGregorian(2000, 7, 1),
+                            cftime.DatetimeGregorian(2000, 10, 1),
+                            cftime.DatetimeGregorian(2001, 1, 1),
                         ],
                     ),
                     dims=["time"],
@@ -560,11 +587,11 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            cftime.datetime(2000, 1, 1),
-                            cftime.datetime(2000, 4, 1),
-                            cftime.datetime(2000, 7, 1),
-                            cftime.datetime(2000, 10, 1),
-                            cftime.datetime(2001, 1, 1),
+                            cftime.DatetimeGregorian(2000, 1, 1),
+                            cftime.DatetimeGregorian(2000, 4, 1),
+                            cftime.DatetimeGregorian(2000, 7, 1),
+                            cftime.DatetimeGregorian(2000, 10, 1),
+                            cftime.DatetimeGregorian(2001, 1, 1),
                         ],
                     ),
                     dims=["time"],
@@ -608,21 +635,21 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            cftime.datetime(2000, 1, 1),
-                            cftime.datetime(2000, 4, 1),
-                            cftime.datetime(2000, 7, 1),
-                            cftime.datetime(2000, 10, 1),
-                            cftime.datetime(2001, 1, 1),
+                            cftime.DatetimeGregorian(2000, 1, 1),
+                            cftime.DatetimeGregorian(2000, 4, 1),
+                            cftime.DatetimeGregorian(2000, 7, 1),
+                            cftime.DatetimeGregorian(2000, 10, 1),
+                            cftime.DatetimeGregorian(2001, 1, 1),
                         ],
                     ),
                     coords={
                         "time": np.array(
                             [
-                                cftime.datetime(2000, 1, 1),
-                                cftime.datetime(2000, 4, 1),
-                                cftime.datetime(2000, 7, 1),
-                                cftime.datetime(2000, 10, 1),
-                                cftime.datetime(2001, 1, 1),
+                                cftime.DatetimeGregorian(2000, 1, 1),
+                                cftime.DatetimeGregorian(2000, 4, 1),
+                                cftime.DatetimeGregorian(2000, 7, 1),
+                                cftime.DatetimeGregorian(2000, 10, 1),
+                                cftime.DatetimeGregorian(2001, 1, 1),
                             ],
                         )
                     },
@@ -672,10 +699,10 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            cftime.datetime(2000, 2, 1),
-                            cftime.datetime(2000, 5, 1),
-                            cftime.datetime(2000, 8, 1),
-                            cftime.datetime(2001, 2, 1),
+                            cftime.DatetimeGregorian(2000, 2, 1),
+                            cftime.DatetimeGregorian(2000, 5, 1),
+                            cftime.DatetimeGregorian(2000, 8, 1),
+                            cftime.DatetimeGregorian(2001, 2, 1),
                         ],
                     ),
                     dims=["time"],
@@ -762,11 +789,11 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            cftime.datetime(2000, 1, 1),
-                            cftime.datetime(2000, 3, 1),
-                            cftime.datetime(2000, 6, 1),
-                            cftime.datetime(2000, 9, 1),
-                            cftime.datetime(2001, 2, 1),
+                            cftime.DatetimeGregorian(2000, 1, 1),
+                            cftime.DatetimeGregorian(2000, 3, 1),
+                            cftime.DatetimeGregorian(2000, 6, 1),
+                            cftime.DatetimeGregorian(2000, 9, 1),
+                            cftime.DatetimeGregorian(2001, 2, 1),
                         ],
                     ),
                     dims=["time"],
@@ -811,11 +838,11 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            cftime.datetime(2000, 1, 1),
-                            cftime.datetime(2000, 3, 1),
-                            cftime.datetime(2000, 6, 1),
-                            cftime.datetime(2000, 9, 1),
-                            cftime.datetime(2001, 2, 1),
+                            cftime.DatetimeGregorian(2000, 1, 1),
+                            cftime.DatetimeGregorian(2000, 3, 1),
+                            cftime.DatetimeGregorian(2000, 6, 1),
+                            cftime.DatetimeGregorian(2000, 9, 1),
+                            cftime.DatetimeGregorian(2001, 2, 1),
                         ],
                     ),
                     dims=["time"],
@@ -853,11 +880,11 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            cftime.datetime(2000, 1, 16),
-                            cftime.datetime(2000, 3, 16),
-                            cftime.datetime(2000, 6, 16),
-                            cftime.datetime(2000, 9, 16),
-                            cftime.datetime(2001, 2, 15),
+                            cftime.DatetimeGregorian(2000, 1, 16),
+                            cftime.DatetimeGregorian(2000, 3, 16),
+                            cftime.DatetimeGregorian(2000, 6, 16),
+                            cftime.DatetimeGregorian(2000, 9, 16),
+                            cftime.DatetimeGregorian(2001, 2, 15),
                         ],
                     ),
                     dims=["time"],
@@ -896,11 +923,11 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            cftime.datetime(2000, 1, 16, 12),
-                            cftime.datetime(2000, 3, 16, 12),
-                            cftime.datetime(2000, 6, 16, 0),
-                            cftime.datetime(2000, 9, 16, 0),
-                            cftime.datetime(2001, 2, 15, 12),
+                            cftime.DatetimeGregorian(2000, 1, 16, 12),
+                            cftime.DatetimeGregorian(2000, 3, 16, 12),
+                            cftime.DatetimeGregorian(2000, 6, 16, 0),
+                            cftime.DatetimeGregorian(2000, 9, 16, 0),
+                            cftime.DatetimeGregorian(2001, 2, 15, 12),
                         ],
                     ),
                     dims=["time"],
@@ -945,19 +972,19 @@ class TestClimatology:
         expected_time = xr.DataArray(
             data=np.array(
                 [
-                    cftime.datetime(1, 1, 1),
-                    cftime.datetime(1, 4, 1),
-                    cftime.datetime(1, 7, 1),
-                    cftime.datetime(1, 10, 1),
+                    cftime.DatetimeGregorian(1, 1, 1),
+                    cftime.DatetimeGregorian(1, 4, 1),
+                    cftime.DatetimeGregorian(1, 7, 1),
+                    cftime.DatetimeGregorian(1, 10, 1),
                 ],
             ),
             coords={
                 "time": np.array(
                     [
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 4, 1),
-                        cftime.datetime(1, 7, 1),
-                        cftime.datetime(1, 10, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 4, 1),
+                        cftime.DatetimeGregorian(1, 7, 1),
+                        cftime.DatetimeGregorian(1, 10, 1),
                     ],
                 ),
             },
@@ -1000,19 +1027,19 @@ class TestClimatology:
         expected_time = xr.DataArray(
             data=np.array(
                 [
-                    cftime.datetime(1, 1, 1),
-                    cftime.datetime(1, 4, 1),
-                    cftime.datetime(1, 7, 1),
-                    cftime.datetime(1, 10, 1),
+                    cftime.DatetimeGregorian(1, 1, 1),
+                    cftime.DatetimeGregorian(1, 4, 1),
+                    cftime.DatetimeGregorian(1, 7, 1),
+                    cftime.DatetimeGregorian(1, 10, 1),
                 ],
             ),
             coords={
                 "time": np.array(
                     [
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 4, 1),
-                        cftime.datetime(1, 7, 1),
-                        cftime.datetime(1, 10, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 4, 1),
+                        cftime.DatetimeGregorian(1, 7, 1),
+                        cftime.DatetimeGregorian(1, 10, 1),
                     ],
                 ),
             },
@@ -1052,19 +1079,19 @@ class TestClimatology:
         expected_time = xr.DataArray(
             data=np.array(
                 [
-                    cftime.datetime(1, 1, 1),
-                    cftime.datetime(1, 4, 1),
-                    cftime.datetime(1, 7, 1),
-                    cftime.datetime(1, 10, 1),
+                    cftime.DatetimeGregorian(1, 1, 1),
+                    cftime.DatetimeGregorian(1, 4, 1),
+                    cftime.DatetimeGregorian(1, 7, 1),
+                    cftime.DatetimeGregorian(1, 10, 1),
                 ],
             ),
             coords={
                 "time": np.array(
                     [
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 4, 1),
-                        cftime.datetime(1, 7, 1),
-                        cftime.datetime(1, 10, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 4, 1),
+                        cftime.DatetimeGregorian(1, 7, 1),
+                        cftime.DatetimeGregorian(1, 10, 1),
                     ],
                 ),
             },
@@ -1109,19 +1136,19 @@ class TestClimatology:
         expected_time = xr.DataArray(
             data=np.array(
                 [
-                    cftime.datetime(1, 2, 1),
-                    cftime.datetime(1, 5, 1),
-                    cftime.datetime(1, 8, 1),
-                    cftime.datetime(1, 11, 1),
+                    cftime.DatetimeGregorian(1, 2, 1),
+                    cftime.DatetimeGregorian(1, 5, 1),
+                    cftime.DatetimeGregorian(1, 8, 1),
+                    cftime.DatetimeGregorian(1, 11, 1),
                 ],
             ),
             coords={
                 "time": np.array(
                     [
-                        cftime.datetime(1, 2, 1),
-                        cftime.datetime(1, 5, 1),
-                        cftime.datetime(1, 8, 1),
-                        cftime.datetime(1, 11, 1),
+                        cftime.DatetimeGregorian(1, 2, 1),
+                        cftime.DatetimeGregorian(1, 5, 1),
+                        cftime.DatetimeGregorian(1, 8, 1),
+                        cftime.DatetimeGregorian(1, 11, 1),
                     ],
                 ),
             },
@@ -1162,35 +1189,35 @@ class TestClimatology:
         expected_time = xr.DataArray(
             data=np.array(
                 [
-                    cftime.datetime(1, 1, 1),
-                    cftime.datetime(1, 2, 1),
-                    cftime.datetime(1, 3, 1),
-                    cftime.datetime(1, 4, 1),
-                    cftime.datetime(1, 5, 1),
-                    cftime.datetime(1, 6, 1),
-                    cftime.datetime(1, 7, 1),
-                    cftime.datetime(1, 8, 1),
-                    cftime.datetime(1, 9, 1),
-                    cftime.datetime(1, 10, 1),
-                    cftime.datetime(1, 11, 1),
-                    cftime.datetime(1, 12, 1),
+                    cftime.DatetimeGregorian(1, 1, 1),
+                    cftime.DatetimeGregorian(1, 2, 1),
+                    cftime.DatetimeGregorian(1, 3, 1),
+                    cftime.DatetimeGregorian(1, 4, 1),
+                    cftime.DatetimeGregorian(1, 5, 1),
+                    cftime.DatetimeGregorian(1, 6, 1),
+                    cftime.DatetimeGregorian(1, 7, 1),
+                    cftime.DatetimeGregorian(1, 8, 1),
+                    cftime.DatetimeGregorian(1, 9, 1),
+                    cftime.DatetimeGregorian(1, 10, 1),
+                    cftime.DatetimeGregorian(1, 11, 1),
+                    cftime.DatetimeGregorian(1, 12, 1),
                 ],
             ),
             coords={
                 "time": np.array(
                     [
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 2, 1),
-                        cftime.datetime(1, 3, 1),
-                        cftime.datetime(1, 4, 1),
-                        cftime.datetime(1, 5, 1),
-                        cftime.datetime(1, 6, 1),
-                        cftime.datetime(1, 7, 1),
-                        cftime.datetime(1, 8, 1),
-                        cftime.datetime(1, 9, 1),
-                        cftime.datetime(1, 10, 1),
-                        cftime.datetime(1, 11, 1),
-                        cftime.datetime(1, 12, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 2, 1),
+                        cftime.DatetimeGregorian(1, 3, 1),
+                        cftime.DatetimeGregorian(1, 4, 1),
+                        cftime.DatetimeGregorian(1, 5, 1),
+                        cftime.DatetimeGregorian(1, 6, 1),
+                        cftime.DatetimeGregorian(1, 7, 1),
+                        cftime.DatetimeGregorian(1, 8, 1),
+                        cftime.DatetimeGregorian(1, 9, 1),
+                        cftime.DatetimeGregorian(1, 10, 1),
+                        cftime.DatetimeGregorian(1, 11, 1),
+                        cftime.DatetimeGregorian(1, 12, 1),
                     ],
                 ),
             },
@@ -1225,35 +1252,35 @@ class TestClimatology:
         expected_time = xr.DataArray(
             data=np.array(
                 [
-                    cftime.datetime(1, 1, 1),
-                    cftime.datetime(1, 2, 1),
-                    cftime.datetime(1, 3, 1),
-                    cftime.datetime(1, 4, 1),
-                    cftime.datetime(1, 5, 1),
-                    cftime.datetime(1, 6, 1),
-                    cftime.datetime(1, 7, 1),
-                    cftime.datetime(1, 8, 1),
-                    cftime.datetime(1, 9, 1),
-                    cftime.datetime(1, 10, 1),
-                    cftime.datetime(1, 11, 1),
-                    cftime.datetime(1, 12, 1),
+                    cftime.DatetimeGregorian(1, 1, 1),
+                    cftime.DatetimeGregorian(1, 2, 1),
+                    cftime.DatetimeGregorian(1, 3, 1),
+                    cftime.DatetimeGregorian(1, 4, 1),
+                    cftime.DatetimeGregorian(1, 5, 1),
+                    cftime.DatetimeGregorian(1, 6, 1),
+                    cftime.DatetimeGregorian(1, 7, 1),
+                    cftime.DatetimeGregorian(1, 8, 1),
+                    cftime.DatetimeGregorian(1, 9, 1),
+                    cftime.DatetimeGregorian(1, 10, 1),
+                    cftime.DatetimeGregorian(1, 11, 1),
+                    cftime.DatetimeGregorian(1, 12, 1),
                 ],
             ),
             coords={
                 "time": np.array(
                     [
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 2, 1),
-                        cftime.datetime(1, 3, 1),
-                        cftime.datetime(1, 4, 1),
-                        cftime.datetime(1, 5, 1),
-                        cftime.datetime(1, 6, 1),
-                        cftime.datetime(1, 7, 1),
-                        cftime.datetime(1, 8, 1),
-                        cftime.datetime(1, 9, 1),
-                        cftime.datetime(1, 10, 1),
-                        cftime.datetime(1, 11, 1),
-                        cftime.datetime(1, 12, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 2, 1),
+                        cftime.DatetimeGregorian(1, 3, 1),
+                        cftime.DatetimeGregorian(1, 4, 1),
+                        cftime.DatetimeGregorian(1, 5, 1),
+                        cftime.DatetimeGregorian(1, 6, 1),
+                        cftime.DatetimeGregorian(1, 7, 1),
+                        cftime.DatetimeGregorian(1, 8, 1),
+                        cftime.DatetimeGregorian(1, 9, 1),
+                        cftime.DatetimeGregorian(1, 10, 1),
+                        cftime.DatetimeGregorian(1, 11, 1),
+                        cftime.DatetimeGregorian(1, 12, 1),
                     ],
                 ),
             },
@@ -1287,35 +1314,35 @@ class TestClimatology:
         expected_time = xr.DataArray(
             data=np.array(
                 [
-                    cftime.datetime(1, 1, 16),
-                    cftime.datetime(1, 2, 15),
-                    cftime.datetime(1, 3, 16),
-                    cftime.datetime(1, 4, 16),
-                    cftime.datetime(1, 5, 16),
-                    cftime.datetime(1, 6, 16),
-                    cftime.datetime(1, 7, 16),
-                    cftime.datetime(1, 8, 16),
-                    cftime.datetime(1, 9, 16),
-                    cftime.datetime(1, 10, 16),
-                    cftime.datetime(1, 11, 16),
-                    cftime.datetime(1, 12, 16),
+                    cftime.DatetimeGregorian(1, 1, 16),
+                    cftime.DatetimeGregorian(1, 2, 15),
+                    cftime.DatetimeGregorian(1, 3, 16),
+                    cftime.DatetimeGregorian(1, 4, 16),
+                    cftime.DatetimeGregorian(1, 5, 16),
+                    cftime.DatetimeGregorian(1, 6, 16),
+                    cftime.DatetimeGregorian(1, 7, 16),
+                    cftime.DatetimeGregorian(1, 8, 16),
+                    cftime.DatetimeGregorian(1, 9, 16),
+                    cftime.DatetimeGregorian(1, 10, 16),
+                    cftime.DatetimeGregorian(1, 11, 16),
+                    cftime.DatetimeGregorian(1, 12, 16),
                 ],
             ),
             coords={
                 "time": np.array(
                     [
-                        cftime.datetime(1, 1, 16),
-                        cftime.datetime(1, 2, 15),
-                        cftime.datetime(1, 3, 16),
-                        cftime.datetime(1, 4, 16),
-                        cftime.datetime(1, 5, 16),
-                        cftime.datetime(1, 6, 16),
-                        cftime.datetime(1, 7, 16),
-                        cftime.datetime(1, 8, 16),
-                        cftime.datetime(1, 9, 16),
-                        cftime.datetime(1, 10, 16),
-                        cftime.datetime(1, 11, 16),
-                        cftime.datetime(1, 12, 16),
+                        cftime.DatetimeGregorian(1, 1, 16),
+                        cftime.DatetimeGregorian(1, 2, 15),
+                        cftime.DatetimeGregorian(1, 3, 16),
+                        cftime.DatetimeGregorian(1, 4, 16),
+                        cftime.DatetimeGregorian(1, 5, 16),
+                        cftime.DatetimeGregorian(1, 6, 16),
+                        cftime.DatetimeGregorian(1, 7, 16),
+                        cftime.DatetimeGregorian(1, 8, 16),
+                        cftime.DatetimeGregorian(1, 9, 16),
+                        cftime.DatetimeGregorian(1, 10, 16),
+                        cftime.DatetimeGregorian(1, 11, 16),
+                        cftime.DatetimeGregorian(1, 12, 16),
                     ],
                 ),
             },
@@ -1349,35 +1376,35 @@ class TestClimatology:
         expected_time = xr.DataArray(
             data=np.array(
                 [
-                    cftime.datetime(1, 1, 16),
-                    cftime.datetime(1, 2, 15),
-                    cftime.datetime(1, 3, 16),
-                    cftime.datetime(1, 4, 16),
-                    cftime.datetime(1, 5, 16),
-                    cftime.datetime(1, 6, 16),
-                    cftime.datetime(1, 7, 16),
-                    cftime.datetime(1, 8, 16),
-                    cftime.datetime(1, 9, 16),
-                    cftime.datetime(1, 10, 16),
-                    cftime.datetime(1, 11, 16),
-                    cftime.datetime(1, 12, 16),
+                    cftime.DatetimeGregorian(1, 1, 16),
+                    cftime.DatetimeGregorian(1, 2, 15),
+                    cftime.DatetimeGregorian(1, 3, 16),
+                    cftime.DatetimeGregorian(1, 4, 16),
+                    cftime.DatetimeGregorian(1, 5, 16),
+                    cftime.DatetimeGregorian(1, 6, 16),
+                    cftime.DatetimeGregorian(1, 7, 16),
+                    cftime.DatetimeGregorian(1, 8, 16),
+                    cftime.DatetimeGregorian(1, 9, 16),
+                    cftime.DatetimeGregorian(1, 10, 16),
+                    cftime.DatetimeGregorian(1, 11, 16),
+                    cftime.DatetimeGregorian(1, 12, 16),
                 ],
             ),
             coords={
                 "time": np.array(
                     [
-                        cftime.datetime(1, 1, 16),
-                        cftime.datetime(1, 2, 15),
-                        cftime.datetime(1, 3, 16),
-                        cftime.datetime(1, 4, 16),
-                        cftime.datetime(1, 5, 16),
-                        cftime.datetime(1, 6, 16),
-                        cftime.datetime(1, 7, 16),
-                        cftime.datetime(1, 8, 16),
-                        cftime.datetime(1, 9, 16),
-                        cftime.datetime(1, 10, 16),
-                        cftime.datetime(1, 11, 16),
-                        cftime.datetime(1, 12, 16),
+                        cftime.DatetimeGregorian(1, 1, 16),
+                        cftime.DatetimeGregorian(1, 2, 15),
+                        cftime.DatetimeGregorian(1, 3, 16),
+                        cftime.DatetimeGregorian(1, 4, 16),
+                        cftime.DatetimeGregorian(1, 5, 16),
+                        cftime.DatetimeGregorian(1, 6, 16),
+                        cftime.DatetimeGregorian(1, 7, 16),
+                        cftime.DatetimeGregorian(1, 8, 16),
+                        cftime.DatetimeGregorian(1, 9, 16),
+                        cftime.DatetimeGregorian(1, 10, 16),
+                        cftime.DatetimeGregorian(1, 11, 16),
+                        cftime.DatetimeGregorian(1, 12, 16),
                     ],
                 ),
             },
@@ -1645,21 +1672,21 @@ class Test_GetWeights:
                 name="month",
                 data=np.array(
                     [
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 2, 1),
-                        cftime.datetime(1, 3, 1),
-                        cftime.datetime(1, 4, 1),
-                        cftime.datetime(1, 5, 1),
-                        cftime.datetime(1, 6, 1),
-                        cftime.datetime(1, 7, 1),
-                        cftime.datetime(1, 8, 1),
-                        cftime.datetime(1, 9, 1),
-                        cftime.datetime(1, 10, 1),
-                        cftime.datetime(1, 11, 1),
-                        cftime.datetime(1, 12, 1),
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 2, 1),
-                        cftime.datetime(1, 12, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 2, 1),
+                        cftime.DatetimeGregorian(1, 3, 1),
+                        cftime.DatetimeGregorian(1, 4, 1),
+                        cftime.DatetimeGregorian(1, 5, 1),
+                        cftime.DatetimeGregorian(1, 6, 1),
+                        cftime.DatetimeGregorian(1, 7, 1),
+                        cftime.DatetimeGregorian(1, 8, 1),
+                        cftime.DatetimeGregorian(1, 9, 1),
+                        cftime.DatetimeGregorian(1, 10, 1),
+                        cftime.DatetimeGregorian(1, 11, 1),
+                        cftime.DatetimeGregorian(1, 12, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 2, 1),
+                        cftime.DatetimeGregorian(1, 12, 1),
                     ],
                 ),
                 coords={"time": ds.time},
@@ -1839,6 +1866,7 @@ class Test_GetWeights:
                     "bounds": "time_bnds",
                 },
             )
+            ds.time.encoding = {"calendar": "standard"}
             ds["ts"] = xr.DataArray(
                 name="ts",
                 data=np.ones((12, 4, 4)),
@@ -2235,6 +2263,7 @@ class Test_GetWeights:
                     "bounds": "time_bnds",
                 },
             )
+            ds.time.encoding = {"calendar": "standard"}
             ds["ts"] = xr.DataArray(
                 name="ts",
                 data=np.ones((12, 4, 4)),
@@ -2312,18 +2341,18 @@ class Test_GetWeights:
                 name="season",
                 data=np.array(
                     [
-                        cftime.datetime(1, 4, 1),
-                        cftime.datetime(1, 4, 1),
-                        cftime.datetime(1, 4, 1),
-                        cftime.datetime(1, 7, 1),
-                        cftime.datetime(1, 7, 1),
-                        cftime.datetime(1, 7, 1),
-                        cftime.datetime(1, 10, 1),
-                        cftime.datetime(1, 10, 1),
-                        cftime.datetime(1, 10, 1),
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 4, 1),
+                        cftime.DatetimeGregorian(1, 4, 1),
+                        cftime.DatetimeGregorian(1, 4, 1),
+                        cftime.DatetimeGregorian(1, 7, 1),
+                        cftime.DatetimeGregorian(1, 7, 1),
+                        cftime.DatetimeGregorian(1, 7, 1),
+                        cftime.DatetimeGregorian(1, 10, 1),
+                        cftime.DatetimeGregorian(1, 10, 1),
+                        cftime.DatetimeGregorian(1, 10, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
                     ],
                 ),
                 coords={"time": ds.time},
@@ -2368,21 +2397,21 @@ class Test_GetWeights:
                 name="season",
                 data=np.array(
                     [
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 4, 1),
-                        cftime.datetime(1, 4, 1),
-                        cftime.datetime(1, 4, 1),
-                        cftime.datetime(1, 7, 1),
-                        cftime.datetime(1, 7, 1),
-                        cftime.datetime(1, 7, 1),
-                        cftime.datetime(1, 10, 1),
-                        cftime.datetime(1, 10, 1),
-                        cftime.datetime(1, 10, 1),
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 4, 1),
+                        cftime.DatetimeGregorian(1, 4, 1),
+                        cftime.DatetimeGregorian(1, 4, 1),
+                        cftime.DatetimeGregorian(1, 7, 1),
+                        cftime.DatetimeGregorian(1, 7, 1),
+                        cftime.DatetimeGregorian(1, 7, 1),
+                        cftime.DatetimeGregorian(1, 10, 1),
+                        cftime.DatetimeGregorian(1, 10, 1),
+                        cftime.DatetimeGregorian(1, 10, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
                     ],
                 ),
                 coords={"time": ds.time},
@@ -2431,21 +2460,21 @@ class Test_GetWeights:
                 name="month",
                 data=np.array(
                     [
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 2, 1),
-                        cftime.datetime(1, 3, 1),
-                        cftime.datetime(1, 4, 1),
-                        cftime.datetime(1, 5, 1),
-                        cftime.datetime(1, 6, 1),
-                        cftime.datetime(1, 7, 1),
-                        cftime.datetime(1, 8, 1),
-                        cftime.datetime(1, 9, 1),
-                        cftime.datetime(1, 10, 1),
-                        cftime.datetime(1, 11, 1),
-                        cftime.datetime(1, 12, 1),
-                        cftime.datetime(1, 1, 1),
-                        cftime.datetime(1, 2, 1),
-                        cftime.datetime(1, 12, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 2, 1),
+                        cftime.DatetimeGregorian(1, 3, 1),
+                        cftime.DatetimeGregorian(1, 4, 1),
+                        cftime.DatetimeGregorian(1, 5, 1),
+                        cftime.DatetimeGregorian(1, 6, 1),
+                        cftime.DatetimeGregorian(1, 7, 1),
+                        cftime.DatetimeGregorian(1, 8, 1),
+                        cftime.DatetimeGregorian(1, 9, 1),
+                        cftime.DatetimeGregorian(1, 10, 1),
+                        cftime.DatetimeGregorian(1, 11, 1),
+                        cftime.DatetimeGregorian(1, 12, 1),
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 2, 1),
+                        cftime.DatetimeGregorian(1, 12, 1),
                     ],
                 ),
                 coords={"time": ds.time},
@@ -2493,21 +2522,21 @@ class Test_GetWeights:
                 name="month_day",
                 data=np.array(
                     [
-                        cftime.datetime(1, 1, 16),
-                        cftime.datetime(1, 2, 15),
-                        cftime.datetime(1, 3, 16),
-                        cftime.datetime(1, 4, 16),
-                        cftime.datetime(1, 5, 6),
-                        cftime.datetime(1, 6, 16),
-                        cftime.datetime(1, 7, 16),
-                        cftime.datetime(1, 8, 16),
-                        cftime.datetime(1, 9, 16),
-                        cftime.datetime(1, 10, 16),
-                        cftime.datetime(1, 11, 16),
-                        cftime.datetime(1, 12, 16),
-                        cftime.datetime(1, 1, 16),
-                        cftime.datetime(1, 2, 15),
-                        cftime.datetime(1, 12, 16),
+                        cftime.DatetimeGregorian(1, 1, 16),
+                        cftime.DatetimeGregorian(1, 2, 15),
+                        cftime.DatetimeGregorian(1, 3, 16),
+                        cftime.DatetimeGregorian(1, 4, 16),
+                        cftime.DatetimeGregorian(1, 5, 6),
+                        cftime.DatetimeGregorian(1, 6, 16),
+                        cftime.DatetimeGregorian(1, 7, 16),
+                        cftime.DatetimeGregorian(1, 8, 16),
+                        cftime.DatetimeGregorian(1, 9, 16),
+                        cftime.DatetimeGregorian(1, 10, 16),
+                        cftime.DatetimeGregorian(1, 11, 16),
+                        cftime.DatetimeGregorian(1, 12, 16),
+                        cftime.DatetimeGregorian(1, 1, 16),
+                        cftime.DatetimeGregorian(1, 2, 15),
+                        cftime.DatetimeGregorian(1, 12, 16),
                     ],
                 ),
                 coords={"time": ds.time},

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -324,8 +324,8 @@ def decode_non_cf_time(dataset: xr.Dataset) -> xr.Dataset:
     time_attrs = time.attrs
 
     # NOTE: When opening datasets with `decode_times=False`, the "calendar" and
-    # "units" attributes are stored in `.encoding` (unlike `decode_times=True`
-    # which stores them in `.attrs`). Since xCDAT manually decodes non-CF
+    # "units" attributes are stored in `.attrs` (unlike `decode_times=True`
+    # which stores them in `.encoding`). Since xCDAT manually decodes non-CF
     # compliant time coordinates by first setting `decode_times=False`, the
     # "calendar" and "units" attrs are popped from the `.attrs` dict and stored
     # in the `.encoding` dict to mimic xarray's behavior.

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1306,16 +1306,13 @@ class TemporalAccessor:
         return df_season
 
     def _convert_df_to_dt(self, df: pd.DataFrame) -> np.ndarray:
-        """Converts a DataFrame of datetime components to datetime objects.
+        """Converts a DataFrame of datetime components to cftime datetime
+        objects.
 
         datetime objects require at least a year, month, and day value. However,
         some modes and time frequencies don't require year, month, and/or day
         for grouping. For these cases, use default values of 1 in order to
         meet this datetime requirement.
-
-        If the default value of 1 is used for the years, datetime objects
-        must be created using `cftime.datetime` because year 1 is outside the
-        Timestamp-valid range.
 
         Parameters
         ----------
@@ -1325,11 +1322,12 @@ class TemporalAccessor:
         Returns
         -------
         np.ndarray
-            A numpy ndarray of datetime.datetime or cftime.datetime objects.
+            A numpy ndarray of cftime.datetime objects.
 
         Notes
         -----
         Refer to [3]_ and [4]_ for more information on Timestamp-valid range.
+        We use cftime.datetime objects to avoid these time range issues.
 
         References
         ----------
@@ -1344,18 +1342,12 @@ class TemporalAccessor:
             if component not in df_new.columns:
                 df_new[component] = default_val
 
-        year_is_unused = self._mode in ["climatology", "departures"] or (
-            self._mode == "average" and self._freq != "year"
-        )
-        if year_is_unused:
-            dates = [
-                cftime.datetime(year, month, day, hour)
-                for year, month, day, hour in zip(
-                    df_new.year, df_new.month, df_new.day, df_new.hour
-                )
-            ]
-        else:
-            dates = pd.to_datetime(df_new)
+        dates = [
+            cftime.datetime(year, month, day, hour)
+            for year, month, day, hour in zip(
+                df_new.year, df_new.month, df_new.day, df_new.hour
+            )
+        ]
 
         return np.array(dates)
 


### PR DESCRIPTION
## Description
This is an attempted fix for #301. The PR uses cftime.datetime objects in the `_convert_df_to_dt` function (instead of datetime / cfdatetime objects depending on the dataset attributes). 

- Closes #301

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
