### PR TITLE
Update departures and climatology APIs with reference period

### DIFF
--- a/docs/examples/climatology-and-departures.ipynb
+++ b/docs/examples/climatology-and-departures.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "Date: 05/27/22\n",
     "\n",
-    "Last Updated: 09/26/22 (v0.3.3)\n",
+    "Last Updated: 2/27/23\n",
     "\n",
     "Related APIs:\n",
     "\n",
@@ -1341,6 +1341,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1353,7 +1354,11 @@
     "Helpful knowledge:\n",
     "\n",
     "* Masked (missing) data is automatically handled.\n",
-    "  * The weight of masked (missing) data is excluded when averages are calculated. This is the same as giving them a weight of 0."
+    "  * The weight of masked (missing) data is excluded when averages are calculated. This is the same as giving them a weight of 0.\n",
+    "* If desired, use the `reference_period` argument to calculate a climatology based on a\n",
+    "  climatological reference period (a subset of the entire time series). If no value is\n",
+    "  provided, the climatological reference period will be the full period covered by the\n",
+    "  dataset."
    ]
   },
   {
@@ -4238,6 +4243,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -4256,6 +4262,10 @@
     "* How is the climatology calculated?\n",
     "  * In the departures API, the reference climatology is calculated internally so there is no need  to pass one to this method.\n",
     "  * You can still calculate the reference climatology using the climatology API.\n",
+    "  * If desired, use the `reference_period` argument to calculate anomalies relative to a\n",
+    "  climatological reference period (a subset of the entire time series). If no value is\n",
+    "  provided, the climatological reference period will be the full period covered by the\n",
+    "  dataset.\n",
     "* Masked (missing) data is automatically handled.\n",
     "  * The weight of masked (missing) data is excluded when averages are calculated. This is the same as giving them a weight of 0.\n"
    ]
@@ -6608,7 +6618,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -2130,7 +2130,7 @@ class TestDepartures:
                 "operation": "temporal_avg",
                 "mode": "departures",
                 "freq": "season",
-                "weighted": "True",
+                "weighted": "False",
                 "dec_mode": "JFD",
             },
         )

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1826,6 +1826,91 @@ class TestDepartures:
 
         assert result.identical(expected)
 
+    def test_monthly_departures_relative_to_climatology_reference_period_with_same_output_freq(
+        self,
+    ):
+        ds = self.ds.copy()
+
+        result = ds.temporal.departures(
+            "ts",
+            "month",
+            weighted=True,
+            season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
+            reference_period=("2000-01-01", "2000-06-01"),
+        )
+
+        expected = ds.copy()
+        expected = expected.drop_dims("time")
+        expected["ts"] = xr.DataArray(
+            name="ts",
+            data=np.array([[[0.0]], [[0.0]], [[np.nan]], [[np.nan]], [[np.nan]]]),
+            coords={
+                "lat": expected.lat,
+                "lon": expected.lon,
+                "time": xr.DataArray(
+                    data=np.array(
+                        [
+                            "2000-01-16T12:00:00.000000000",
+                            "2000-03-16T12:00:00.000000000",
+                            "2000-06-16T00:00:00.000000000",
+                            "2000-09-16T00:00:00.000000000",
+                            "2001-02-15T12:00:00.000000000",
+                        ],
+                        dtype="datetime64[ns]",
+                    ),
+                    dims=["time"],
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
+                    },
+                ),
+            },
+            dims=["time", "lat", "lon"],
+            attrs={
+                "test_attr": "test",
+                "operation": "temporal_avg",
+                "mode": "departures",
+                "freq": "month",
+                "weighted": "True",
+            },
+        )
+        expected["time_bnds"] = xr.DataArray(
+            name="time_bnds",
+            data=np.array(
+                [
+                    [
+                        "2000-01-01T00:00:00.000000000",
+                        "2000-02-01T00:00:00.000000000",
+                    ],
+                    [
+                        "2000-03-01T00:00:00.000000000",
+                        "2000-04-01T00:00:00.000000000",
+                    ],
+                    [
+                        "2000-06-01T00:00:00.000000000",
+                        "2000-07-01T00:00:00.000000000",
+                    ],
+                    [
+                        "2000-09-01T00:00:00.000000000",
+                        "2000-10-01T00:00:00.000000000",
+                    ],
+                    [
+                        "2001-02-01T00:00:00.000000000",
+                        "2001-03-01T00:00:00.000000000",
+                    ],
+                ],
+                dtype="datetime64[ns]",
+            ),
+            dims=["time", "bnds"],
+            attrs={
+                "xcdat_bounds": "True",
+            },
+        )
+
+        assert result.identical(expected)
+
     def test_weighted_seasonal_departures_with_DJF(self):
         ds = self.ds.copy()
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1654,6 +1654,9 @@ class TestDepartures:
             "ds['time'].encoding['calendar'] = 'noleap') and try again."
         ) in caplog.text
 
