### PR TITLE
Make `xesmf` an optional dependency

### DIFF
--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -50,16 +50,18 @@ dependencies:
     - jupyterlab=3.4.5
     - tbump=6.9.0
 
-run_constrained:
-    # ==================
-    # Deal with existing limitation on osx-arm64
-    # Base
-    # ==================
-    - esmpy=8.2.0 # https://github.com/conda-forge/esmpy-feedstock/issues/55
-    - xesmf=0.6.3 # depends on esmpy
-    # ==================
-    # Documentation
-    # ==================
-    - pandoc=2.19 # currently broken for osx-arm64 https://anaconda.org/conda-forge/pandoc/files?version=2.19
+requirements:
+    # per https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#run-constrained
+    run_constrained:
+        # ==================
+        # Deal with existing limitation on osx-arm64
+        # Base
+        # ==================
+        - esmpy=8.2.0 # https://github.com/conda-forge/esmpy-feedstock/issues/55
+        - xesmf=0.6.3 # depends on esmpy
+        # ==================
+        # Documentation
+        # ==================
+        - pandoc=2.19 # currently broken for osx-arm64 https://anaconda.org/conda-forge/pandoc/files?version=2.19
 
 prefix: /opt/miniconda3/envs/xcdat_dev

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -55,5 +55,4 @@ dependencies:
     - matplotlib=3.5.2
     - jupyterlab=3.4.5
     - tbump=6.9.0
-
 prefix: /opt/miniconda3/envs/xcdat_dev

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -12,13 +12,11 @@ dependencies:
     - cf_xarray=0.7.4
     - cftime=1.6.1
     - dask=2022.8.0
-    - esmpy=8.2.0
     - netcdf4=1.6.0
     - numba=0.55.2 # TODO: Remove this pin once `numba` is properly patched with `numpy` compatibility.
     - numpy=1.22.4
     - pandas=1.4.3
     - xarray=2022.6.0
-    - xesmf=0.6.3
     - python-dateutil=2.8.2
     - types-python-dateutil=2.8.19
     # ==================
@@ -30,7 +28,6 @@ dependencies:
     - sphinx-book-theme=0.3.3
     - sphinx-copybutton=0.5.0
     - nbsphinx=0.8.9
-    - pandoc=2.19
     # ==================
     # Quality Assurance
     # ==================
@@ -52,4 +49,17 @@ dependencies:
     - matplotlib=3.5.2
     - jupyterlab=3.4.5
     - tbump=6.9.0
+
+run_constrained:
+    # ==================
+    # Deal with existing limitation on osx-arm64
+    # Base
+    # ==================
+    - esmpy=8.2.0 # https://github.com/conda-forge/esmpy-feedstock/issues/55
+    - xesmf=0.6.3 # depends on esmpy
+    # ==================
+    # Documentation
+    # ==================
+    - pandoc=2.19 # currently broken for osx-arm64 https://anaconda.org/conda-forge/pandoc/files?version=2.19
+
 prefix: /opt/miniconda3/envs/xcdat_dev

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -1,4 +1,4 @@
-name: xcdat_dev
+name: xcdat_dev_noEsmpy
 channels:
     - conda-forge
     - defaults

--- a/conda-env/dev_min.yml
+++ b/conda-env/dev_min.yml
@@ -1,5 +1,6 @@
-# A conda development environment with all dependencies, including optional and documentation dependencies.
-name: xcdat_dev
+# A conda development environment without the optional and documentation dependencies.
+# Use the environment if are developing on an `osx-arm64` or `windows` platform (`xesmf`/`esmpy` not supported)
+name: xcdat_dev_min
 channels:
     - conda-forge
     - defaults
@@ -19,20 +20,6 @@ dependencies:
     - pandas=1.4.3
     - python-dateutil=2.8.2
     - xarray=2022.6.0
-    # ==================
-    # Optional
-    # ==================
-    - xesmf=0.6.3
-    # ==================
-    # Documentation
-    # ==================
-    - sphinx=4.5.0
-    - sphinxcontrib-napoleon=0.7
-    - sphinx-autosummary-accessors=2022.4.0
-    - sphinx-book-theme=0.3.3
-    - sphinx-copybutton=0.5.0
-    - nbsphinx=0.8.9
-    - pandoc=2.19
     # ==================
     # Quality Assurance
     # ==================
@@ -56,4 +43,4 @@ dependencies:
     - jupyterlab=3.4.5
     - tbump=6.9.0
 
-prefix: /opt/miniconda3/envs/xcdat_dev
+prefix: /opt/miniconda3/envs/xcdat_dev_min

--- a/conda-env/dev_min.yml
+++ b/conda-env/dev_min.yml
@@ -1,5 +1,5 @@
 # A conda development environment without the optional and documentation dependencies.
-# Use the environment if are developing on an `osx-arm64` or `windows` platform (`xesmf`/`esmpy` not supported)
+# Use the environment if you are developing on an `osx-arm64` or `windows` platform (`xesmf`/`esmpy` not supported)
 name: xcdat_dev_min
 channels:
     - conda-forge

--- a/conda-env/readthedocs.yml
+++ b/conda-env/readthedocs.yml
@@ -12,15 +12,17 @@ dependencies:
     - cf_xarray=0.7.4
     - cftime=1.6.1
     - dask=2022.8.0
-    - esmpy=8.2.0
     - netcdf4=1.6.0
     - numba=0.55.2 # TODO: Remove this pin once `numba` is properly patched with `numpy` compatibility.
     - numpy=1.22.4
     - pandas=1.4.3
-    - xarray=2022.6.0
-    - xesmf=0.6.3
     - python-dateutil=2.8.2
     - types-python-dateutil=2.8.19
+    - xarray=2022.6.0
+    # ==================
+    # Optional
+    # ==================
+    - xesmf=0.6.3
     # ==================
     # Documentation
     # ==================

--- a/docs/getting-started-hpc-jupyter.rst
+++ b/docs/getting-started-hpc-jupyter.rst
@@ -34,12 +34,17 @@ example, some machines make both available via:
    module load python
 
 Once ``conda`` is active, you can create and activate a new ``xcdat`` environment
-with:
+with ``xesmf`` (a recommended dependency):
 
 ::
 
-   conda create -n <ENV_NAME> -c conda-forge xcdat
+   conda create -n <ENV_NAME> -c conda-forge xcdat xesmf
    conda activate <ENV_NAME>
+
+Note that ``xesmf`` is an optional dependency, which is required for horizontal
+regridding. ``xesmf`` is not currently supported on `osx-arm64`_ or `windows`_
+because ``esmpy`` is not yet available on these platforms. ``windows`` users can
+try `WSL2`_ as a workaround.
 
 You may also want to use ``xcdat`` with some additional packages. For example, you can
 install ``xcdat`` with ``matplotlib``, ``ipython``, and ``ipykernel`` (see the next
@@ -47,7 +52,7 @@ section for more about ``ipykernel``):
 
 ::
 
