### PR TITLE
Fix multiple temporal avg calls on same dataset breaking

### DIFF
--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1606,6 +1606,7 @@ class Test_GetWeights:
             ds.temporal._mode = "average"
             ds.temporal._freq = "year"
             ds.temporal._weighted = "True"
+            ds.temporal._time_bounds = ds.time_bnds
             ds.temporal._labeled_time = xr.DataArray(
                 name="year",
                 data=np.array(
@@ -1668,6 +1669,7 @@ class Test_GetWeights:
             ds.temporal._mode = "average"
             ds.temporal._freq = "month"
             ds.temporal._weighted = "True"
+            ds.temporal._time_bounds = ds.time_bnds
             ds.temporal._labeled_time = xr.DataArray(
                 name="month",
                 data=np.array(
@@ -1734,6 +1736,7 @@ class Test_GetWeights:
             ds.temporal._mode = "group_average"
             ds.temporal._freq = "year"
             ds.temporal._weighted = "True"
+            ds.temporal._time_bounds = ds.time_bnds
             ds.temporal._labeled_time = xr.DataArray(
                 name="year",
                 data=np.array(
@@ -1796,6 +1799,7 @@ class Test_GetWeights:
             ds.temporal._mode = "group_average"
             ds.temporal._freq = "month"
             ds.temporal._weighted = "True"
+            ds.temporal._time_bounds = ds.time_bnds
             ds.temporal._labeled_time = xr.DataArray(
                 name="year_month",
                 data=np.array(
@@ -1940,6 +1944,7 @@ class Test_GetWeights:
             ds.temporal._freq = "season"
             ds.temporal._weighted = "True"
             ds.temporal._season_config = {"dec_mode": "DJF"}
+            ds.temporal._time_bounds = ds.time_bnds
             ds.temporal._labeled_time = xr.DataArray(
                 name="year_season",
                 data=np.array(
@@ -2001,6 +2006,7 @@ class Test_GetWeights:
             ds.temporal._freq = "season"
             ds.temporal._weighted = "True"
             ds.temporal._season_config = {"dec_mode": "JDF"}
+            ds.temporal._time_bounds = ds.time_bnds
             ds.temporal._labeled_time = xr.DataArray(
                 name="year_season",
                 data=np.array(
@@ -2069,6 +2075,7 @@ class Test_GetWeights:
             ds.temporal._mode = "group_average"
             ds.temporal._freq = "season"
             ds.temporal._weighted = "True"
+            ds.temporal._time_bounds = ds.time_bnds
             ds.temporal._season_config = {
                 "custom_seasons": {
                     "JanFebMar": ["Jan", "Feb", "Mar"],
@@ -2145,6 +2152,7 @@ class Test_GetWeights:
             ds.temporal._mode = "group_average"
             ds.temporal._freq = "day"
             ds.temporal._weighted = "True"
+            ds.temporal._time_bounds = ds.time_bnds
             ds.temporal._labeled_time = xr.DataArray(
                 name="year_month_day",
                 data=np.array(
@@ -2190,6 +2198,7 @@ class Test_GetWeights:
             ds.temporal._freq = "hour"
             ds.temporal._weighted = "True"
             ds.temporal._season_config = {"dec_mode": "JDF"}
+            ds.temporal._time_bounds = ds.time_bnds
             ds.temporal._labeled_time = xr.DataArray(
                 name="year_month_day_hour",
                 data=np.array(
@@ -2337,6 +2346,7 @@ class Test_GetWeights:
             ds.temporal._freq = "season"
             ds.temporal._weighted = "True"
             ds.temporal._season_config = {"dec_mode": "DJF"}
+            ds.temporal._time_bounds = ds.time_bnds
             ds.temporal._labeled_time = xr.DataArray(
                 name="season",
                 data=np.array(
@@ -2393,6 +2403,7 @@ class Test_GetWeights:
             ds.temporal._freq = "season"
             ds.temporal._weighted = "True"
             ds.temporal._season_config = {"dec_mode": "JDF"}
+            ds.temporal._time_bounds = ds.time_bnds
             ds.temporal._labeled_time = xr.DataArray(
                 name="season",
                 data=np.array(
@@ -2456,6 +2467,7 @@ class Test_GetWeights:
             ds.temporal._mode = "climatology"
             ds.temporal._freq = "month"
             ds.temporal._weighted = "True"
+            ds.temporal._time_bounds = ds.time_bnds
             ds.temporal._labeled_time = xr.DataArray(
                 name="month",
                 data=np.array(
@@ -2518,6 +2530,7 @@ class Test_GetWeights:
             ds.temporal._mode = "climatology"
             ds.temporal._freq = "day"
             ds.temporal._weighted = "True"
+            ds.temporal._time_bounds = ds.time_bnds
             ds.temporal._labeled_time = xr.DataArray(
                 name="month_day",
                 data=np.array(

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -146,9 +146,8 @@ class TemporalAccessor:
     def __init__(self, dataset: xr.Dataset):
         self._dataset: xr.Dataset = dataset
 
+        # The name of the time dimension.
         self._dim = get_axis_coord(self._dataset, "T").name
-
-        self._time_bounds = self._dataset.bounds.get_bounds("T").copy()
 
         try:
             self.calendar = self._dataset[self._dim].encoding["calendar"]
@@ -739,6 +738,9 @@ class TemporalAccessor:
         ValueError
             If an incorrect ``dec_mode`` arg was passed.
         """
+        # The time bounds.
+        self._time_bounds = self._dataset.bounds.get_bounds("T")
+
         # General configuration attributes.
         if mode not in list(MODES):
             modes = ", ".join(f'"{word}"' for word in MODES)


### PR DESCRIPTION

## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This was caused by initializing the `ds.temporal` class once with `self._time_bounds`. Instead, it needs to be set every time the user runs temporal averaging because this `self._time_bounds` can change between each call depending on user settings (e.g., drop incomplete djf).

- Closes #325 
- Closes #327 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
