### PR TITLE
fix incorrect results for group averaging with missing data

### DIFF
--- a/conda-env/readthedocs.yml
+++ b/conda-env/readthedocs.yml
@@ -1,4 +1,4 @@
-gitname: xcdat_rtd
+name: xcdat_rtd
 channels:
     - conda-forge
     - defaults

--- a/conda-env/readthedocs.yml
+++ b/conda-env/readthedocs.yml
@@ -1,4 +1,4 @@
-name: xcdat_rtd
+gitname: xcdat_rtd
 channels:
     - conda-forge
     - defaults

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -418,6 +418,7 @@ class TestGroupAverage:
             ),
             coords={"time": self.ds.time, "lat": self.ds.lat, "lon": self.ds.lon},
             dims=["time", "lat", "lon"],
+            attrs={"test_attr": "test"},
         )
 
     def test_weighted_annual_averages(self):
@@ -458,6 +459,7 @@ class TestGroupAverage:
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "group_average",
                 "freq": "year",
@@ -467,6 +469,7 @@ class TestGroupAverage:
 
         xr.testing.assert_allclose(result, expected)
         assert result.ts.attrs == expected.ts.attrs
+        assert result.time.attrs == expected.time.attrs
 
     @requires_dask
     def test_weighted_annual_averages_with_chunking(self):
@@ -507,6 +510,7 @@ class TestGroupAverage:
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "group_average",
                 "freq": "year",
@@ -516,6 +520,7 @@ class TestGroupAverage:
 
         xr.testing.assert_allclose(result, expected)
         assert result.ts.attrs == expected.ts.attrs
+        assert result.time.attrs == expected.time.attrs
 
     def test_weighted_seasonal_averages_with_DJF_and_drop_incomplete_seasons(self):
         ds = self.ds.copy()
@@ -555,6 +560,7 @@ class TestGroupAverage:
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "group_average",
                 "freq": "season",
@@ -605,6 +611,7 @@ class TestGroupAverage:
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "group_average",
                 "freq": "season",
@@ -664,6 +671,7 @@ class TestGroupAverage:
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "group_average",
                 "freq": "season",
@@ -716,6 +724,7 @@ class TestGroupAverage:
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "group_average",
                 "freq": "season",
@@ -807,6 +816,7 @@ class TestGroupAverage:
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "group_average",
                 "freq": "month",
@@ -824,6 +834,7 @@ class TestGroupAverage:
             ),
             coords={"time": self.ds.time, "lat": self.ds.lat, "lon": self.ds.lon},
             dims=["time", "lat", "lon"],
+            attrs={"test_attr": "test"},
         )
 
         result = ds.temporal.group_average("ts", "month")
@@ -856,6 +867,7 @@ class TestGroupAverage:
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "group_average",
                 "freq": "month",
@@ -898,6 +910,7 @@ class TestGroupAverage:
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "group_average",
                 "freq": "day",
@@ -941,6 +954,7 @@ class TestGroupAverage:
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "group_average",
                 "freq": "hour",

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -831,7 +831,7 @@ class TestGroupAverage:
         expected = expected.drop_dims("time")
         expected["ts"] = xr.DataArray(
             name="ts",
-            data=np.array([[[2.0]], [[0.0]], [[1.0]], [[1.0]], [[2.0]]]),
+            data=np.array([[[2.0]], [[np.nan]], [[1.0]], [[1.0]], [[2.0]]]),
             coords={
                 "lat": expected.lat,
                 "lon": expected.lon,

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -919,43 +919,40 @@ class TemporalAccessor:
 
         if self._weighted:
             self._weights = self._get_weights()
-            # grab metadata
-            dv_attrs = dv.attrs
-            dv_name = dv.name
-            # grab metadata (populated after calling ._group_data())
-            lt_attrs = self._labeled_time.attrs
-            lt_encoding = self._labeled_time.encoding
-            # weight the data variable
+            # Weight the data variable.
             dv *= self._weights
-            # cast the weights to match the dv.shape / dims
-            weights, x = xr.broadcast(self._weights, dv)
-            # ensure missing data receives no weight
+
+            # Ensure missing data (`np.nan`) receives no weight (zero). To
+            # achieve this, first broadcast the one-dimensional (temporal
+            # dimension) shape of the `weights` DataArray to the
+            # multi-dimensional shape of its corresponding data variable.
+            weights, _ = xr.broadcast(self._weights, dv)
             weights = xr.where(np.isnan(dv), 0.0, weights)
-            # perform weighted average
-            dv = self._group_data(dv).sum() / self._group_data(weights).sum()
-            # add dv attributes
-            dv.attrs = dv_attrs
-            dv.name = dv_name
+
+            # Perform weighted average using the formula
+            # WA = sum(data*weights) / sum(weights). The denominator must be
+            # included to take into account zero weight for missing data.
+            with xr.set_options(keep_attrs=True):
+                dv = self._group_data(dv).sum() / self._group_data(weights).sum()
+            # Restore the data variable's name.
+            dv.name = data_var.name
         else:
             dv = self._group_data(dv).mean()
-            # grab metadata (populated after calling ._group_data())
-            lt_attrs = self._labeled_time.attrs
-            lt_encoding = self._labeled_time.encoding
 
         # After grouping and aggregating the data variable values, the
         # original time dimension is replaced with the grouped time dimension.
         # For example, grouping on "year_season" replaces the time dimension
         # with "year_season". This dimension needs to be renamed back to
         # the original time dimension name before the data variable is added
-        # back to the dataset so that the CF compliant name is maintained.
+        # back to the dataset so that the original name is preserved.
         dv = dv.rename({self._labeled_time.name: self._dim})
 
         # After grouping and aggregating, the grouped time dimension's
         # attributes are removed. Xarray's `keep_attrs=True` option only keeps
         # attributes for data variables and not their coordinates, so the
         # coordinate attributes have to be restored manually.
-        dv[self._dim].attrs = lt_attrs
-        dv[self._dim].encoding = lt_encoding
+        dv[self._dim].attrs = self._labeled_time.attrs
+        dv[self._dim].encoding = self._labeled_time.encoding
 
         dv = self._add_operation_attrs(dv)
 
@@ -1037,7 +1034,12 @@ class TemporalAccessor:
         if self._mode == "average":
             dv_gb = dv.groupby(f"{self._dim}.{self._freq}")
         else:
-            self._labeled_time = self._label_time_coords(dv[self._dim])
+            # Reuse the labeled time coordinates if they are already generated.
+            # This specifically applies when generating weights, which calls
+            # this method again after it has already been called to group
+            # the data variable with the same time coordinates.
+            if not hasattr(self, "_labeled_time"):
+                self._labeled_time = self._label_time_coords(dv[self._dim])
             dv.coords[self._labeled_time.name] = self._labeled_time
             dv_gb = dv.groupby(self._labeled_time.name)
 


### PR DESCRIPTION
## Description

This PR fixes an issue that leads to incorrect results for group averaging with missing data; the PR ensures that these data points receive no weight when averaging.

- Closes #319

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