-   conda create -n <ENV_NAME> -c conda-forge xcdat matplotlib ipython ipykernel
+   conda create -n <ENV_NAME> -c conda-forge xcdat xesmf matplotlib ipython ipykernel
    conda activate <ENV_NAME>
 
 The advantage with following this approach is that conda will attempt to resolve

--- a/docs/getting-started-hpc-jupyter.rst
+++ b/docs/getting-started-hpc-jupyter.rst
@@ -41,10 +41,10 @@ with ``xesmf`` (a recommended dependency):
    conda create -n <ENV_NAME> -c conda-forge xcdat xesmf
    conda activate <ENV_NAME>
 
-Note that ``xesmf`` is an optional dependency, which is required for horizontal
-regridding. ``xesmf`` is not currently supported on `osx-arm64`_ or `windows`_
-because ``esmpy`` is not yet available on these platforms. Windows users can
-try `WSL2`_ as a workaround.
+Note that ``xesmf`` is an optional dependency, which is required using ``xesmf``
+based horizontal regridding APIs in ``xcdat``. ``xesmf`` is not currently supported
+on `osx-arm64`_ or `windows`_ because ``esmpy`` is not yet available on these
+platforms. Windows users can try `WSL2`_ as a workaround.
 
 .. _windows: https://github.com/conda-forge/esmf-feedstock/issues/64
 .. _osx-arm64: https://github.com/conda-forge/esmf-feedstock/issues/74

--- a/docs/getting-started-hpc-jupyter.rst
+++ b/docs/getting-started-hpc-jupyter.rst
@@ -18,12 +18,12 @@ Ensure ``conda`` is installed
 
 Generally, the instructions from `getting started guide <getting-started.rst>`_ can also
 be followed for HPC machines. This guide covers installing Miniconda3 and creating
-a conda environment with the ``xcdat`` package. 
+a conda environment with the ``xcdat`` package.
 
 Before installing Miniconda3, you should consult your HPC documentation to see if