+    def test_weighted_seasonal_departures_with_DJF_and_reference_period(self):
+        pass
+
     def test_weighted_seasonal_departures_with_DJF(self):
         ds = self.ds.copy()
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -2093,7 +2093,7 @@ class TestDepartures:
         result = ds.temporal.departures(
             "ts",
             "season",
-            weighted=True,
+            weighted=False,
             season_config={"dec_mode": "JFD"},
         )
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1053,6 +1053,69 @@ class TestClimatology:
             "ds['time'].encoding['calendar'] = 'noleap') and try again."
         ) in caplog.text
 
+    def test_raises_error_if_reference_period_arg_is_incorrect(self):
+        ds = self.ds.copy()
+
+        with pytest.raises(ValueError):
+            ds.temporal.climatology(
+                "ts",
+                "season",
+                season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
+                reference_period=("01-01-2000", "01-01-2000"),
+            )
+
+        with pytest.raises(ValueError):
+            ds.temporal.climatology(
+                "ts",
+                "season",
+                season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
+                reference_period=("01-01-2000"),
+            )
+
+    def test_subsets_climatology_based_on_reference_period(self):
+        ds = self.ds.copy()
+
+        result = ds.temporal.climatology(
+            "ts",
+            "season",
+            season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
+            reference_period=("2000-01-01", "2000-06-01"),
+        )
+
+        # The first month Jan/Feb are dropped (incomplete DJF). This means
+        # only the MAM season will be present, with April being the middle month
+        # (represented by month number 4).
+        expected = ds.copy()
+        expected = expected.drop_dims("time")
+        expected_time = xr.DataArray(
+            data=np.array([cftime.DatetimeGregorian(1, 4, 1)]),
+            coords={
+                "time": np.array([cftime.DatetimeGregorian(1, 4, 1)]),
+            },
+            attrs={
+                "axis": "T",
+                "long_name": "time",
+                "standard_name": "time",
+                "bounds": "time_bnds",
+            },
+        )
+        expected["ts"] = xr.DataArray(
+            name="ts",
+            data=np.ones((1, 4, 4)),
+            coords={"lat": expected.lat, "lon": expected.lon, "time": expected_time},
+            dims=["time", "lat", "lon"],
+            attrs={
+                "operation": "temporal_avg",
+                "mode": "climatology",
+                "freq": "season",
+                "weighted": "True",
+                "dec_mode": "DJF",
+                "drop_incomplete_djf": "True",
+            },
+        )
+
+        assert result.identical(expected)
+
     def test_weighted_seasonal_climatology_with_DJF(self):
         ds = self.ds.copy()
 
@@ -1618,15 +1681,54 @@ class TestClimatology:
 
 
 class TestDepartures:
-    # TODO: Update TestDepartures tests to use other numbers rather than 1's for
-    # better test reliability and accuracy. This may require subsetting.
     @pytest.fixture(autouse=True)
     def setup(self):
