### PR TITLE
Add better support for using custom time coordinates in temporal APIs

### DIFF
--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -51,7 +51,8 @@ class TestAverage:
             "'time' does not have a calendar encoding attribute set, "
             "which is used to determine the `cftime.datetime` object type for the "
             "output time coordinates. Defaulting to CF 'standard' calendar. "
-            "Otherwise, set the calendar type and try again."
+            "Otherwise, set the calendar type (e.g., "
+            "ds['time'].encoding['calendar'] = 'noleap') and try again."
         ) in caplog.text
 
     def test_averages_for_yearly_time_series(self):
@@ -469,7 +470,8 @@ class TestGroupAverage:
             "'time' does not have a calendar encoding attribute set, "
             "which is used to determine the `cftime.datetime` object type for the "
             "output time coordinates. Defaulting to CF 'standard' calendar. "
-            "Otherwise, set the calendar type and try again."
+            "Otherwise, set the calendar type (e.g., "
+            "ds['time'].encoding['calendar'] = 'noleap') and try again."
         ) in caplog.text
 
     def test_weighted_annual_averages(self):
@@ -1047,7 +1049,8 @@ class TestClimatology:
             "'time' does not have a calendar encoding attribute set, "
             "which is used to determine the `cftime.datetime` object type for the "
             "output time coordinates. Defaulting to CF 'standard' calendar. "
-            "Otherwise, set the calendar type and try again."
+            "Otherwise, set the calendar type (e.g., "
+            "ds['time'].encoding['calendar'] = 'noleap') and try again."
         ) in caplog.text
 
     def test_weighted_seasonal_climatology_with_DJF(self):
@@ -1647,7 +1650,8 @@ class TestDepartures:
             "'time' does not have a calendar encoding attribute set, "
             "which is used to determine the `cftime.datetime` object type for the "
             "output time coordinates. Defaulting to CF 'standard' calendar. "
-            "Otherwise, set the calendar type and try again."
+            "Otherwise, set the calendar type (e.g., "
+            "ds['time'].encoding['calendar'] = 'noleap') and try again."
         ) in caplog.text
 
     def test_weighted_seasonal_departures_with_DJF(self):

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -216,9 +216,11 @@ class BoundsAccessor:
 
         if len(bounds_keys) == 0:
             raise KeyError(
-                f"No bounds were found for the '{axis}' axis. Make sure bounds vars "
-                "exist in the Dataset with names that match the 'bounds' keys, or try "
-                "adding bounds."
+                f"No bounds data variables were found for the '{axis}' axis. Make sure "
+                "the dataset has bound data vars and their names match the 'bounds' "
+                "attributes found on their related time coordinate variables. "
+                "Alternatively, you can add bounds with `xcdat.add_missing_bounds` "
+                "or `xcdat.add_bounds`."
             )
 
         bounds: Union[xr.Dataset, xr.DataArray] = self._dataset[

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -720,7 +720,9 @@ class TemporalAccessor:
         return ds
 
     def _set_data_var_attrs(self, data_var: str):
-        """Set data variable metadata as object attributes.
+        """
+        Set data variable metadata as object attributes and checks whether the
+        time axis is decoded.
 
         This includes the name of the data variable, the time axis dimension
         name, the calendar type and its corresponding cftime object (date type).

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -522,7 +522,7 @@ class TemporalAccessor:
               If the CF calendar type is ``"gregorian"``,
               ``"proleptic_gregorian"``, or ``"standard"``, leap days (if
               present) are dropped to avoid inconsistencies when calculating
-              climatologies. Refer to [3]_ for more details on this
+              climatologies. Refer to [2]_ for more details on this
               implementation decision.
 
         weighted : bool, optional
@@ -586,12 +586,12 @@ class TemporalAccessor:
 
         Notes
         -----
-        Refer to [2]_ to learn more about how xarray's grouped arithmetic works.
+        Refer to [3]_ to learn more about how xarray's grouped arithmetic works.
 
         References
         ----------
-        .. [2] https://xarray.pydata.org/en/stable/user-guide/groupby.html#grouped-arithmetic
-        .. [3] https://github.com/xCDAT/xcdat/discussions/332
+        .. [2] https://github.com/xCDAT/xcdat/discussions/332
+        .. [3] https://xarray.pydata.org/en/stable/user-guide/groupby.html#grouped-arithmetic
 
         Examples
         --------
@@ -1113,11 +1113,11 @@ class TemporalAccessor:
 
         Notes
         -----
-        Refer to [5]_ for the supported CF convention calendar types.
+        Refer to [4]_ for the supported CF convention calendar types.
 
         References
         ----------
-        .. [5] https://cfconventions.org/cf-conventions/cf-conventions.html#calendar
+        .. [4] https://cfconventions.org/cf-conventions/cf-conventions.html#calendar
         """
         with xr.set_options(keep_attrs=True):
             time_lengths: xr.DataArray = time_bounds[:, 1] - time_bounds[:, 0]
@@ -1257,11 +1257,11 @@ class TemporalAccessor:
 
         Notes
         -----
-        Refer to [2]_ for information on xarray datetime accessor components.
+        Refer to [5]_ for information on xarray datetime accessor components.
 
         References
         ----------
-        .. [2] https://xarray.pydata.org/en/stable/user-guide/time-series.html#datetime-components
+        .. [5] https://xarray.pydata.org/en/stable/user-guide/time-series.html#datetime-components
         """
         df = pd.DataFrame()
 
@@ -1486,14 +1486,13 @@ class TemporalAccessor:
 
         Notes
         -----
-        Refer to [4]_ and [5]_ for more information on Timestamp-valid range.
+        Refer to [6]_ and [7]_ for more information on Timestamp-valid range.
         We use cftime.datetime objects to avoid these time range issues.
 
         References
         ----------
-        .. [4] https://docs.xarray.dev/en/stable/user-guide/weather-climate.html#non-standard-calendars-and-dates-outside-the-timestamp-valid-range
-
-        .. [5] https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timestamp-limitations
+        .. [6] https://docs.xarray.dev/en/stable/user-guide/weather-climate.html#non-standard-calendars-and-dates-outside-the-timestamp-valid-range
+        .. [7] https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timestamp-limitations
         """
         df_new = df.copy()
 

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -753,7 +753,7 @@ class TemporalAccessor:
 
         # Get the `cftime` date type based on the CF calendar attribute.
         # The date type is used to get the correct cftime.datetime sub-class
-        # type for creating new grouped time coordinates after averaging.
+        # type for creating new grouped time coordinates for averaging.
         try:
             self.calendar = dv[self.dim].encoding["calendar"]
         except KeyError:
@@ -762,7 +762,8 @@ class TemporalAccessor:
                 f"'{self.dim}' does not have a calendar encoding attribute set, "
                 "which is used to determine the `cftime.datetime` object type for the "
                 "output time coordinates. Defaulting to CF 'standard' calendar. "
-                "Otherwise, set the calendar type and try again."
+                "Otherwise, set the calendar type (e.g., "
+                "ds['time'].encoding['calendar'] = 'noleap') and try again."
             )
 
         self.date_type = get_date_type(self.calendar)


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #414 

Summary of Changes
- Update check for decoded time and calendar attr in `TemporalAccessor`
  - We determine if time is decoded by checking the type of the first time coordinate
  - If no `calendar` attr is set, calendar is defaulted to `"standard"` and a logger warning is raised (instead of a KeyError). Calendar is required for determining the `cftime.datetime` object type and checking if leap days should be dropped for high freq climatology/departures calculations.
- Update tests
- Update docstring for dropping leap days with high freq
- Update `KeyError` when bounds are not found for an axis

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
