### PR TITLE
Wrap open_dataset and open_mfdataset to flexibly open datasets

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -13,6 +13,7 @@ dependencies:
     - cftime
     - dask
     - esmpy
+    - lxml
     - netcdf4
     - numpy
     - pandas

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -13,6 +13,7 @@ dependencies:
     - cf_xarray=0.7.7
     - cftime=1.6.2
     - dask=2023.1.0
+    - lxml=4.9.2
     - netcdf4=1.6.2
     - numpy=1.23.5
     - pandas=1.5.3

--- a/conda-env/readthedocs.yml
+++ b/conda-env/readthedocs.yml
@@ -12,6 +12,7 @@ dependencies:
     - cf_xarray=0.7.7
     - cftime=1.6.2
     - dask=2023.1.0
+    - lxml=4.9.2
     - netcdf4=1.6.2
     - numpy=1.23.5
     - pandas=1.5.3

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -642,7 +642,7 @@ class TestOpenMfDataset:
         with pytest.raises(KeyError):
             open_mfdataset(xml_path, decode_times=True)
 
-    def test_opens_datasets_from_xml(self):
+    def test_opens_datasets_from_xml_using_str_path(self):
         ds1 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
         ds1.to_netcdf(self.file_path1)
         ds2 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
@@ -651,6 +651,24 @@ class TestOpenMfDataset:
 
         # Create the XML file
         xml_path = f"{self.dir}/datasets.xml"
+        page = etree.Element("dataset", directory=str(self.dir))
+        doc = etree.ElementTree(page)
+        doc.write(xml_path, xml_declaration=True, encoding="utf-16")
+
+        result = open_mfdataset(xml_path, decode_times=True)
+        expected = ds1.merge(ds2)
+
+        result.identical(expected)
+
+    def test_opens_datasets_from_xml_using_pathlib_path(self):
+        ds1 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
+        ds1.to_netcdf(self.file_path1)
+        ds2 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
+        ds2 = ds2.rename_vars({"ts": "tas"})
+        ds2.to_netcdf(self.file_path2)
+
+        # Create the XML file
+        xml_path = self.dir / "datasets.xml"
         page = etree.Element("dataset", directory=str(self.dir))
         doc = etree.ElementTree(page)
         doc.write(xml_path, xml_declaration=True, encoding="utf-16")

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -626,7 +626,7 @@ class TestOpenMfDataset:
         expected = ds1.merge(ds2)
         assert result.identical(expected)
 
-    def test_raises_error_if_xml_does_not_have_root_direcory(self):
+    def test_raises_error_if_xml_does_not_have_root_directory_attr(self):
         ds1 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
         ds1.to_netcdf(self.file_path1)
         ds2 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -627,11 +627,6 @@ class TestOpenMfDataset:
         assert result.identical(expected)
 
     def test_raises_error_if_xml_does_not_have_root_direcory(self):
-        """
-        The structure of CDAT xml files (climate data markup language) is a dialect of xml files that have a defined set of attributes.
-        We only care that the xml file has a directory attribute – we can probably just return an error saying "the xml file provided does not have a root directory attribute" or something like that
-        XML probably isn't used that widely by the broad climate community, but it is used pretty widely by former CDAT users
-        """
         ds1 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
         ds1.to_netcdf(self.file_path1)
         ds2 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)

--- a/xcdat/__init__.py
+++ b/xcdat/__init__.py
@@ -6,7 +6,7 @@ from xcdat.axis import (  # noqa: F401
     swap_lon_axis,
 )
 from xcdat.bounds import BoundsAccessor  # noqa: F401