-``conda`` is already available; in some cases, ``python`` and ``conda`` may be 
-pre-installed on an HPC machine. You can check to see whether they are available by 
-entering ``which conda`` and/or ``which python`` in the command line (which will 
+``conda`` is already available; in some cases, ``python`` and ``conda`` may be
+pre-installed on an HPC machine. You can check to see whether they are available by
+entering ``which conda`` and/or ``which python`` in the command line (which will
 return their path if they are available).
 
 In other cases, ``python`` and ``conda`` are available via modules on an HPC machine. For
@@ -43,8 +43,12 @@ with ``xesmf`` (a recommended dependency):
 
 Note that ``xesmf`` is an optional dependency, which is required for horizontal
 regridding. ``xesmf`` is not currently supported on `osx-arm64`_ or `windows`_
-because ``esmpy`` is not yet available on these platforms. ``windows`` users can
+because ``esmpy`` is not yet available on these platforms. Windows users can
 try `WSL2`_ as a workaround.
+
+.. _windows: https://github.com/conda-forge/esmf-feedstock/issues/64
+.. _osx-arm64: https://github.com/conda-forge/esmf-feedstock/issues/74
+.. _WSL2: https://docs.microsoft.com/en-us/windows/wsl/install
 
 You may also want to use ``xcdat`` with some additional packages. For example, you can
 install ``xcdat`` with ``matplotlib``, ``ipython``, and ``ipykernel`` (see the next

--- a/docs/getting-started-hpc-jupyter.rst
+++ b/docs/getting-started-hpc-jupyter.rst
@@ -41,7 +41,7 @@ with ``xesmf`` (a recommended dependency):
    conda create -n <ENV_NAME> -c conda-forge xcdat xesmf
    conda activate <ENV_NAME>
 
-Note that ``xesmf`` is an optional dependency, which is required using ``xesmf``
+Note that ``xesmf`` is an optional dependency, which is required using for ``xesmf``
 based horizontal regridding APIs in ``xcdat``. ``xesmf`` is not currently supported
 on `osx-arm64`_ or `windows`_ because ``esmpy`` is not yet available on these
 platforms. Windows users can try `WSL2`_ as a workaround.

--- a/docs/getting-started-hpc-jupyter.rst
+++ b/docs/getting-started-hpc-jupyter.rst
@@ -41,7 +41,7 @@ with ``xesmf`` (a recommended dependency):
    conda create -n <ENV_NAME> -c conda-forge xcdat xesmf
    conda activate <ENV_NAME>
 
-Note that ``xesmf`` is an optional dependency, which is required using for ``xesmf``
+Note that ``xesmf`` is an optional dependency, which is required for using ``xesmf``
 based horizontal regridding APIs in ``xcdat``. ``xesmf`` is not currently supported
 on `osx-arm64`_ or `windows`_ because ``esmpy`` is not yet available on these
 platforms. Windows users can try `WSL2`_ as a workaround.

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -44,8 +44,9 @@ Installation
 
    .. code-block:: console
 
-       >>> conda create -n <ENV_NAME> -c conda-forge xcdat
+       >>> conda create -n <ENV_NAME> -c conda-forge xcdat <OPTIONAL_DEPENDENCIES>
        >>> conda activate <ENV_NAME>
+
 
 2. Install ``xcdat`` in an existing conda environment (`conda install`_)
 
@@ -55,34 +56,28 @@ Installation
    .. code-block:: console
 
        >>> conda activate <ENV_NAME>
-       >>> conda install -c conda-forge xcdat
+       >>> conda install -c conda-forge xcdat <OPTIONAL_DEPENDENCIES>
 
-3. [Optional] Some packages that are commonly used with ``xcdat`` can be installed
-   either in step 1 or step 2 above:
+3. [Optional] Specific features in ``xcdat`` require the installation of optional
+   dependencies, either in step 1 or step 2 above:
 
-        - ``jupyterlab``: a web-based interactive development environment for notebooks,
-          code, and data. This package also includes ``ipykernel``.
-        - ``matplotlib``: a library for creating visualizations in Python.
-        - ``cartopy``: an add-on package for ``matplotlib`` and specialized for geospatial data processing.
+   - ``xesmf``: required to enable horizontal regridding with ``xesmf``
 
-.. _conda create: https://docs.conda.io/projects/conda/en/latest/commands/create.html?highlight=create
-.. _conda install: https://docs.conda.io/projects/conda/en/latest/commands/install.html?highlight=install
-
-.. _optional-dependencies:
-
-Optional dependencies
----------------------
-
-``xcdat`` includes APIs that are enabled by installing optional dependencies. conda will automatically attempt to install these optional dependencies with ``xcdat``. However, some optional dependencies might be skipped if your platform does not support it (e.g., ``osx-arm64``, ``windows``). ``windows`` users can try `WSL2`_ as a workaround.
-
-.. _WSL2: https://docs.microsoft.com/en-us/windows/wsl/install
-
-Regridding
-~~~~~~~~~~
-
-* ``xesmf``: required to enable horizontal regridding with ``xesmf``
-
-  * Currently not supported on `osx-arm64`_ and `windows`_ due to ``esmpy``, which lacks support for these platforms.
+     - Currently not supported on `osx-arm64`_ and `windows`_ due to ``esmpy``,
+       which lacks support for these platforms. ``windows`` users can try `WSL2`_
+       as a workaround.
 
 .. _windows: https://github.com/conda-forge/esmf-feedstock/issues/64
 .. _osx-arm64: https://github.com/conda-forge/esmf-feedstock/issues/74
+.. _WSL2: https://docs.microsoft.com/en-us/windows/wsl/install
+
+4. [Optional] Some packages that are commonly used with ``xcdat`` can be installed
+   either in step 1 or step 2 above:
+
+   - ``jupyterlab``: a web-based interactive development environment for notebooks,
+     code, and data. This package also includes ``ipykernel``.
+   - ``matplotlib``: a library for creating visualizations in Python.
+   - ``cartopy``: an add-on package for ``matplotlib`` and specialized for geospatial data processing.
+
+.. _conda create: https://docs.conda.io/projects/conda/en/latest/commands/create.html?highlight=create
+.. _conda install: https://docs.conda.io/projects/conda/en/latest/commands/install.html?highlight=install

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -48,10 +48,10 @@ Installation
        >>> conda create -n <ENV_NAME> -c conda-forge xcdat xesmf
        >>> conda activate <ENV_NAME>
 
-   Note that ``xesmf`` is an optional dependency, which is required for horizontal
-   regridding. ``xesmf`` is not currently supported on `osx-arm64`_ or `windows`_
-   because ``esmpy`` is not yet available on these platforms. Windows users can
-   try `WSL2`_ as a workaround.
+   Note that ``xesmf`` is an optional dependency, which is required using ``xesmf``
+   based horizontal regridding APIs in ``xcdat``. ``xesmf`` is not currently supported
+   on `osx-arm64`_ or `windows`_ because ``esmpy`` is not yet available on these
+   platforms. Windows users can try `WSL2`_ as a workaround.
 
 .. _windows: https://github.com/conda-forge/esmf-feedstock/issues/64
 .. _osx-arm64: https://github.com/conda-forge/esmf-feedstock/issues/74

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -73,16 +73,17 @@ Installation
 Optional dependencies
 ---------------------
 
-`xcdat` includes APIs that are enabled by installing optional dependencies.
-When installing `xcdat`, conda will attempt to also install these optional dependencies. However, some optional dependencies might be skipped if your platform does not support it (e.g., osx-arm64, windows).
-Refer to the list below for more details.
+``xcdat`` includes APIs that are enabled by installing optional dependencies. conda will automatically attempt to install these optional dependencies with ``xcdat``.
+However, some optional dependencies might be skipped if your platform does not support it (e.g., ``osx-arm64``, ``windows``). ``windows`` users can try `WSL2`_ as a workaround.
+
+.. _WSL2: https://docs.microsoft.com/en-us/windows/wsl/install
 
 Regridding
 ~~~~~~~~~~
 
 * ``xesmf``: required to enable horizontal regridding with ``xesmf``
-  * Currently not supported on `osx-arm64`_ and `windows`_
-  * Inherently, ``xcdat``'s ``xesmf`` `horizontal regridding API <generated/xcdat.regridder.xesmf.XESMFRegridder.rst>`_ is not supported on these platforms.
+
+  * Currently not supported on `osx-arm64`_ and `windows`_ due to ``esmpy``, which lacks support for these platforms.
 
 .. _windows: https://github.com/conda-forge/esmf-feedstock/issues/64
 .. _osx-arm64: https://github.com/conda-forge/esmf-feedstock/issues/74

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -40,13 +40,18 @@ Installation
    The advantage with following this approach is that Conda will attempt to resolve
    dependencies (e.g. ``python >= 3.8``) for compatibility.
 
-   To create a conda environment with ``xcdat``, run:
+   To create an ``xcdat`` conda environment with ``xesmf`` (a recommended dependency),
+   run:
 
    .. code-block:: console
 
-       >>> conda create -n <ENV_NAME> -c conda-forge xcdat <OPTIONAL_DEPENDENCIES>
+       >>> conda create -n <ENV_NAME> -c conda-forge xcdat xesmf
        >>> conda activate <ENV_NAME>
 
+   Note that ``xesmf`` is an optional dependency, which is required for horizontal
+   regridding. ``xesmf`` is not currently supported on `osx-arm64`_ or `windows`_
+   because ``esmpy`` is not yet available on these platforms. ``windows`` users can
+   try `WSL2`_ as a workaround.
 
 2. Install ``xcdat`` in an existing conda environment (`conda install`_)
 
@@ -56,16 +61,9 @@ Installation
    .. code-block:: console
 
        >>> conda activate <ENV_NAME>
-       >>> conda install -c conda-forge xcdat <OPTIONAL_DEPENDENCIES>
+       >>> conda install -c conda-forge xcdat xesmf
 
-3. [Optional] Specific features in ``xcdat`` require the installation of optional
-   dependencies, either in step 1 or step 2 above:
-
-   - ``xesmf``: required to enable horizontal regridding with ``xesmf``
-
-     - Currently not supported on `osx-arm64`_ and `windows`_ due to ``esmpy``,
-       which lacks support for these platforms. ``windows`` users can try `WSL2`_
-       as a workaround.
+   Note: As above, ``xesmf`` is an optional dependency.
 
 .. _windows: https://github.com/conda-forge/esmf-feedstock/issues/64
 .. _osx-arm64: https://github.com/conda-forge/esmf-feedstock/issues/74

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -34,17 +34,17 @@ log back in.
 Installation
 ------------
 
-1. Create a Conda environment from scratch with ``xcdat`` (`conda create`_)
+1. Create a conda environment from scratch with ``xcdat`` (`conda create`_)
 
    We recommend using the Conda environment creation procedure to install ``xcdat``.
    The advantage with following this approach is that Conda will attempt to resolve
    dependencies (e.g. ``python >= 3.8``) for compatibility.
 
-   To create a Conda environment with ``xcdat``, run:
+   To create a conda environment with ``xcdat``, run:
 
    .. code-block:: console
 
-       >>> conda create -n <ENV_NAME> -c conda-forge xcdat
+       >>> conda create -n <ENV_NAME> -c conda-forge xcdat <OPTIONAL_DEPENDENCIES>
        >>> conda activate <ENV_NAME>
 
 
@@ -56,7 +56,9 @@ Installation
    .. code-block:: console
 
        >>> conda activate <ENV_NAME>
-       >>> conda install -c conda-forge xcdat
+       >>> conda install -c conda-forge xcdat <OPTIONAL_DEPENDENCIES>
+
+   Refer to the `optional dependencies`_ section for dependencies you might want to install with ``xcdat``.
 
 3. [Optional] Some packages that are commonly used with ``xcdat`` can be installed
    either in step 1 or step 2 above:
@@ -68,3 +70,22 @@ Installation
 
 .. _conda create: https://docs.conda.io/projects/conda/en/latest/commands/create.html?highlight=create
 .. _conda install: https://docs.conda.io/projects/conda/en/latest/commands/install.html?highlight=install
+
+.. _optional-dependencies:
+
+Optional dependencies
+---------------------
+
+xCDAT includes APIs that can be enabled by installing optional dependencies.
+These dependencies are optional because they might not be supported on specific platforms (e.g., osx-arm64, windows).
+
+
+Regridding
+~~~~~~~~~~
+
+* ``xesmf``: required to enable horizontal regridding with ``xesmf``, currently not supported on `osx-arm64`_ and `windows`_
+
+  * Inherently, ``xcdat``'s ``xesmf`` `horizontal regridding API <generated/xcdat.regridder.xesmf.XESMFRegridder.rst>`_ is not supported on these platforms.
+
+.. _windows: https://github.com/conda-forge/esmf-feedstock/issues/64
+.. _osx-arm64: https://github.com/conda-forge/esmf-feedstock/issues/74

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -50,8 +50,12 @@ Installation
 
    Note that ``xesmf`` is an optional dependency, which is required for horizontal
    regridding. ``xesmf`` is not currently supported on `osx-arm64`_ or `windows`_
-   because ``esmpy`` is not yet available on these platforms. ``windows`` users can
+   because ``esmpy`` is not yet available on these platforms. Windows users can
    try `WSL2`_ as a workaround.
+
+.. _windows: https://github.com/conda-forge/esmf-feedstock/issues/64
+.. _osx-arm64: https://github.com/conda-forge/esmf-feedstock/issues/74
+.. _WSL2: https://docs.microsoft.com/en-us/windows/wsl/install
 
 2. Install ``xcdat`` in an existing conda environment (`conda install`_)
 
@@ -65,11 +69,7 @@ Installation
 
    Note: As above, ``xesmf`` is an optional dependency.
 
-.. _windows: https://github.com/conda-forge/esmf-feedstock/issues/64
-.. _osx-arm64: https://github.com/conda-forge/esmf-feedstock/issues/74
-.. _WSL2: https://docs.microsoft.com/en-us/windows/wsl/install
-
-4. [Optional] Some packages that are commonly used with ``xcdat`` can be installed
+3. [Optional] Some packages that are commonly used with ``xcdat`` can be installed
    either in step 1 or step 2 above:
 
    - ``jupyterlab``: a web-based interactive development environment for notebooks,

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -44,11 +44,10 @@ Installation
 
    .. code-block:: console
 
-       >>> conda create -n <ENV_NAME> -c conda-forge xcdat <OPTIONAL_DEPENDENCIES>
+       >>> conda create -n <ENV_NAME> -c conda-forge xcdat
        >>> conda activate <ENV_NAME>
 
-
-2. Install ``xcdat`` in an existing Conda environment (`conda install`_)
+2. Install ``xcdat`` in an existing conda environment (`conda install`_)
 
    You can also install ``xcdat`` in an existing Conda environment, granted that Conda
    is able to resolve the compatible dependencies.
@@ -56,9 +55,7 @@ Installation
    .. code-block:: console
 
        >>> conda activate <ENV_NAME>
-       >>> conda install -c conda-forge xcdat <OPTIONAL_DEPENDENCIES>
-
-   Refer to the `optional dependencies`_ section for dependencies you might want to install with ``xcdat``.
+       >>> conda install -c conda-forge xcdat
 
 3. [Optional] Some packages that are commonly used with ``xcdat`` can be installed
    either in step 1 or step 2 above:
@@ -76,15 +73,15 @@ Installation
 Optional dependencies
 ---------------------
 
-xCDAT includes APIs that can be enabled by installing optional dependencies.
-These dependencies are optional because they might not be supported on specific platforms (e.g., osx-arm64, windows).
-
+`xcdat` includes APIs that are enabled by installing optional dependencies.
+When installing `xcdat`, conda will attempt to also install these optional dependencies. However, some optional dependencies might be skipped if your platform does not support it (e.g., osx-arm64, windows).
+Refer to the list below for more details.
 
 Regridding
 ~~~~~~~~~~
 
-* ``xesmf``: required to enable horizontal regridding with ``xesmf``, currently not supported on `osx-arm64`_ and `windows`_
-
+* ``xesmf``: required to enable horizontal regridding with ``xesmf``
+  * Currently not supported on `osx-arm64`_ and `windows`_
   * Inherently, ``xcdat``'s ``xesmf`` `horizontal regridding API <generated/xcdat.regridder.xesmf.XESMFRegridder.rst>`_ is not supported on these platforms.
 
 .. _windows: https://github.com/conda-forge/esmf-feedstock/issues/64

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -73,8 +73,7 @@ Installation
 Optional dependencies
 ---------------------
 
-``xcdat`` includes APIs that are enabled by installing optional dependencies. conda will automatically attempt to install these optional dependencies with ``xcdat``.
-However, some optional dependencies might be skipped if your platform does not support it (e.g., ``osx-arm64``, ``windows``). ``windows`` users can try `WSL2`_ as a workaround.
+``xcdat`` includes APIs that are enabled by installing optional dependencies. conda will automatically attempt to install these optional dependencies with ``xcdat``. However, some optional dependencies might be skipped if your platform does not support it (e.g., ``osx-arm64``, ``windows``). ``windows`` users can try `WSL2`_ as a workaround.
 
 .. _WSL2: https://docs.microsoft.com/en-us/windows/wsl/install
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -48,7 +48,7 @@ Installation
        >>> conda create -n <ENV_NAME> -c conda-forge xcdat xesmf
        >>> conda activate <ENV_NAME>
 
-   Note that ``xesmf`` is an optional dependency, which is required using for ``xesmf``
+   Note that ``xesmf`` is an optional dependency, which is required for using ``xesmf``
    based horizontal regridding APIs in ``xcdat``. ``xesmf`` is not currently supported
    on `osx-arm64`_ or `windows`_ because ``esmpy`` is not yet available on these
    platforms. Windows users can try `WSL2`_ as a workaround.

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -48,7 +48,7 @@ Installation
        >>> conda create -n <ENV_NAME> -c conda-forge xcdat xesmf
        >>> conda activate <ENV_NAME>
 
-   Note that ``xesmf`` is an optional dependency, which is required using ``xesmf``
+   Note that ``xesmf`` is an optional dependency, which is required using for ``xesmf``
    based horizontal regridding APIs in ``xcdat``. ``xesmf`` is not currently supported
    on `osx-arm64`_ or `windows`_ because ``esmpy`` is not yet available on these
    platforms. Windows users can try `WSL2`_ as a workaround.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,5 +4,4 @@ from xarray.tests import _importorskip, requires_dask  # noqa: F401
 
 set_options(warn_for_unclosed_files=False)
 
-
 has_xesmf, requires_xesmf = _importorskip("xesmf")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,8 @@
 """Unit test package for xcdat."""
 from xarray.core.options import set_options
-from xarray.tests import requires_dask  # noqa: F401
+from xarray.tests import _importorskip, requires_dask  # noqa: F401
 
 set_options(warn_for_unclosed_files=False)
+
+
+has_xesmf, requires_xesmf = _importorskip("xesmf")

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -7,8 +7,11 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from tests import fixtures
-from xcdat.regridder import accessor, base, grid, regrid2, xesmf
+from tests import fixtures, has_xesmf, requires_xesmf
+from xcdat.regridder import accessor, base, grid, regrid2
+
+if has_xesmf:
+    from xcdat.regridder import xesmf
 
 np.set_printoptions(threshold=sys.maxsize, suppress=True)
 
@@ -409,11 +412,11 @@ class TestRegrid2Regridder:
         assert north[0], north[-1] == (60, 90)
 
 
+@requires_xesmf
 class TestXESMFRegridder:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.ds = fixtures.generate_dataset(cf_compliant=True, has_bounds=True)
-
         self.new_grid = grid.create_uniform_grid(-90, 90, 4.0, -180, 180, 5.0)
 
     def test_regrid(self):
@@ -616,6 +619,7 @@ class TestAccessor:
         ):
             self.ac.horizontal("ts", mock.MagicMock(), "test")  # type: ignore
 
+    @requires_xesmf
     @pytest.mark.filterwarnings("ignore:.*invalid value.*true_divide.*:RuntimeWarning")
     def test_convenience_methods(self):
         ds = fixtures.generate_dataset(cf_compliant=True, has_bounds=True)

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -419,6 +419,13 @@ class TestXESMFRegridder:
         self.ds = fixtures.generate_dataset(cf_compliant=True, has_bounds=True)
         self.new_grid = grid.create_uniform_grid(-90, 90, 4.0, -180, 180, 5.0)
 
+    @pytest.mark.xfail
+    def test_raises_error_if_xesmf_is_not_installed(self):
+        # TODO Find a way to mock the value of `_has_xesmf` to False or
+        # to remove the `xesmf` module entirely
+        with pytest.raises(ModuleNotFoundError):
+            xesmf.XESMFRegridder(self.ds, self.new_grid, "bilinear")
+
     def test_regrid(self):
         ds = self.ds.copy()
 
@@ -633,6 +640,16 @@ class TestAccessor:
         output_regrid2 = ds.regridder.horizontal_regrid2("ts", out_grid)
 
         assert output_regrid2.ts.shape == (15, 32, 65)
+
+    @pytest.mark.xfail
+    def test_raises_error_if_xesmf_is_not_installed(self):
+        # TODO Find a way to mock the value of `_has_xesmf` to False or
+        # to remove the `xesmf` module entirely
+        ds = fixtures.generate_dataset(cf_compliant=True, has_bounds=True)
+
+        out_grid = grid.create_gaussian_grid(32)
+        with pytest.raises(ModuleNotFoundError):
+            ds.regridder.horizontal_xesmf("ts", out_grid, method="bilinear")
 
 
 class TestBase:

--- a/xcdat/__init__.py
+++ b/xcdat/__init__.py
@@ -7,20 +7,14 @@ from xcdat.axis import (  # noqa: F401
 )
 from xcdat.bounds import BoundsAccessor  # noqa: F401
 from xcdat.dataset import decode_non_cf_time, open_dataset, open_mfdataset  # noqa: F401
-# esmpy, xesmf dependency not solved for osx-arm64 https://github.com/conda-forge/esmpy-feedstock/issues/55
-# _importorskip is another option if these accumulate https://github.com/pydata/xarray/blob/main/xarray/tests/__init__.py#L29-L60
-# discussion: https://github.com/xCDAT/xcdat/issues/315
-try:
-    from xcdat.regridder.accessor import RegridderAccessor  # noqa: F401
-    from xcdat.regridder.grid import (  # noqa: F401
-        create_gaussian_grid,
-        create_global_mean_grid,
-        create_grid,
-        create_uniform_grid,
-        create_zonal_grid,
-    )
-except ImportError:
-    pass
+from xcdat.regridder.accessor import RegridderAccessor  # noqa: F401
+from xcdat.regridder.grid import (  # noqa: F401
+    create_gaussian_grid,
+    create_global_mean_grid,
+    create_grid,
+    create_uniform_grid,
+    create_zonal_grid,
+)
 from xcdat.spatial import SpatialAccessor  # noqa: F401
 from xcdat.temporal import TemporalAccessor  # noqa: F401
 from xcdat.utils import compare_datasets  # noqa: F401

--- a/xcdat/__init__.py
+++ b/xcdat/__init__.py
@@ -7,14 +7,20 @@ from xcdat.axis import (  # noqa: F401
 )
 from xcdat.bounds import BoundsAccessor  # noqa: F401
 from xcdat.dataset import decode_non_cf_time, open_dataset, open_mfdataset  # noqa: F401
-from xcdat.regridder.accessor import RegridderAccessor  # noqa: F401
-from xcdat.regridder.grid import (  # noqa: F401
-    create_gaussian_grid,
-    create_global_mean_grid,
-    create_grid,
-    create_uniform_grid,
-    create_zonal_grid,
-)
+# esmpy, xesmf dependency not solved for osx-arm64 https://github.com/conda-forge/esmpy-feedstock/issues/55
+# _importorskip is another option if these accumulate https://github.com/pydata/xarray/blob/main/xarray/tests/__init__.py#L29-L60
+# discussion: https://github.com/xCDAT/xcdat/issues/315
+try:
+    from xcdat.regridder.accessor import RegridderAccessor  # noqa: F401
+    from xcdat.regridder.grid import (  # noqa: F401
+        create_gaussian_grid,
+        create_global_mean_grid,
+        create_grid,
+        create_uniform_grid,
+        create_zonal_grid,
+    )
+except ImportError:
+    pass
 from xcdat.spatial import SpatialAccessor  # noqa: F401
 from xcdat.temporal import TemporalAccessor  # noqa: F401
 from xcdat.utils import compare_datasets  # noqa: F401

--- a/xcdat/regridder/__init__.py
+++ b/xcdat/regridder/__init__.py
@@ -1,3 +1,10 @@
 from xcdat.regridder.accessor import RegridderAccessor
 from xcdat.regridder.regrid2 import Regrid2Regridder
-from xcdat.regridder.xesmf import XESMFRegridder
+# esmpy, xesmf dependency not solved for osx-arm64 https://github.com/conda-forge/esmpy-feedstock/issues/55
+# _importorskip is another option if these accumulate https://github.com/pydata/xarray/blob/main/xarray/tests/__init__.py#L29-L60
+# discussion: https://github.com/xCDAT/xcdat/issues/315
+try:
+    from xcdat.regridder.xesmf import XESMFRegridder
+except ImportError:
+    print("xesmf module not available")
+    pass

--- a/xcdat/regridder/__init__.py
+++ b/xcdat/regridder/__init__.py
@@ -2,6 +2,6 @@ from xcdat.regridder.accessor import RegridderAccessor
 from xcdat.regridder.regrid2 import Regrid2Regridder
 from xcdat.utils import _has_module
 
-has_xesmf = _has_module("xesmf")
-if has_xesmf:
+_has_xesmf = _has_module("xesmf")
+if _has_xesmf:
     from xcdat.regridder.xesmf import XESMFRegridder

--- a/xcdat/regridder/__init__.py
+++ b/xcdat/regridder/__init__.py
@@ -1,10 +1,7 @@
 from xcdat.regridder.accessor import RegridderAccessor
 from xcdat.regridder.regrid2 import Regrid2Regridder
-# esmpy, xesmf dependency not solved for osx-arm64 https://github.com/conda-forge/esmpy-feedstock/issues/55
-# _importorskip is another option if these accumulate https://github.com/pydata/xarray/blob/main/xarray/tests/__init__.py#L29-L60
-# discussion: https://github.com/xCDAT/xcdat/issues/315
-try:
+from xcdat.utils import _has_module
+
+has_xesmf = _has_module("xesmf")
+if has_xesmf:
     from xcdat.regridder.xesmf import XESMFRegridder
-except ImportError:
-    print("xesmf module not available")
-    pass

--- a/xcdat/regridder/accessor.py
+++ b/xcdat/regridder/accessor.py
@@ -197,7 +197,7 @@ class RegridderAccessor:
         self,
         data_var: str,
         output_grid: xr.Dataset,
-        tool: RegridTool,
+        tool: RegridTool = "xesmf",
         **options: Dict[str, Any],
     ) -> xr.Dataset:
         """

--- a/xcdat/regridder/accessor.py
+++ b/xcdat/regridder/accessor.py
@@ -3,13 +3,11 @@ from typing import Any, Dict, Literal, Tuple
 import xarray as xr
 
 from xcdat.axis import CFAxisName, get_axis_coord
-from xcdat.regridder import regrid2
-from xcdat.utils import _has_module
+from xcdat.regridder import has_xesmf, regrid2
 
 RegridTool = Literal["xesmf", "regrid2"]
 REGRID_TOOLS = {"regrid2": regrid2.Regrid2Regridder}
 
-has_xesmf = _has_module("xesmf")
 if has_xesmf:
     from xcdat.regridder import xesmf
 

--- a/xcdat/regridder/accessor.py
+++ b/xcdat/regridder/accessor.py
@@ -197,7 +197,7 @@ class RegridderAccessor:
         self,
         data_var: str,
         output_grid: xr.Dataset,
-        tool: RegridTool = "xesmf",
+        tool: RegridTool,
         **options: Dict[str, Any],
     ) -> xr.Dataset:
         """