-        self.ds: xr.Dataset = generate_dataset(
-            decode_times=True, cf_compliant=False, has_bounds=True
+        time = xr.DataArray(
+            data=np.array(
+                [
+                    "2000-01-16T12:00:00.000000000",
+                    "2000-03-16T12:00:00.000000000",
+                    "2000-06-16T00:00:00.000000000",
+                    "2000-09-16T00:00:00.000000000",
+                    "2001-02-15T12:00:00.000000000",
+                ],
+                dtype="datetime64[ns]",
+            ),
+            dims=["time"],
+            attrs={"axis": "T", "long_name": "time", "standard_name": "time"},
+        )
+        time.encoding = {"calendar": "standard"}
+        time_bnds = xr.DataArray(
+            name="time_bnds",
+            data=np.array(
+                [
+                    ["2000-01-01T00:00:00.000000000", "2000-02-01T00:00:00.000000000"],
+                    ["2000-03-01T00:00:00.000000000", "2000-04-01T00:00:00.000000000"],
+                    ["2000-06-01T00:00:00.000000000", "2000-07-01T00:00:00.000000000"],
+                    ["2000-09-01T00:00:00.000000000", "2000-10-01T00:00:00.000000000"],
+                    ["2001-02-01T00:00:00.000000000", "2001-03-01T00:00:00.000000000"],
+                ],
+                dtype="datetime64[ns]",
+            ),
+            coords={"time": time},
+            dims=["time", "bnds"],
+            attrs={"xcdat_bounds": "True"},
         )
 
-        self.seasons = ["JJA", "MAM", "SON", "DJF"]
+        self.ds = xr.Dataset(
+            data_vars={"time_bnds": time_bnds},
+            coords={"lat": [-90], "lon": [0], "time": time},
+        )
+        self.ds.time.attrs["bounds"] = "time_bnds"
+
+        self.ds["ts"] = xr.DataArray(
+            data=np.array(
+                [[[2.0]], [[1.0]], [[1.0]], [[1.0]], [[2.0]]], dtype="float64"
+            ),
+            coords={"time": self.ds.time, "lat": self.ds.lat, "lon": self.ds.lon},
+            dims=["time", "lat", "lon"],
+            attrs={"test_attr": "test"},
+        )
 
     def test_raises_error_if_time_coords_are_not_decoded(self):
         ds: xr.Dataset = generate_dataset(
@@ -1654,31 +1756,115 @@ class TestDepartures:
             "ds['time'].encoding['calendar'] = 'noleap') and try again."
         ) in caplog.text
 
-    def test_weighted_seasonal_departures_with_DJF_and_reference_period(self):
-        pass
+    def test_raises_error_if_reference_period_arg_is_incorrect(self):
+        ds = self.ds.copy()
+
+        with pytest.raises(ValueError):
+            ds.temporal.departures(
+                "ts",
+                "season",
+                season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
+                reference_period=("01-01-2000", "01-01-2000"),
+            )
+
+        with pytest.raises(ValueError):
+            ds.temporal.departures(
+                "ts",
+                "season",
+                season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
+                reference_period=("01-01-2000"),
+            )
+
+    def test_seasonal_departures_relative_to_climatology_reference_period(self):
+        ds = self.ds.copy()
+
+        result = ds.temporal.departures(
+            "ts",
+            "season",
+            weighted=True,
+            season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
+            reference_period=("2000-01-01", "2000-06-01"),
+        )
+
+        expected = ds.copy()
+        expected = expected.drop_dims("time")
+        expected["ts"] = xr.DataArray(
+            name="ts",
+            data=np.array([[[0.0]], [[np.nan]], [[np.nan]], [[np.nan]]]),
+            coords={
+                "lat": expected.lat,
+                "lon": expected.lon,
+                "time": xr.DataArray(
+                    data=np.array(
+                        [
+                            cftime.DatetimeGregorian(2000, 4, 1),
+                            cftime.DatetimeGregorian(2000, 7, 1),
+                            cftime.DatetimeGregorian(2000, 10, 1),
+                            cftime.DatetimeGregorian(2001, 1, 1),
+                        ],
+                    ),
+                    dims=["time"],
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
+                    },
+                ),
+            },
+            dims=["time", "lat", "lon"],
+            attrs={
+                "test_attr": "test",
+                "operation": "temporal_avg",
+                "mode": "departures",
+                "freq": "season",
+                "weighted": "True",
+                "dec_mode": "DJF",
+                "drop_incomplete_djf": "True",
+            },
+        )
+
+        assert result.identical(expected)
 
     def test_weighted_seasonal_departures_with_DJF(self):
         ds = self.ds.copy()
 
