### PR TITLE
modify preserve bounds logic

### DIFF
--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -641,16 +641,12 @@ class TestBase:
 
         output_ds = base.preserve_bounds(ds_with_bounds, ds_without_bounds, target)
 
-        assert "lat_bnds" in output_ds
-        assert "lon_bnds" in output_ds
         assert "time_bnds" in output_ds
 
         target = xr.Dataset()
 
         output_ds = base.preserve_bounds(ds_without_bounds, ds_without_bounds, target)
 
-        assert "lat_bnds" not in output_ds
-        assert "lon_bnds" not in output_ds
         assert "time_bnds" in output_ds
 
     def test_regridder_implementation(self):

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -641,12 +641,16 @@ class TestBase:
 
         output_ds = base.preserve_bounds(ds_with_bounds, ds_without_bounds, target)
 
+        assert "lat_bnds" not in output_ds
+        assert "lon_bnds" not in output_ds
         assert "time_bnds" in output_ds
 
         target = xr.Dataset()
 
         output_ds = base.preserve_bounds(ds_without_bounds, ds_without_bounds, target)
 
+        assert "lat_bnds" not in output_ds
+        assert "lon_bnds" not in output_ds
         assert "time_bnds" in output_ds
 
     def test_regridder_implementation(self):

--- a/xcdat/regridder/base.py
+++ b/xcdat/regridder/base.py
@@ -10,11 +10,11 @@ logger = setup_custom_logger(__name__)
 
 
 def preserve_bounds(
-    source: xr.Dataset, source_grid: xr.Dataset, target: xr.Dataset
+    source: xr.Dataset, target_grid: xr.Dataset, target: xr.Dataset
 ) -> xr.Dataset:
     """Preserves bounds from sources to target.
 
-    Preserve the lat/lon bounds from `source_grid` to `target`.
+    Ensure the lat/lon bounds from `target_grid` are included in the `target` dataset.
 
     Preserve any additional bounds e.g. time, vertical from `source` to `target`.
 
@@ -22,8 +22,8 @@ def preserve_bounds(
     ----------
     source : xr.Dataset
         Source Dataset.
-    source_grid : xr.Dataset
-        Source grid Dataset.
+    target_grid : xr.Dataset
+        Target grid Dataset.
     target : xr.Dataset
         Target Dataset to preserve bounds to.
 
@@ -33,14 +33,14 @@ def preserve_bounds(
         Target Dataset with preserved bounds.
     """
     try:
-        lat_bnds = source_grid.bounds.get_bounds("Y")
+        lat_bnds = target_grid.bounds.get_bounds("Y")
     except KeyError:
         pass
     else:
         target[lat_bnds.name] = lat_bnds.copy()
 
     try:
-        lon_bnds = source_grid.bounds.get_bounds("X")
+        lon_bnds = target_grid.bounds.get_bounds("X")
     except KeyError:
         pass
     else:
@@ -54,6 +54,9 @@ def preserve_bounds(
         else:
             if source_bnds.name in target:
                 logger.debug(f"Bounds {source_bnds.name!r} already present")
+            elif dim_name in ["X", "Y"]:
+                # the X / Y bounds are copied from the target grid above
+                continue
             else:
                 target[source_bnds.name] = source_bnds.copy()
 


### PR DESCRIPTION
## Description
This resolves an issue in which the bounds are populated by NaN values after regridding. The issue was related to functionality to preserve the source grid bounds in the target grid. Sometimes this functionality would result in multiple bounds (with different names) being saved for a single spatial axis (though I'm not sure why the values were NaN). 

- Closes #316
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