--- a/xcdat/regridder/accessor.py
+++ b/xcdat/regridder/accessor.py
@@ -14,6 +14,7 @@ try:
         "xesmf": xesmf.XESMFRegridder,
         "regrid2": regrid2.Regrid2Regridder,
     }
+    xesmfAvailable = True
 except ImportError:
     from xcdat.regridder import regrid2
     RegridTool = Literal["regrid2"]

--- a/xcdat/regridder/accessor.py
+++ b/xcdat/regridder/accessor.py
@@ -3,25 +3,17 @@ from typing import Any, Dict, Literal, Tuple
 import xarray as xr
 
 from xcdat.axis import CFAxisName, get_axis_coord
+from xcdat.regridder import regrid2
+from xcdat.utils import _has_module
 
-# esmpy, xesmf dependency not solved for osx-arm64 https://github.com/conda-forge/esmpy-feedstock/issues/55
-# _importorskip is another option if these accumulate https://github.com/pydata/xarray/blob/main/xarray/tests/__init__.py#L29-L60
-# discussion: https://github.com/xCDAT/xcdat/issues/315
-try:
-    from xcdat.regridder import regrid2, xesmf
-    RegridTool = Literal["xesmf", "regrid2"]
-    REGRID_TOOLS = {
-        "xesmf": xesmf.XESMFRegridder,
-        "regrid2": regrid2.Regrid2Regridder,
-    }
-    xesmfAvailable = True
-except ImportError:
-    from xcdat.regridder import regrid2
-    RegridTool = Literal["regrid2"]
-    REGRID_TOOLS = {
-        "regrid2": regrid2.Regrid2Regridder,
-    }
-    xesmfAvailable = False
+RegridTool = Literal["xesmf", "regrid2"]
+REGRID_TOOLS = {"regrid2": regrid2.Regrid2Regridder}
+
+has_xesmf = _has_module("xesmf")
+if has_xesmf:
+    from xcdat.regridder import xesmf
+
+    REGRID_TOOLS["xesmf"] = xesmf.XESMFRegridder  # type: ignore
 
 
 @xr.register_dataset_accessor(name="regridder")