-        # Drop incomplete DJF seasons
-        ds = ds.isel(time=slice(2, -1))
-
-        # Compare result of the method against the expected.
         result = ds.temporal.departures(
             "ts",
             "season",
+            weighted=True,
             season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
         )
+
         expected = ds.copy()
+        expected = expected.drop_dims("time")
         expected["ts"] = xr.DataArray(
-            data=np.zeros((12, 4, 4)),
+            name="ts",
+            data=np.array([[[0.0]], [[0.0]], [[0.0]], [[0.0]]]),
             coords={
                 "lat": expected.lat,
                 "lon": expected.lon,
-                "time": ds.time,
+                "time": xr.DataArray(
+                    data=np.array(
+                        [
+                            cftime.DatetimeGregorian(2000, 4, 1),
+                            cftime.DatetimeGregorian(2000, 7, 1),
+                            cftime.DatetimeGregorian(2000, 10, 1),
+                            cftime.DatetimeGregorian(2001, 1, 1),
+                        ],
+                    ),
+                    dims=["time"],
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
+                    },
+                ),
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "departures",
                 "freq": "season",
@@ -1693,10 +1879,6 @@ class TestDepartures:
     def test_weighted_seasonal_departures_with_DJF_and_keep_weights(self):
         ds = self.ds.copy()
 
-        # Drop incomplete DJF seasons
-        ds = ds.isel(time=slice(2, -1))
-
-        # Compare result of the method against the expected.
         result = ds.temporal.departures(
             "ts",
             "season",
@@ -1704,16 +1886,36 @@ class TestDepartures:
             keep_weights=True,
             season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
         )
+
         expected = ds.copy()
+        expected = expected.drop_dims("time")
         expected["ts"] = xr.DataArray(
-            data=np.zeros((12, 4, 4)),
+            name="ts",
+            data=np.array([[[0.0]], [[0.0]], [[0.0]], [[0.0]]]),
             coords={
                 "lat": expected.lat,
                 "lon": expected.lon,
-                "time": ds.time,
+                "time": xr.DataArray(
+                    data=np.array(
+                        [
+                            cftime.DatetimeGregorian(2000, 4, 1),
+                            cftime.DatetimeGregorian(2000, 7, 1),
+                            cftime.DatetimeGregorian(2000, 10, 1),
+                            cftime.DatetimeGregorian(2001, 1, 1),
+                        ],
+                    ),
+                    dims=["time"],
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
+                    },
+                ),
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "departures",
                 "freq": "season",
@@ -1723,51 +1925,72 @@ class TestDepartures:
             },
         )
         expected["time_wts"] = xr.DataArray(
-            data=np.array(
-                [
-                    0.33695652,
-                    0.32608696,
-                    0.33695652,
-                    0.32608696,
-                    0.33695652,
-                    0.33695652,
-                    0.32967033,
-                    0.34065934,
-                    0.32967033,
-                    0.34444444,
-                    0.34444444,
-                    0.31111111,
-                ]
-            ),
-            coords={"time": ds.time},
-            dims=["time"],
+            name="ts",
+            data=np.array([1.0, 1.0, 1.0, 1.0]),
+            coords={
+                "time_original": xr.DataArray(
+                    data=np.array(
+                        [
+                            "2000-03-16T12:00:00.000000000",
+                            "2000-06-16T00:00:00.000000000",
+                            "2000-09-16T00:00:00.000000000",
+                            "2001-02-15T12:00:00.000000000",
+                        ],
+                        dtype="datetime64[ns]",
+                    ),
+                    dims=["time_original"],
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
+                    },
+                )
+            },
+            dims=["time_original"],
         )
 
