### PR TITLE
Fix spatial bugs: handle datasets with domain bounds out of order and zonal averaging

### DIFF
--- a/xcdat/spatial.py
+++ b/xcdat/spatial.py
@@ -333,8 +333,8 @@ class SpatialAccessor:
             new_domain_bounds[index_bad_cells, 1] = domain_bounds[index_bad_cells, 0]
 
             return new_domain_bounds
-        else:
-            return domain_bounds
+
+        return domain_bounds
 
     def _validate_region_bounds(self, axis: SpatialAxis, bounds: RegionAxisBounds):
         """Validates the ``bounds`` arg based on a set of criteria.

--- a/xcdat/spatial.py
+++ b/xcdat/spatial.py
@@ -263,6 +263,10 @@ class SpatialAccessor:
 
         for key in axis:
             d_bounds = axis_bounds[key]["domain"]
+            # the logic for generating longitude weights depends on the
+            # bounds being ordered such that d_bounds[:, 0] < d_bounds[:, 1]
+            # they are re-ordered (if need be) for the purpose of creating
+            # weights
             d_bounds = self._force_domain_order_low_to_high(d_bounds)
 
             r_bounds: Union[Optional[RegionAxisBounds], np.ndarray] = axis_bounds[key][


### PR DESCRIPTION
## Description
This PR is intended to fix #324 and #338. It allows users to perform spatial averaging on datasets in which `domain_bounds[:, 0] > domain_bounds[:, 1]` by re-ordering the domain bounds for the purposes of calculating spatial weights. It also fixes an issue that prevented spatial averaging on lat-plev grids. A section of the code tried to load longitude bounds even when that axis was not specified for averaging; this section of code is updated to only load bounds information if the axis is specified for averaging. 

- Closes #324, #338

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