@@ -97,54 +89,60 @@ class RegridderAccessor:
 
         return coord_var, bounds_var
 
-    if xesmfAvailable:
-        def horizontal_xesmf(
-            self,
-            data_var: str,
-            output_grid: xr.Dataset,
-            **options: Dict[str, Any],
-        ) -> xr.Dataset:
-            """
-            Wraps the xESMF library providing access to regridding between
-            structured rectilinear and curvilinear grids.
+    def horizontal_xesmf(
+        self,
+        data_var: str,
+        output_grid: xr.Dataset,
+        **options: Dict[str, Any],
+    ) -> xr.Dataset:
+        """
+        Wraps the xESMF library providing access to regridding between
+        structured rectilinear and curvilinear grids.
 
-            Regrids ``data_var`` in dataset to ``output_grid``.
+        Regrids ``data_var`` in dataset to ``output_grid``.
 
-            Option documentation :py:func:`xcdat.regridder.xesmf.XESMFRegridder`
+        Option documentation :py:func:`xcdat.regridder.xesmf.XESMFRegridder`
 
-            Parameters
-            ----------
-            data_var: str
-                Name of the variable in the `xr.Dataset` to regrid.
-            output_grid : xr.Dataset
-                Dataset containing output grid.
-            options : Dict[str, Any]
-                Dictionary with extra parameters for the regridder.
+        Parameters
+        ----------
+        data_var: str
+            Name of the variable in the `xr.Dataset` to regrid.
+        output_grid : xr.Dataset
+            Dataset containing output grid.
+        options : Dict[str, Any]
+            Dictionary with extra parameters for the regridder.
 