-        xr.testing.assert_allclose(result, expected)
-        assert result.ts.attrs == expected.ts.attrs
+        assert result.identical(expected)
 
     def test_unweighted_seasonal_departures_with_DJF(self):
         ds = self.ds.copy()
-        # Drop incomplete DJF seasons
-        ds = ds.isel(time=slice(2, -1))
 
-        # Compare result of the method against the expected.
         result = ds.temporal.departures(
             "ts",
             "season",
             weighted=False,
             season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
         )
+
         expected = ds.copy()
+        expected = expected.drop_dims("time")
         expected["ts"] = xr.DataArray(
-            data=np.zeros((12, 4, 4)),
+            name="ts",
+            data=np.array([[[0.0]], [[0.0]], [[0.0]], [[0.0]]]),
             coords={
                 "lat": expected.lat,
                 "lon": expected.lon,
-                "time": ds.time,
+                "time": xr.DataArray(
+                    data=np.array(
+                        [
+                            cftime.DatetimeGregorian(2000, 4, 1),
+                            cftime.DatetimeGregorian(2000, 7, 1),
+                            cftime.DatetimeGregorian(2000, 10, 1),
+                            cftime.DatetimeGregorian(2001, 1, 1),
+                        ],
+                    ),
+                    dims=["time"],
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
+                    },
+                ),
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "departures",
                 "freq": "season",
@@ -1782,27 +2005,47 @@ class TestDepartures:
     def test_unweighted_seasonal_departures_with_JFD(self):
         ds = self.ds.copy()
 
-        # Compare result of the method against the expected.
         result = ds.temporal.departures(
             "ts",
             "season",
-            weighted=False,
+            weighted=True,
             season_config={"dec_mode": "JFD"},
         )
+
         expected = ds.copy()
+        expected = expected.drop_dims("time")
         expected["ts"] = xr.DataArray(
-            data=np.zeros((15, 4, 4)),
+            name="ts",
+            data=np.array([[[0.0]], [[0.0]], [[0.0]], [[0.0]], [[0.0]]]),
             coords={
                 "lat": expected.lat,
                 "lon": expected.lon,
-                "time": ds.time,
+                "time": xr.DataArray(
+                    data=np.array(
+                        [
+                            cftime.DatetimeGregorian(2000, 1, 1),
+                            cftime.DatetimeGregorian(2000, 4, 1),
+                            cftime.DatetimeGregorian(2000, 7, 1),
+                            cftime.DatetimeGregorian(2000, 10, 1),
+                            cftime.DatetimeGregorian(2001, 1, 1),
+                        ],
+                    ),
+                    dims=["time"],
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
+                    },
+                ),
             },
             dims=["time", "lat", "lon"],
             attrs={
+                "test_attr": "test",
                 "operation": "temporal_avg",
                 "mode": "departures",
                 "freq": "season",
-                "weighted": "False",
+                "weighted": "True",
                 "dec_mode": "JFD",
             },
         )