-from xcdat.dataset import decode_time, open, open_dataset, open_mfdataset  # noqa: F401
+from xcdat.dataset import decode_time, open_dataset, open_mfdataset  # noqa: F401
 from xcdat.regridder.accessor import RegridderAccessor  # noqa: F401
 from xcdat.regridder.grid import (  # noqa: F401
     create_gaussian_grid,

--- a/xcdat/__init__.py
+++ b/xcdat/__init__.py
@@ -6,7 +6,7 @@ from xcdat.axis import (  # noqa: F401
     swap_lon_axis,
 )
 from xcdat.bounds import BoundsAccessor  # noqa: F401
-from xcdat.dataset import decode_time, open_dataset, open_mfdataset  # noqa: F401
+from xcdat.dataset import decode_time, open, open_dataset, open_mfdataset  # noqa: F401
 from xcdat.regridder.accessor import RegridderAccessor  # noqa: F401
 from xcdat.regridder.grid import (  # noqa: F401
     create_gaussian_grid,

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -38,7 +38,7 @@ Paths = Union[
 
 
 def open_dataset(
-    path: Paths,
+    path: str,
     data_var: Optional[str] = None,
     add_bounds: bool = True,
     decode_times: bool = True,

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -395,7 +395,7 @@ def _parse_xml_for_nc_glob(xml_path: Union[str, pathlib.Path]) -> str:
 
     Parameters
     ----------
-    xml_path : str
+    xml_path : Union[str, pathlib.Path]
         The CDML XML file path.
 
     Returns

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -205,11 +205,11 @@ def open_mfdataset(
     ----------
     .. [2] https://xarray.pydata.org/en/stable/generated/xarray.open_mfdataset.html
     """
-    if isinstance(paths, str):
-        if paths.split(".")[-1] == "xml":
-            paths = _parse_xml_for_nc_glob(paths)
+    if not isinstance(paths, list):
+        if _is_paths_to_xml(paths):
+            paths = _parse_xml_for_nc_glob(paths)  # type: ignore
         elif os.path.isdir(paths):
-            paths = _parse_dir_for_nc_glob(paths)
+            paths = _parse_dir_for_nc_glob(paths)  # type: ignore
 
     preprocess = partial(_preprocess, decode_times=decode_times, callable=preprocess)
 
@@ -365,6 +365,24 @@ def decode_time(dataset: xr.Dataset) -> xr.Dataset:
                 ds = ds.assign({bounds.name: decoded_bounds})
 
     return ds
+
+
+def _is_paths_to_xml(paths: Union[str, pathlib.Path]) -> bool:
+    """Checks if the ``paths`` argument is a path to an XML file.
+
+    Parameters
+    ----------
+    paths : Union[str, pathlib.Path]
+        A string or pathlib.Path represnting a file path.
+
+    Returns
+    -------
+    bool
+    """
+    if isinstance(paths, str):
+        return paths.split(".")[-1] == "xml"
+    elif isinstance(paths, pathlib.Path):
+        return paths.parts[-1].endswith("xml")
 
 
 def _parse_xml_for_nc_glob(xml_path: str) -> str:

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -207,7 +207,7 @@ def open_mfdataset(
     """
     if not isinstance(paths, list):
         if _is_paths_to_xml(paths):
-            paths = _parse_xml_for_nc_glob(paths)  # type: ignore
+            paths = _parse_xml_for_nc_glob(paths)
         elif os.path.isdir(paths):
             paths = _parse_dir_for_nc_glob(paths)  # type: ignore
 

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -385,7 +385,7 @@ def _is_paths_to_xml(paths: Union[str, pathlib.Path]) -> bool:
         return paths.parts[-1].endswith("xml")
 
 
-def _parse_xml_for_nc_glob(xml_path: str) -> str:
+def _parse_xml_for_nc_glob(xml_path: Union[str, pathlib.Path]) -> str:
     """Parses a CDAT XML file for a glob of `*.nc` paths.
 
     The CDAT "Climate Data Markup Language" (CDML) is a dialect of XML with a


### PR DESCRIPTION
## Description

This PR is intended to wrap `xc.open_dataset()` and `xc.open_mfdataset()` such that xcdat can flexibly open the dataset path passed in (whether it is a directory, wildcard search, xml file, single file, etc.). 

- Closes #128

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