-            Returns
-            -------
-            xr.Dataset
-                With the ``data_var`` variable on the grid defined in ``output_grid``.
+        Returns
+        -------
+        xr.Dataset
+            With the ``data_var`` variable on the grid defined in ``output_grid``.
 
-            Raises
-            ------
-            ValueError
-                If tool is not supported.
+        Raises
+        ------
+        ValueError
+            If tool is not supported.
 
-            Examples
-            --------
+        Examples
+        --------
 
-            Generate output grid:
+        Generate output grid:
 
-            >>> output_grid = xcdat.create_gaussian_grid(32)
+        >>> output_grid = xcdat.create_gaussian_grid(32)
 
-            Regrid data to output grid using regrid2:
+        Regrid data to output grid using xesmf:
 
-            >>> ds.regridder.horizontal_regrid2("ts", output_grid)
-            """
+        >>> ds.regridder.horizontal_xesmf("ts", output_grid)
+        """
+        if has_xesmf:
             regridder = REGRID_TOOLS["xesmf"](self._ds, output_grid, **options)
 
             return regridder.horizontal(data_var, self._ds)
+        else:
+            raise ModuleNotFoundError(
+                "The `xesmf` package is required for horizontal regridding with "
+                "`xesmf`. Make sure your platform supports `xesmf` and it is installed "
+                "in your conda environment."
+            )
 
     def horizontal_regrid2(
         self,
@@ -256,6 +254,13 @@ class RegridderAccessor:
 
         >>> ds.regridder.horizontal_regrid2("ts", output_grid)
         """
+        if tool == "xesmf" and not has_xesmf:
+            raise ModuleNotFoundError(
+                "The `xesmf` package is required for horizontal regridding with "
+                "`xesmf`. Make sure your platform supports `xesmf` and it is installed "
+                "in your conda environment."
+            )
+
         try:
             regrid_tool = REGRID_TOOLS[tool]
         except KeyError as e:
@@ -264,7 +269,6 @@ class RegridderAccessor:
             )
 
         regridder = regrid_tool(self._ds, output_grid, **options)
-
         output_ds = regridder.horizontal(data_var, self._ds)
 
         return output_ds

--- a/xcdat/regridder/accessor.py
+++ b/xcdat/regridder/accessor.py
@@ -3,12 +3,14 @@ from typing import Any, Dict, Literal, Tuple
 import xarray as xr
 
 from xcdat.axis import CFAxisName, get_axis_coord
-from xcdat.regridder import has_xesmf, regrid2
+from xcdat.regridder import regrid2
+from xcdat.utils import _has_module
 
 RegridTool = Literal["xesmf", "regrid2"]
 REGRID_TOOLS = {"regrid2": regrid2.Regrid2Regridder}
 
-if has_xesmf:
+_has_xesmf = _has_module("xesmf")
+if _has_xesmf:
     from xcdat.regridder import xesmf
 
     REGRID_TOOLS["xesmf"] = xesmf.XESMFRegridder  # type: ignore
@@ -131,7 +133,7 @@ class RegridderAccessor:
 
         >>> ds.regridder.horizontal_xesmf("ts", output_grid)
         """
-        if has_xesmf:
+        if _has_xesmf:
             regridder = REGRID_TOOLS["xesmf"](self._ds, output_grid, **options)
 
             return regridder.horizontal(data_var, self._ds)
@@ -252,7 +254,7 @@ class RegridderAccessor:
 
         >>> ds.regridder.horizontal_regrid2("ts", output_grid)
         """
-        if tool == "xesmf" and not has_xesmf:
+        if tool == "xesmf" and not _has_xesmf:
             raise ModuleNotFoundError(
                 "The `xesmf` package is required for horizontal regridding with "
                 "`xesmf`. Make sure your platform supports `xesmf` and it is installed "

--- a/xcdat/regridder/accessor.py
+++ b/xcdat/regridder/accessor.py
@@ -9,8 +9,9 @@ from xcdat.utils import _has_module
 RegridTool = Literal["xesmf", "regrid2"]
 REGRID_TOOLS = {"regrid2": regrid2.Regrid2Regridder}
 
+# TODO: Test this conditional.
 _has_xesmf = _has_module("xesmf")
-if _has_xesmf:
+if _has_xesmf:  # pragma: no cover
     from xcdat.regridder import xesmf
 
     REGRID_TOOLS["xesmf"] = xesmf.XESMFRegridder  # type: ignore
@@ -133,11 +134,12 @@ class RegridderAccessor:
 
         >>> ds.regridder.horizontal_xesmf("ts", output_grid)
         """
-        if _has_xesmf:
+        # TODO: Test this conditional.
+        if _has_xesmf:  # pragma: no cover
             regridder = REGRID_TOOLS["xesmf"](self._ds, output_grid, **options)
 
             return regridder.horizontal(data_var, self._ds)
-        else:
+        else:  # pragma: no cover
             raise ModuleNotFoundError(
                 "The `xesmf` package is required for horizontal regridding with "
                 "`xesmf`. Make sure your platform supports `xesmf` and it is installed "
@@ -254,7 +256,8 @@ class RegridderAccessor:
 
         >>> ds.regridder.horizontal_regrid2("ts", output_grid)
         """
-        if tool == "xesmf" and not _has_xesmf:
+        # TODO: Test this conditional.
+        if tool == "xesmf" and not _has_xesmf:  # pragma: no cover
             raise ModuleNotFoundError(
                 "The `xesmf` package is required for horizontal regridding with "
                 "`xesmf`. Make sure your platform supports `xesmf` and it is installed "

--- a/xcdat/regridder/accessor.py
+++ b/xcdat/regridder/accessor.py
@@ -21,7 +21,6 @@ except ImportError:
     REGRID_TOOLS = {
         "regrid2": regrid2.Regrid2Regridder,
     }
-    print("xesmf module not available")
     xesmfAvailable = False
 
 

--- a/xcdat/regridder/xesmf.py
+++ b/xcdat/regridder/xesmf.py
@@ -1,15 +1,18 @@
 import xarray as xr
-# esmpy, xesmf dependency not solved for osx-arm64 https://github.com/conda-forge/esmpy-feedstock/issues/55
-# _importorskip is another option if these accumulate https://github.com/pydata/xarray/blob/main/xarray/tests/__init__.py#L29-L60
-# discussion: https://github.com/xCDAT/xcdat/issues/315
-# try:
-import xesmf as xe
-# except ModuleNotFoundError:
-#    raise ModuleNotFoundError("xesmf module not available")
-# except ImportError:
-#    raise ImportError("xesmf module not available")
 
 from xcdat.regridder.base import BaseRegridder, preserve_bounds
+from xcdat.utils import _has_module
+
+has_xesmf = _has_module("xesmf")
+if has_xesmf:
+    import xesmf as xe
+else:
+    raise ModuleNotFoundError(
+        "The `xesmf` package is required for horizontal regridding with `xesmf`. Make "
+        "sure your platform supports `xesmf` and it is installed in your conda "
+        "environment."
+    )
+
 
 VALID_METHODS = [
     "bilinear",

--- a/xcdat/regridder/xesmf.py
+++ b/xcdat/regridder/xesmf.py
@@ -3,8 +3,8 @@ import xarray as xr
 from xcdat.regridder.base import BaseRegridder, preserve_bounds
 from xcdat.utils import _has_module
 
-has_xesmf = _has_module("xesmf")
-if has_xesmf:
+_has_xesmf = _has_module("xesmf")
+if _has_xesmf:
     import xesmf as xe
 else:
     raise ModuleNotFoundError(

--- a/xcdat/regridder/xesmf.py
+++ b/xcdat/regridder/xesmf.py
@@ -2,10 +2,12 @@ import xarray as xr
 # esmpy, xesmf dependency not solved for osx-arm64 https://github.com/conda-forge/esmpy-feedstock/issues/55
 # _importorskip is another option if these accumulate https://github.com/pydata/xarray/blob/main/xarray/tests/__init__.py#L29-L60
 # discussion: https://github.com/xCDAT/xcdat/issues/315
-try:
-    import xesmf as xe
-except ImportError:
-    raise ImportError("xesmf module not available")
+# try:
+import xesmf as xe
+# except ModuleNotFoundError:
+#    raise ModuleNotFoundError("xesmf module not available")
+# except ImportError:
+#    raise ImportError("xesmf module not available")
 
 from xcdat.regridder.base import BaseRegridder, preserve_bounds
 

--- a/xcdat/regridder/xesmf.py
+++ b/xcdat/regridder/xesmf.py
@@ -5,8 +5,7 @@ import xarray as xr
 try:
     import xesmf as xe
 except ImportError:
-    print("xesmf module not available")
-    pass
+    raise ImportError("xesmf module not available")
 
 from xcdat.regridder.base import BaseRegridder, preserve_bounds
 

--- a/xcdat/regridder/xesmf.py
+++ b/xcdat/regridder/xesmf.py
@@ -3,10 +3,11 @@ import xarray as xr
 from xcdat.regridder.base import BaseRegridder, preserve_bounds
 from xcdat.utils import _has_module
 
+# TODO: Test this conditional.
 _has_xesmf = _has_module("xesmf")
-if _has_xesmf:
+if _has_xesmf:  # pragma: no cover
     import xesmf as xe
-else:
+else:  # pragma: no cover
     raise ModuleNotFoundError(
         "The `xesmf` package is required for horizontal regridding with `xesmf`. Make "
         "sure your platform supports `xesmf` and it is installed in your conda "

--- a/xcdat/regridder/xesmf.py
+++ b/xcdat/regridder/xesmf.py
@@ -1,5 +1,12 @@
 import xarray as xr
-import xesmf as xe
+# esmpy, xesmf dependency not solved for osx-arm64 https://github.com/conda-forge/esmpy-feedstock/issues/55
+# _importorskip is another option if these accumulate https://github.com/pydata/xarray/blob/main/xarray/tests/__init__.py#L29-L60
+# discussion: https://github.com/xCDAT/xcdat/issues/315
+try:
+    import xesmf as xe
+except ImportError:
+    print("xesmf module not available")
+    pass
 
 from xcdat.regridder.base import BaseRegridder, preserve_bounds
 

--- a/xcdat/utils.py
+++ b/xcdat/utils.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 from typing import Dict, List
 
@@ -85,3 +86,24 @@ def str_to_bool(attr: str) -> bool:
 
     bool_attr = json.loads(attr.lower())
     return bool_attr
+
+
+def _has_module(modname: str) -> bool:  # pragma: no cover
+    """Checks module is installed in the environment.
+
+    Parameters
+    ----------
+    modname : str
+        The name of the module.
+
+    Returns
+    -------
+    bool
+    """
+    try:
+        importlib.import_module(modname)
+        has = True
+    except ImportError:
+        has = False
+
+    return has

--- a/xcdat/utils.py
+++ b/xcdat/utils.py
@@ -89,7 +89,7 @@ def str_to_bool(attr: str) -> bool:
 
 
 def _has_module(modname: str) -> bool:  # pragma: no cover
-    """Checks module is installed in the environment.
+    """Checks if the specified module is installed in the Python environment.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description
This PR attempts to create a conda dev env omitting `esmpy` and `xesmf`. There is also a problem with `pandoc` on `osx-arm64` which is a [similar platform support issue, with the 2.19 release labelled "broken"](https://anaconda.org/conda-forge/pandoc/files?version=2.19) but not directly related.

- [x] Closes #333 
- [x] Remove `esmpy` from conda env dependencies since it isn't directly imported in `xcdat`

Companion PR for package recipe: [Bump to v0.3.2 and make xesmf an optional dependency #14 ](https://github.com/conda-forge/xcdat-feedstock/pull/14)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

I have tested this change across platforms:
- [x] `osx-arm64`
- [ ] `osx-64`
- [ ] `linux-64` - currently fails to install `esmpy=8.2.0` even though it is available
- [ ] `windows`
- [ ] `windows - subsystem for linux (WSL)`

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)

@tomvothecoder @jasonb5 @pochedls ping