@@ -1869,12 +2112,11 @@ class TestDepartures:
                     "time": xr.DataArray(
                         data=np.array(
                             [
-                                "2000-01-16T12:00:00.000000000",
-                                "2000-06-16T00:00:00.000000000",
-                                "2000-09-16T00:00:00.000000000",
-                                "2001-03-15T12:00:00.000000000",
+                                cftime.DatetimeGregorian(2000, 1, 16),
+                                cftime.DatetimeGregorian(2000, 6, 16),
+                                cftime.DatetimeGregorian(2000, 9, 16),
+                                cftime.DatetimeGregorian(2001, 3, 15),
                             ],
-                            dtype="datetime64[ns]",
                         ),
                         dims=["time"],
                         attrs={
@@ -1897,32 +2139,6 @@ class TestDepartures:
                             "freq": "day",
                             "weighted": "True",
                         },
-                    ),
-                    "time_bnds": xr.DataArray(
-                        name="time_bnds",
-                        data=np.array(
-                            [
-                                [
-                                    "2000-01-01T00:00:00.000000000",
-                                    "2000-02-01T00:00:00.000000000",
-                                ],
-                                [
-                                    "2000-06-01T00:00:00.000000000",
-                                    "2000-07-01T00:00:00.000000000",
-                                ],
-                                [
-                                    "2000-09-01T00:00:00.000000000",
-                                    "2000-10-01T00:00:00.000000000",
-                                ],
-                                [
-                                    "2001-03-01T00:00:00.000000000",
-                                    "2001-04-01T00:00:00.000000000",
-                                ],
-                            ],
-                            dtype="datetime64[ns]",
-                        ),
-                        dims=["time", "bnds"],
-                        attrs={"xcdat_bounds": "True"},
                     ),
                 },
             )

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -850,8 +850,6 @@ class TemporalAccessor:
         self._freq = freq
         self._weighted = weighted
 
-        # TODO: Add validation for reference_period
-        # https://stackoverflow.com/questions/16870663/how-do-i-validate-a-date-string-format-in-python
         self._reference_period = None
         if reference_period is not None:
             self._is_valid_reference_period(reference_period)

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -390,7 +390,9 @@ class TemporalAccessor:
         reference_period : Optional[Tuple[str, str]], optional
             The climatological reference period, which is a subset of the entire
             time series. This parameter accepts a tuple of strings in the format
-            'yyyy-mm-dd'. For example, ``('1850-01-01', 1899-12-31')``.
+            'yyyy-mm-dd'. For example, ``('1850-01-01', 1899-12-31')``. If no
+            value is provided, the climatological reference period will be the
+            full period covered by the dataset.
         season_config: SeasonConfigInput, optional
             A dictionary for "season" frequency configurations. If configs for
             predefined seasons are passed, configs for custom seasons are
@@ -555,7 +557,9 @@ class TemporalAccessor:
             The climatological reference period, which is a subset of the entire
             time series and used for calculating departures. This parameter
             accepts a tuple of strings in the format 'yyyy-mm-dd'. For example,
-            ``('1850-01-01', 1899-12-31')``.
+            ``('1850-01-01', 1899-12-31')``. If no value is provided, the 
+            climatological reference period will be the full period covered by 
+            the dataset.
         season_config: SeasonConfigInput, optional
             A dictionary for "season" frequency configurations. If configs for
             predefined seasons are passed, configs for custom seasons are

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -974,7 +974,6 @@ class TemporalAccessor:
         ):
             ds = self._drop_leap_days(ds)
 
-        # TODO: Add subsetting based on reference period
         if self._mode == "climatology" and self._reference_period is not None:
             ds = ds.sel(
                 {self.dim: slice(self._reference_period[0], self._reference_period[1])}


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #387 
- Add `reference_period` parameter to `climatology()` and `departures()` to subset climatology 
- In `departures()`, calculate the the grouped average of the observation data before calculating anomalies
  - This behavior makes `departures()` align with CDAT's APIs for calculating departures
  - If the input frequency from the dataset is the same as the output frequency `freq` arg, no grouped average is performed since it is unnecessary and incurs a performance cost 
- Update `departures()` notebook with `reference_period` example
 
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
