### PR TITLE
Modify logic to not throw error for singleton coordinates (with no bounds)

### DIFF
--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -167,7 +167,7 @@ class TestAddBounds:
         with pytest.raises(ValueError):
             ds.bounds.add_bounds("Y")
 
-    def test_raises_errors_for_data_dim_and_length(self, caplog):
+    def test_raises_errors_for_data_dim_and_length(self):
         # Multidimensional
         lat = xr.DataArray(
             data=np.array([[0, 1, 2], [3, 4, 5]]),

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -148,7 +148,7 @@ class TestAddBounds:
         with pytest.raises(ValueError):
             ds.bounds.add_bounds("Y")
 
-    def test_raises_errors_for_data_dim_and_length(self):
+    def test_raises_errors_for_data_dim_and_length(self, caplog):
         # Multidimensional
         lat = xr.DataArray(
             data=np.array([[0, 1, 2], [3, 4, 5]]),
@@ -166,6 +166,12 @@ class TestAddBounds:
         # If coords dimensions does not equal 1.
         with pytest.raises(ValueError):
             ds.bounds.add_bounds("Y")
+
+        # If coords are length of <=1; no error, but original ds returned
+        # Update logger level to silence the logger warning during test runs.
+        caplog.set_level(logging.ERROR)
+        result = ds.bounds.add_bounds("X")
+        assert result.identical(ds)
 
     def test_raises_error_if_lat_coord_var_units_is_not_in_degrees(self):
         lat = xr.DataArray(

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -60,7 +60,6 @@ class TestAddMissingBounds:
     def test_adds_bounds_to_the_dataset(self):
         ds = self.ds_with_bnds.copy()
 
-        # Delete the lat and lon bounds and remove the "bounds" attr mapping
         ds = ds.drop_vars(["lat_bnds", "lon_bnds"])
 
         result = ds.bounds.add_missing_bounds()

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -166,9 +166,6 @@ class TestAddBounds:
         # If coords dimensions does not equal 1.
         with pytest.raises(ValueError):
             ds.bounds.add_bounds("Y")
-        # If coords are length of <=1.
-        with pytest.raises(ValueError):
-            ds.bounds.add_bounds("X")
 
     def test_raises_error_if_lat_coord_var_units_is_not_in_degrees(self):
         lat = xr.DataArray(

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -252,8 +252,6 @@ class BoundsAccessor:
         ------
         ValueError
             If coords dimensions does not equal 1.
-        ValueError
-            If coords are length of <=1.
 
         Notes
         -----

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -296,7 +296,7 @@ class BoundsAccessor:
         # Validate coordinate shape and dimensions
         if coord_var.ndim != 1:
             raise ValueError(
-                f"Cannot generate bounds for coordinate variable '{coord_var.name}"
+                f"Cannot generate bounds for coordinate variable '{coord_var.name}'"
                 " because it is multidimensional coordinates."
             )
         if coord_var.shape[0] <= 1:

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -274,7 +274,11 @@ class BoundsAccessor:
         if coord_var.ndim != 1:
             raise ValueError("Cannot generate bounds for multidimensional coordinates.")
         if coord_var.shape[0] <= 1:
-            raise ValueError("Cannot generate bounds for a coordinate of length <= 1.")
+            logger.warning(
+                f"Cannot generate bounds for coordinate variable '{coord_var.name}'"
+                " which has a length <= 1."
+            )
+            return ds
 
         # Retrieve coordinate dimension to calculate the diffs between points.
         dim = coord_var.dims[0]

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -157,6 +157,7 @@ class BoundsAccessor:
             # Otherwise, try to add bounds if it meets the function's criteria.
             try:
                 self.get_bounds(axis)
+                continue
             except KeyError:
                 pass
 

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -297,7 +297,7 @@ class BoundsAccessor:
         if coord_var.ndim != 1:
             raise ValueError(
                 f"Cannot generate bounds for coordinate variable '{coord_var.name}"
-                "because it is multidimensional coordinates."
+                " because it is multidimensional coordinates."
             )
         if coord_var.shape[0] <= 1:
             raise ValueError(

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -296,7 +296,7 @@ class BoundsAccessor:
         # Validate coordinate shape and dimensions
         if coord_var.ndim != 1:
             raise ValueError(
-                "Cannot generate bounds for coordinate variable '{coord_var.name}"
+                f"Cannot generate bounds for coordinate variable '{coord_var.name}"
                 "because it is multidimensional coordinates."
             )
         if coord_var.shape[0] <= 1:


### PR DESCRIPTION
Handle axis with single timesteps when adding bounds

## Description
When a coordinate has a length of 0 or 1, do not throw an error (in order to accommodate single timestep datasets). Simply do not add bounds and warn the user. 

- Closes #304

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass with my changes (locally and CI/CD build)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
