### PR TITLE
Automate release notes generation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,19 @@
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
+autolabeler:
+  - label: 'Type: Enhancement'
+    branch:
+      - '/feature\/.+/'
+  - label: 'Type: Bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+    - label: 'Type: Documentation'
+    files:
+      - '*.rst'
+    branch:
+      - '/docs{0,1}\/.+/'
 categories:
     - title: "Features"
       labels: "Type: Enhancement"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -14,6 +14,9 @@ autolabeler:
           - "*.rst"
       branch:
           - '/docs{0,1}\/.+/'
+    - label: "Type: DevOps"
+      branch:
+          - '/devops\/.+/'
 categories:
     - title: "Features"
       labels: "Type: Enhancement"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+    - title: "Features"
+      labels: "Type: Enhancement"
+    - title: "Bug Fixes"
+      labels: "Type: Bug"
+    - title: "Documentation"
+      label: "Type: Documentation"
+    - title: "DevOps"
+      label: "Type: DevOps"
+change-template: "- $TITLE by @$AUTHOR in $URL"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+exclude-labels: "skip-changelog"
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+    ## Changes
+
+    $CHANGES
+footer: |
+    **Full Changelog**: https://github.com/xCDAT/xcdat/compare/$PREVIOUS_TAG...$RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,7 +4,7 @@ autolabeler:
     - label: "Type: Enhancement"
       branch: '/feature\/.+/'
     - label: "Type: Bug"
-      branch: '/fix\/.+/'
+      branch: '/(bug)?fix\/.+/'
       title: "/fix/i"
     - label: "Type: Documentation"
       files: "*.rst"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,21 +2,15 @@ name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 autolabeler:
     - label: "Type: Enhancement"
-      branch:
-          - '/feature\/.+/'
+      branch: '/feature\/.+/'
     - label: "Type: Bug"
-      branch:
-          - '/fix\/.+/'
-      title:
-          - "/fix/i"
+      branch: '/fix\/.+/'
+      title: "/fix/i"
     - label: "Type: Documentation"
-      files:
-          - "*.rst"
-      branch:
-          - '/docs{0,1}\/.+/'
+      files: "*.rst"
+      branch: '/docs{0,1}\/.+/'
     - label: "Type: DevOps"
-      branch:
-          - '/devops\/.+/'
+      branch: '/devops\/.+/'
 categories:
     - title: "Features"
       labels: "Type: Enhancement"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,19 +1,19 @@
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 autolabeler:
-  - label: 'Type: Enhancement'
-    branch:
-      - '/feature\/.+/'
-  - label: 'Type: Bug'
-    branch:
-      - '/fix\/.+/'
-    title:
-      - '/fix/i'
-    - label: 'Type: Documentation'
-    files:
-      - '*.rst'
-    branch:
-      - '/docs{0,1}\/.+/'
+    - label: "Type: Enhancement"
+      branch:
+          - '/feature\/.+/'
+    - label: "Type: Bug"
+      branch:
+          - '/fix\/.+/'
+      title:
+          - "/fix/i"
+    - label: "Type: Documentation"
+      files:
+          - "*.rst"
+      branch:
+          - '/docs{0,1}\/.+/'
 categories:
     - title: "Features"
       labels: "Type: Enhancement"
@@ -27,16 +27,16 @@ change-template: "- $TITLE by @$AUTHOR in $URL"
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 exclude-labels: "skip-changelog"
 version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
+    major:
+        labels:
+            - "major"
+    minor:
+        labels:
+            - "minor"
+    patch:
+        labels:
+            - "patch"
+    default: patch
 template: |
     ## Changes
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,32 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,9 +9,6 @@ on:
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #366 
- Uses GH Actions `release-drafter` action
- Resolves the next version based on the PR labels
- Categorizes merged PR commits based on PR labels
- Note, release-drafter job will fail because the config file has to be on `master` first.
  - https://github.com/release-drafter/release-drafter/issues/365
  
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
