### PR TITLE
Functions to produce accurate time bounds

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,7 +14,7 @@ Currently, coordinate variable bounds can only be stored on ``Dataset`` objects 
 Top-level API Functions
 -----------------------
 
-Below is a list of top-level API functions available in ``xcdat``.
+Below is a list of top-level API functions that are available in ``xcdat``.
 
 .. autosummary::
     :toctree: generated/
@@ -27,10 +27,6 @@ Below is a list of top-level API functions available in ``xcdat``.
     compare_datasets
     get_dim_coords
     get_dim_keys
-    create_time_bounds
-    create_yearly_time_bounds
-    create_monthly_time_bounds
-    create_daily_time_bounds
     create_gaussian_grid
     create_global_mean_grid
     create_grid
@@ -116,6 +112,7 @@ Methods
    :template: autosummary/accessor_method.rst
 
     Dataset.bounds.add_bounds
+    Dataset.bounds.add_time_bounds
     Dataset.bounds.get_bounds
     Dataset.bounds.add_missing_bounds
     Dataset.spatial.average

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,6 +27,10 @@ Below is a list of top-level API functions available in ``xcdat``.
     compare_datasets
     get_dim_coords
     get_dim_keys
+    create_time_bounds
+    create_yearly_time_bounds
+    create_monthly_time_bounds
+    create_daily_time_bounds
     create_gaussian_grid
     create_global_mean_grid
     create_grid

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -42,6 +42,54 @@ time_decoded = xr.DataArray(
         "standard_name": "time",
     },
 )
+time_yearly = xr.DataArray(
+    data=np.array(
+        [
+            cftime.DatetimeGregorian(2000, 7, 1, 12, 0, 0, 0, has_year_zero=False),
+            cftime.DatetimeGregorian(2001, 7, 1, 12, 0, 0, 0, has_year_zero=False),
+            cftime.DatetimeGregorian(2002, 7, 1, 12, 0, 0, 0, has_year_zero=False),
+        ],
+        dtype=object,
+    ),
+    dims=["time"],
+    attrs={
+        "axis": "T",
+        "long_name": "time",
+        "standard_name": "time",
+    },
+)
+time_daily = xr.DataArray(
+    data=np.array(
+        [
+            cftime.DatetimeGregorian(2000, 1, 1, 12, 0, 0, 0, has_year_zero=False),
+            cftime.DatetimeGregorian(2000, 1, 2, 12, 0, 0, 0, has_year_zero=False),
+            cftime.DatetimeGregorian(2000, 1, 3, 12, 0, 0, 0, has_year_zero=False),
+        ],
+        dtype=object,
+    ),
+    dims=["time"],
+    attrs={
+        "axis": "T",
+        "long_name": "time",
+        "standard_name": "time",
+    },
+)
+time_hourly = xr.DataArray(
+    data=np.array(
+        [
+            cftime.DatetimeGregorian(2000, 1, 1, 0, 0, 0, 0, has_year_zero=False),
+            cftime.DatetimeGregorian(2000, 1, 1, 1, 0, 0, 0, has_year_zero=False),
+            cftime.DatetimeGregorian(2000, 1, 1, 2, 0, 0, 0, has_year_zero=False),
+        ],
+        dtype=object,
+    ),
+    dims=["time"],
+    attrs={
+        "axis": "T",
+        "long_name": "time",
+        "standard_name": "time",
+    },
+)
 time_encoded = xr.DataArray(
     data=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
     dims=["time"],
@@ -51,7 +99,78 @@ time_encoded = xr.DataArray(
         "standard_name": "time",
     },
 )
-
+time_bnds_yearly = xr.DataArray(
+    name="time_bnds",
+    data=np.array(
+        [
+            [
+                cftime.DatetimeGregorian(2000, 1, 1, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2001, 1, 1, 0, 0, 0, 0, has_year_zero=False),
+            ],
+            [
+                cftime.DatetimeGregorian(2001, 1, 1, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2002, 1, 1, 0, 0, 0, 0, has_year_zero=False),
+            ],
+            [
+                cftime.DatetimeGregorian(2002, 1, 1, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2003, 1, 1, 0, 0, 0, 0, has_year_zero=False),
+            ],
+        ],
+        dtype=object,
+    ),
+    dims=["time", "bnds"],
+    attrs={
+        "xcdat_bounds": "True",
+    },
+)
+time_bnds_daily = xr.DataArray(
+    name="time_bnds",
+    data=np.array(
+        [
+            [
+                cftime.DatetimeGregorian(2000, 1, 1, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2000, 1, 2, 0, 0, 0, 0, has_year_zero=False),
+            ],
+            [
+                cftime.DatetimeGregorian(2000, 1, 2, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2000, 1, 3, 0, 0, 0, 0, has_year_zero=False),
+            ],
+            [
+                cftime.DatetimeGregorian(2000, 1, 3, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2000, 1, 4, 0, 0, 0, 0, has_year_zero=False),
+            ],
+        ],
+        dtype=object,
+    ),
+    dims=["time", "bnds"],
+    attrs={
+        "xcdat_bounds": "True",
+    },
+)
+time_bnds_hourly = xr.DataArray(
+    name="time_bnds",
+    data=np.array(
+        [
+            [
+                cftime.DatetimeGregorian(2000, 1, 1, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2000, 1, 1, 1, 0, 0, 0, has_year_zero=False),
+            ],
+            [
+                cftime.DatetimeGregorian(2000, 1, 1, 1, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2000, 1, 1, 2, 0, 0, 0, has_year_zero=False),
+            ],
+            [
+                cftime.DatetimeGregorian(2000, 1, 1, 2, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2000, 1, 1, 3, 0, 0, 0, has_year_zero=False),
+            ],
+        ],
+        dtype=object,
+    ),
+    dims=["time", "bnds"],
+    attrs={
+        "xcdat_bounds": "True",
+    },
+)
 time_bnds_decoded = xr.DataArray(
     name="time_bnds",
     data=np.array(
@@ -202,9 +321,7 @@ ts_encoded = xr.DataArray(
 
 
 def generate_dataset(
-    decode_times: bool,
-    cf_compliant: bool,
-    has_bounds: bool,
+    decode_times: bool, cf_compliant: bool, has_bounds: bool
 ) -> xr.Dataset:
     """Generates a dataset using coordinate and data variable fixtures.
 
@@ -212,44 +329,55 @@ def generate_dataset(
     ----------
     decode_times : bool
         If True, represent time coordinates `cftime` objects. If False,
-        represent time coordinates as numbers.
+        represent time coordinates as numbers. Note that
+        decode_times = False only works with monthly time steps (i.e.,
+        freq='month').
     cf_compliant : bool
         If True, use CF compliant time units ("days since ..."). If False,
         use non-CF compliant time units ("months since ...").
     has_bounds : bool
         Include bounds for coordinates. This also adds the "bounds" attribute
         to existing coordinates to link them to their respective bounds.
+    freq : str
+        Frequency of time step (and bounds). Options include hour, day,
+        month, and year. Default is 'month'.
+
+    Raises
+    ------
+    ValueError
+        If an incompatible ``freq`` argument is passed.
 
     Returns
     -------
     xr.Dataset
         Test dataset.
     """
-    # First, create a dataset with either encoded or decoded coordinates.
+    # get correct data_var, time axis, and time_bnds
     if decode_times:
-        ds = xr.Dataset(
-            data_vars={
-                "ts": ts_decoded.copy(),
-            },
-            coords={"lat": lat.copy(), "lon": lon.copy(), "time": time_decoded.copy()},
-        )
+        ts = ts_decoded.copy()
+        time = time_decoded.copy()
+        time_bnds = time_bnds_decoded.copy()
+    else:
+        ts = ts_encoded.copy()
+        time = time_encoded.copy()
+        time_bnds = time_bnds_encoded.copy()
 
-        # Add the calendar and units attr to the encoding dict.
+    # Create dataset
+    ds = xr.Dataset(
+        data_vars={
+            "ts": ts,
+        },
+        coords={"lat": lat.copy(), "lon": lon.copy(), "time": time},
+    )
+
+    # Add the calendar and units attr to the encoding dict.
+    if decode_times:
         ds["time"].encoding["calendar"] = "standard"
         if cf_compliant:
             ds["time"].encoding["units"] = "days since 2000-01-01"
         else:
             ds["time"].encoding["units"] = "months since 2000-01-01"
-
     else:
-        ds = xr.Dataset(
-            data_vars={
-                "ts": ts_encoded.copy(),
-            },
-            coords={"lat": lat.copy(), "lon": lon.copy(), "time": time_encoded.copy()},
-        )
-
-        # Add the calendar and units attr to the attrs dict.
         ds["time"].attrs["calendar"] = "standard"
         if cf_compliant:
             ds["time"].attrs["units"] = "days since 2000-01-01"
@@ -259,11 +387,7 @@ def generate_dataset(
     if has_bounds:
         ds["lat_bnds"] = lat_bnds.copy()
         ds["lon_bnds"] = lon_bnds.copy()
-
-        if decode_times:
-            ds["time_bnds"] = time_bnds_decoded.copy()
-        else:
-            ds["time_bnds"] = time_bnds_encoded.copy()
+        ds["time_bnds"] = time_bnds
 
         # If the "bounds" attribute is included in an existing DataArray and
         # added to a new Dataset, it will get dropped. Therefore, it needs to be
@@ -271,5 +395,60 @@ def generate_dataset(
         ds["lat"].attrs["bounds"] = "lat_bnds"
         ds["lon"].attrs["bounds"] = "lon_bnds"
         ds["time"].attrs["bounds"] = "time_bnds"
+
+    return ds
+
+
+def generate_dataset_by_frequency(freq: str = "month") -> xr.Dataset:
+    """Generates a dataset using coordinate and data variable fixtures.
+    The generated dataset is decoded, cf-compliant, and includes bounds.
+
+    Parameters
+    ----------
+    freq : str, optional
+        Frequency of time step (and bounds). Options include hour, day,
+        month, and year. Default is 'month'.
+
+    Returns
+    -------
+    xr.Dataset
+        Test dataset.
+    """
+    # get correct time axis and time_bnds
+    if freq == "month":
+        time = time_decoded.copy()
+        time_bnds = time_bnds_decoded.copy()
+    if freq == "year":
+        time = time_yearly.copy()
+        time_bnds = time_bnds_yearly.copy()
+    if freq == "day":
+        time = time_daily.copy()
+        time_bnds = time_bnds_daily.copy()
+    if freq == "hour":
+        time = time_hourly.copy()
+        time_bnds = time_bnds_hourly.copy()
+
+    # Create dataset
+    ds = xr.Dataset(
+        data_vars={
+            "ts": ts_decoded,
+        },
+        coords={"lat": lat.copy(), "lon": lon.copy(), "time": time},
+    )
+
+    # Add the calendar and units attr to the encoding dict.
+    ds["time"].encoding["calendar"] = "standard"
+    ds["time"].encoding["units"] = "days since 2000-01-01"
+
+    ds["lat_bnds"] = lat_bnds.copy()
+    ds["lon_bnds"] = lon_bnds.copy()
+    ds["time_bnds"] = time_bnds
+
+    # If the "bounds" attribute is included in an existing DataArray and
+    # added to a new Dataset, it will get dropped. Therefore, it needs to be
+    # assigned to the DataArrays after they are added to Dataset.
+    ds["lat"].attrs["bounds"] = "lat_bnds"
+    ds["lon"].attrs["bounds"] = "lon_bnds"
+    ds["time"].attrs["bounds"] = "time_bnds"
 
     return ds

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -369,23 +369,13 @@ def generate_dataset(
     ----------
     decode_times : bool
         If True, represent time coordinates `cftime` objects. If False,
-        represent time coordinates as numbers. Note that
-        decode_times = False only works with monthly time steps (i.e.,
-        freq='month').
+        represent time coordinates as numbers.
     cf_compliant : bool
         If True, use CF compliant time units ("days since ..."). If False,
         use non-CF compliant time units ("months since ...").
     has_bounds : bool
         Include bounds for coordinates. This also adds the "bounds" attribute
         to existing coordinates to link them to their respective bounds.
-    freq : str
-        Frequency of time step (and bounds). Options include hour, day,
-        month, and year. Default is 'month'.
-
-    Raises
-    ------
-    ValueError
-        If an incompatible ``freq`` argument is passed.
 
     Returns
     -------
@@ -440,8 +430,9 @@ def generate_dataset(
 
 
 def generate_dataset_by_frequency(freq: str = "month") -> xr.Dataset:
-    """Generates a dataset using coordinate and data variable fixtures.
-    The generated dataset is decoded, cf-compliant, and includes bounds.
+    """Generates a dataset of a given temporal frequency using coordinate
+    and data variable fixtures. The generated dataset is decoded,
+    cf-compliant, and includes bounds.
 
     Parameters
     ----------

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -90,6 +90,22 @@ time_hourly = xr.DataArray(
         "standard_name": "time",
     },
 )
+time_subhourly = xr.DataArray(
+    data=np.array(
+        [
+            cftime.DatetimeGregorian(2000, 1, 1, 0, 15, 0, 0, has_year_zero=False),
+            cftime.DatetimeGregorian(2000, 1, 1, 0, 45, 0, 0, has_year_zero=False),
+            cftime.DatetimeGregorian(2000, 1, 2, 1, 15, 0, 0, has_year_zero=False),
+        ],
+        dtype=object,
+    ),
+    dims=["time"],
+    attrs={
+        "axis": "T",
+        "long_name": "time",
+        "standard_name": "time",
+    },
+)
 time_encoded = xr.DataArray(
     data=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
     dims=["time"],
@@ -162,6 +178,30 @@ time_bnds_hourly = xr.DataArray(
             [
                 cftime.DatetimeGregorian(2000, 1, 1, 2, 0, 0, 0, has_year_zero=False),
                 cftime.DatetimeGregorian(2000, 1, 1, 3, 0, 0, 0, has_year_zero=False),
+            ],
+        ],
+        dtype=object,
+    ),
+    dims=["time", "bnds"],
+    attrs={
+        "xcdat_bounds": "True",
+    },
+)
+time_bnds_subhourly = xr.DataArray(
+    name="time_bnds",
+    data=np.array(
+        [
+            [
+                cftime.DatetimeGregorian(2000, 1, 1, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2000, 1, 1, 0, 30, 0, 0, has_year_zero=False),
+            ],
+            [
+                cftime.DatetimeGregorian(2000, 1, 1, 0, 30, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2000, 1, 1, 1, 0, 0, 0, has_year_zero=False),
+            ],
+            [
+                cftime.DatetimeGregorian(2000, 1, 1, 1, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2000, 1, 1, 1, 30, 0, 0, has_year_zero=False),
             ],
         ],
         dtype=object,
@@ -406,8 +446,8 @@ def generate_dataset_by_frequency(freq: str = "month") -> xr.Dataset:
     Parameters
     ----------
     freq : str, optional
-        Frequency of time step (and bounds). Options include hour, day,
-        month, and year. Default is 'month'.
+        Frequency of time step (and bounds). Options include subhour, hour,
+        day, month, and year. Default is 'month'.
 
     Returns
     -------
@@ -427,6 +467,9 @@ def generate_dataset_by_frequency(freq: str = "month") -> xr.Dataset:
     if freq == "hour":
         time = time_hourly.copy()
         time_bnds = time_bnds_hourly.copy()
+    if freq == "subhour":
+        time = time_subhourly.copy()
+        time_bnds = time_bnds_subhourly.copy()
 
     # Create dataset
     ds = xr.Dataset(

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,4 +1,6 @@
 """This module stores reusable test fixtures."""
+from typing import Literal
+
 import cftime
 import numpy as np
 import xarray as xr
@@ -382,7 +384,7 @@ def generate_dataset(
     xr.Dataset
         Test dataset.
     """
-    # get correct data_var, time axis, and time_bnds
+    # Get the data_var, time axis, and time_bnds based on if time is decoded.
     if decode_times:
         ts = ts_decoded.copy()
         time = time_decoded.copy()
@@ -392,11 +394,9 @@ def generate_dataset(
         time = time_encoded.copy()
         time_bnds = time_bnds_encoded.copy()
 
-    # Create dataset
+    # Create the base dataset.
     ds = xr.Dataset(
-        data_vars={
-            "ts": ts,
-        },
+        data_vars={"ts": ts},
         coords={"lat": lat.copy(), "lon": lon.copy(), "time": time},
     )
 
@@ -429,16 +429,18 @@ def generate_dataset(
     return ds
 
 
-def generate_dataset_by_frequency(freq: str = "month") -> xr.Dataset:
-    """Generates a dataset of a given temporal frequency using coordinate
-    and data variable fixtures. The generated dataset is decoded,
-    cf-compliant, and includes bounds.
+def generate_dataset_by_frequency(
+    freq: Literal["subhour", "hour", "day", "month", "year"] = "month"
+) -> xr.Dataset:
+    """Generates a dataset for a given temporal frequency.
+
+    This function uses the coordinate and data variable fixtures to generate a
+    dataset that is decoded, cf-compliant, and includes bounds.
 
     Parameters
     ----------
-    freq : str, optional
-        Frequency of time step (and bounds). Options include subhour, hour,
-        day, month, and year. Default is 'month'.
+    freq : Literal["subhour", "hour", "day", "month", "year"], optional
+        Frequency of time step (and bounds), by default 'month'.
 
     Returns
     -------
@@ -449,24 +451,22 @@ def generate_dataset_by_frequency(freq: str = "month") -> xr.Dataset:
     if freq == "month":
         time = time_decoded.copy()
         time_bnds = time_bnds_decoded.copy()
-    if freq == "year":
+    elif freq == "year":
         time = time_yearly.copy()
         time_bnds = time_bnds_yearly.copy()
-    if freq == "day":
+    elif freq == "day":
         time = time_daily.copy()
         time_bnds = time_bnds_daily.copy()
-    if freq == "hour":
+    elif freq == "hour":
         time = time_hourly.copy()
         time_bnds = time_bnds_hourly.copy()
-    if freq == "subhour":
+    elif freq == "subhour":
         time = time_subhourly.copy()
         time_bnds = time_bnds_subhourly.copy()
 
-    # Create dataset
+    # Create the base dataset.
     ds = xr.Dataset(
-        data_vars={
-            "ts": ts_decoded,
-        },
+        data_vars={"ts": ts_decoded},
         coords={"lat": lat.copy(), "lon": lon.copy(), "time": time},
     )
 

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -440,7 +440,7 @@ class TestAddBounds:
 
         assert result.time_bnds.identical(expected_time_bnds)
 
-    def test_set_and_add_monthly_bounds(self):
+    def test_get_monthly_bounds(self):
         # reference dataset has bounds
         ds_with_bnds = self.ds_with_bnds.copy()
         # create test dataset
@@ -449,13 +449,11 @@ class TestAddBounds:
         # reproduces reference
         ds = ds.drop_vars("time_bnds")
         # generate time bounds
-        time_bnds = get_monthly_time_bounds(ds.time)
-        # add bounds to test dataset
-        result = ds.bounds.add_bounds("T", bounds=time_bnds)
+        result = get_monthly_time_bounds(ds.time)
 
-        assert result.identical(ds_with_bnds)
+        assert result.identical(ds_with_bnds.time_bnds)
 
-    def test_set_and_add_yearly_bounds(self):
+    def test_get_yearly_bounds(self):
         # reference dataset has bounds
         ds_with_bnds = self.ds_yearly_with_bnds.copy()
         # create test dataset
@@ -464,13 +462,11 @@ class TestAddBounds:
         # reproduces reference
         ds = ds.drop_vars("time_bnds")
         # generate time bounds
-        time_bnds = get_yearly_time_bounds(ds.time)
-        # add bounds to test dataset
-        result = ds.bounds.add_bounds("T", bounds=time_bnds)
+        result = get_yearly_time_bounds(ds.time)
 
-        assert result.identical(ds_with_bnds)
+        assert result.identical(ds_with_bnds.time_bnds)
 
-    def test_set_and_add_daily_bounds(self):
+    def test_get_daily_bounds(self):
         # reference dataset has bounds
         ds_with_bnds = self.ds_daily_with_bnds.copy()
         # create test dataset
@@ -479,13 +475,11 @@ class TestAddBounds:
         # reproduces reference
         ds = ds.drop_vars("time_bnds")
         # generate time bounds
-        time_bnds = get_daily_time_bounds(ds.time)
-        # add bounds to test dataset
-        result = ds.bounds.add_bounds("T", bounds=time_bnds)
+        result = get_daily_time_bounds(ds.time)
 
-        assert result.identical(ds_with_bnds)
+        assert result.identical(ds_with_bnds.time_bnds)
 
-    def test_set_and_add_hourly_bounds(self):
+    def test_get_hourly_bounds(self):
         # reference dataset has bounds
         ds_with_bnds = self.ds_hourly_with_bnds.copy()
         # create test dataset
@@ -494,11 +488,9 @@ class TestAddBounds:
         # reproduces reference
         ds = ds.drop_vars("time_bnds")
         # generate time bounds
-        time_bnds = get_daily_time_bounds(ds.time, frequency=24)
-        # add bounds to test dataset
-        result = ds.bounds.add_bounds("T", bounds=time_bnds)
+        result = get_daily_time_bounds(ds.time, frequency=24)
 
-        assert result.identical(ds_with_bnds)
+        assert result.identical(ds_with_bnds.time_bnds)
 
     def test_generate_monthly_bounds_for_eom_set_true(self):
         # reference dataset

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -87,12 +87,13 @@ class TestAddMissingBounds:
 
     def test_time_bounds_not_added_to_the_dataset_if_not_specified(self):
         ds = self.ds_with_bnds.copy()
+        # generate datasets without time bounds
         ds_no_time_bnds = ds.copy()
-
-        ds = ds.drop_vars(["time_bnds"])
         ds_no_time_bnds = ds_no_time_bnds.drop_vars(["time_bnds"])
-
+        ds = ds.drop_vars(["time_bnds"])
+        # add bounds
         result = ds.bounds.add_missing_bounds()
+        # ensure time bounds are not added
         assert result.identical(ds_no_time_bnds)
 
     def test_skips_adding_bounds_for_coords_that_are_1_dim_singleton(self):
@@ -294,6 +295,7 @@ class TestAddBounds:
         self.ds_with_bnds = generate_dataset(
             decode_times=True, cf_compliant=False, has_bounds=True
         )
+        # generate datasets of varying temporal frequencies
         self.ds_yearly_with_bnds = generate_dataset_by_frequency(freq="year")
         self.ds_daily_with_bnds = generate_dataset_by_frequency(freq="day")
         self.ds_hourly_with_bnds = generate_dataset_by_frequency(freq="hour")

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -13,10 +13,10 @@ from tests.fixtures import (
 )
 from xcdat.bounds import (
     BoundsAccessor,
-    get_daily_time_bounds,
-    get_monthly_time_bounds,
-    get_time_bounds,
-    get_yearly_time_bounds,
+    create_daily_time_bounds,
+    create_monthly_time_bounds,
+    create_time_bounds,
+    create_yearly_time_bounds,
 )
 from xcdat.temporal import _month_add
 
@@ -440,7 +440,7 @@ class TestAddBounds:
 
         assert result.time_bnds.identical(expected_time_bnds)
 
-    def test_get_monthly_bounds(self):
+    def test_create_monthly_bounds(self):
         # reference dataset has bounds
         ds_with_bnds = self.ds_with_bnds.copy()
         # create test dataset
@@ -449,11 +449,11 @@ class TestAddBounds:
         # reproduces reference
         ds = ds.drop_vars("time_bnds")
         # generate time bounds
-        result = get_monthly_time_bounds(ds.time)
+        result = create_monthly_time_bounds(ds.time)
 
         assert result.identical(ds_with_bnds.time_bnds)
 
-    def test_get_yearly_bounds(self):
+    def test_create_yearly_bounds(self):
         # reference dataset has bounds
         ds_with_bnds = self.ds_yearly_with_bnds.copy()
         # create test dataset
@@ -462,11 +462,11 @@ class TestAddBounds:
         # reproduces reference
         ds = ds.drop_vars("time_bnds")
         # generate time bounds
-        result = get_yearly_time_bounds(ds.time)
+        result = create_yearly_time_bounds(ds.time)
 
         assert result.identical(ds_with_bnds.time_bnds)
 
-    def test_get_daily_bounds(self):
+    def test_create_daily_bounds(self):
         # reference dataset has bounds
         ds_with_bnds = self.ds_daily_with_bnds.copy()
         # create test dataset
@@ -475,11 +475,11 @@ class TestAddBounds:
         # reproduces reference
         ds = ds.drop_vars("time_bnds")
         # generate time bounds
-        result = get_daily_time_bounds(ds.time)
+        result = create_daily_time_bounds(ds.time)
 
         assert result.identical(ds_with_bnds.time_bnds)
 
-    def test_get_hourly_bounds(self):
+    def test_create_hourly_bounds(self):
         # reference dataset has bounds
         ds_with_bnds = self.ds_hourly_with_bnds.copy()
         # create test dataset
@@ -488,11 +488,11 @@ class TestAddBounds:
         # reproduces reference
         ds = ds.drop_vars("time_bnds")
         # generate time bounds
-        result = get_daily_time_bounds(ds.time, frequency=24)
+        result = create_daily_time_bounds(ds.time, freq=24)
 
         assert result.identical(ds_with_bnds.time_bnds)
 
-    def test_generate_monthly_bounds_for_eom_set_true(self):
+    def test_create_monthly_bounds_for_eom_set_true(self):
         # reference dataset
         ds_with_bnds = self.ds_with_bnds.copy()
         # get time axis
@@ -524,11 +524,11 @@ class TestAddBounds:
         expected_time_bnds[:, 0] = lower
         expected_time_bnds[:, 1] = upper
         # test bounds generation
-        result = get_monthly_time_bounds(ds.time, end_of_month=True)
+        result = create_monthly_time_bounds(ds.time, end_of_month=True)
 
         assert result.identical(expected_time_bnds)
 
-    def test_generic_get_time_bounds_function(self):
+    def test_generic_create_time_bounds_function(self):
         # get reference datasets
         ds_subhrly_with_bnds = self.ds_subhourly_with_bnds.copy()
         ds_hrly_with_bnds = self.ds_hourly_with_bnds.copy()
@@ -544,13 +544,13 @@ class TestAddBounds:
         ds_yearly_wo_bnds = ds_yearly_with_bnds.drop_vars("time_bnds")
 
         # test adding bounds
-        hourly_bounds = get_time_bounds(ds_hrly_wo_bnds.time)
-        daily_bounds = get_time_bounds(ds_daily_wo_bnds.time)
-        monthly_bounds = get_time_bounds(ds_monthly_wo_bnds.time)
-        yearly_bounds = get_time_bounds(ds_yearly_wo_bnds.time)
+        hourly_bounds = create_time_bounds(ds_hrly_wo_bnds.time)
+        daily_bounds = create_time_bounds(ds_daily_wo_bnds.time)
+        monthly_bounds = create_time_bounds(ds_monthly_wo_bnds.time)
+        yearly_bounds = create_time_bounds(ds_yearly_wo_bnds.time)
         # sub hourly data is not supported
         with pytest.raises(ValueError):
-            get_time_bounds(ds_subhrly_wo_bnds.time)
+            create_time_bounds(ds_subhrly_wo_bnds.time)
 
         # ensure identical
         assert hourly_bounds.identical(ds_hrly_with_bnds.time_bnds)

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -11,14 +11,7 @@ from tests.fixtures import (
     lat_bnds,
     lon_bnds,
 )
-from xcdat.bounds import (
-    BoundsAccessor,
-    create_daily_time_bounds,
-    create_monthly_time_bounds,
-    create_time_bounds,
-    create_yearly_time_bounds,
-)
-from xcdat.temporal import _month_add
+from xcdat.bounds import BoundsAccessor
 
 logger = logging.getLogger(__name__)
 
@@ -82,19 +75,8 @@ class TestAddMissingBounds:
 
         ds = ds.drop_vars(["lat_bnds", "lon_bnds"])
 
-        result = ds.bounds.add_missing_bounds()
+        result = ds.bounds.add_missing_bounds(axes=["X", "Y"])
         assert result.identical(self.ds_with_bnds)
-
-    def test_time_bounds_not_added_to_the_dataset_if_not_specified(self):
-        ds = self.ds_with_bnds.copy()
-        # generate datasets without time bounds
-        ds_no_time_bnds = ds.copy()
-        ds_no_time_bnds = ds_no_time_bnds.drop_vars(["time_bnds"])
-        ds = ds.drop_vars(["time_bnds"])
-        # add bounds
-        result = ds.bounds.add_missing_bounds()
-        # ensure time bounds are not added
-        assert result.identical(ds_no_time_bnds)
 
     def test_skips_adding_bounds_for_coords_that_are_1_dim_singleton(self):
         # Length <=1
@@ -105,7 +87,7 @@ class TestAddMissingBounds:
         )
         ds = xr.Dataset(coords={"lon": lon})
 
-        result = ds.bounds.add_missing_bounds()
+        result = ds.bounds.add_missing_bounds(axes=["X"])
 
         assert result.identical(ds)
 
@@ -117,7 +99,34 @@ class TestAddMissingBounds:
         )
         ds = xr.Dataset(coords={"lon": lon})
 
-        result = ds.bounds.add_missing_bounds()
+        result = ds.bounds.add_missing_bounds(axes=["X"])
+
+        assert result.identical(ds)
+
+    def test_skips_adding_time_bounds_for_coords_that_are_1_dim_singleton(self):
+        # Length <=1
+        time = xr.DataArray(
+            data=np.array(["2000-01-01T12:00:00.000000000"], dtype="datetime64[ns]"),
+            dims=["time"],
+            attrs={"calendar": "standard", "units": "days since 1850-01-01"},
+        )
+        ds = xr.Dataset(coords={"time": time})
+
+        result = ds.bounds.add_missing_bounds(axes=["T"])
+
+        assert result.identical(ds)
+
+    def test_skips_adding_time_bounds_for_coords_that_are_not_datetime_like_objects(
+        self,
+    ):
+        time = xr.DataArray(
+            data=np.array([0, 1, 2]),
+            dims=["time"],
+            attrs={"calendar": "standard", "units": "days since 1850-01-01"},
+        )
+        ds = xr.Dataset(coords={"time": time})
+
+        result = ds.bounds.add_missing_bounds(axes=["T"])
 
         assert result.identical(ds)
 
@@ -295,11 +304,6 @@ class TestAddBounds:
         self.ds_with_bnds = generate_dataset(
             decode_times=True, cf_compliant=False, has_bounds=True
         )
-        # generate datasets of varying temporal frequencies
-        self.ds_yearly_with_bnds = generate_dataset_by_frequency(freq="year")
-        self.ds_daily_with_bnds = generate_dataset_by_frequency(freq="day")
-        self.ds_hourly_with_bnds = generate_dataset_by_frequency(freq="hour")
-        self.ds_subhourly_with_bnds = generate_dataset_by_frequency(freq="subhour")
 
     def test_raises_error_for_singleton_coords(self):
         # Length <=1
@@ -346,7 +350,7 @@ class TestAddBounds:
 
         assert ds.identical(result)
 
-    def test_add_bounds_for_dataset_with_time_coords_as_datetime_objects(self):
+    def test_adds_y_and_x_axis_bounds(self):
         ds = self.ds.copy()
         ds = ds.drop_dims("time")
         ds["time"] = xr.DataArray(
@@ -377,7 +381,107 @@ class TestAddBounds:
         assert result.lon_bnds.xcdat_bounds == "True"
         assert result.lon.attrs["bounds"] == "lon_bnds"
 
-        result = ds.bounds.add_bounds("T")
+
+class TestAddTimeBounds:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.ds = generate_dataset(
+            decode_times=True, cf_compliant=False, has_bounds=False
+        )
+        self.ds_with_bnds = generate_dataset(
+            decode_times=True, cf_compliant=False, has_bounds=True
+        )
+        # generate datasets of varying temporal frequencies
+        self.ds_yearly_with_bnds = generate_dataset_by_frequency(freq="year")
+        self.ds_daily_with_bnds = generate_dataset_by_frequency(freq="day")
+        self.ds_hourly_with_bnds = generate_dataset_by_frequency(freq="hour")
+        self.ds_subhourly_with_bnds = generate_dataset_by_frequency(freq="subhour")
+
+    def test_raises_error_for_non_decoded_time_coords_with_freq_method(self):
+        ds = self.ds.copy()
+        ds = ds.drop_dims("time")
+        ds["time"] = xr.DataArray(
+            name="time",
+            data=np.array([0, 1, 2], dtype="int64"),
+            dims=["time"],
+            attrs={
+                "axis": "T",
+                "long_name": "time",
+                "standard_name": "time",
+            },
+        )
+
+        with pytest.raises(TypeError):
+            ds.bounds.add_time_bounds(method="freq")
+
+    def test_skips_adding_bounds_for_coord_vars_with_bounds(self):
+        ds = self.ds_with_bnds.copy()
+        result = ds.bounds.add_time_bounds(method="freq")
+
+        assert ds.identical(result)
+
+    def test_add_bounds_for_np_datetime_time_coords_using_freq(self):
+        ds = self.ds.copy()
+        ds = ds.drop_dims("time")
+        ds["time"] = xr.DataArray(
+            name="time",
+            data=np.array(
+                [
+                    "2000-01-01T12:00:00.000000000",
+                    "2000-02-01T12:00:00.000000000",
+                    "2000-03-01T12:00:00.000000000",
+                ],
+                dtype="datetime64[ns]",
+            ),
+            dims=["time"],
+            attrs={
+                "axis": "T",
+                "long_name": "time",
+                "standard_name": "time",
+            },
+        )
+
+        result = ds.bounds.add_time_bounds(method="freq")
+        # NOTE: The algorithm for generating time bounds doesn't extend the
+        # upper bound into the next month.
+        expected_time_bnds = xr.DataArray(
+            name="time_bnds",
+            data=np.array(
+                [
+                    ["2000-01-01T00:00:00.000000000", "2000-02-01T00:00:00.000000000"],
+                    ["2000-02-01T00:00:00.000000000", "2000-03-01T00:00:00.000000000"],
+                    ["2000-03-01T00:00:00.000000000", "2000-04-01T00:00:00.000000000"],
+                ],
+                dtype="datetime64[ns]",
+            ),
+            coords={"time": ds.time.assign_attrs({"bounds": "time_bnds"})},
+            dims=["time", "bnds"],
+            attrs={"xcdat_bounds": "True"},
+        )
+
+        assert result.time_bnds.identical(expected_time_bnds)
+
+    def test_add_bounds_for_np_datetime_time_coords_as_midpoints(self):
+        ds = self.ds.copy()
+        ds = ds.drop_dims("time")
+        ds["time"] = xr.DataArray(
+            name="time",
+            data=np.array(
+                [
+                    "2000-01-01T12:00:00.000000000",
+                    "2000-02-01T12:00:00.000000000",
+                    "2000-03-01T12:00:00.000000000",
+                ],
+                dtype="datetime64[ns]",
+            ),
+            dims=["time"],
+            attrs={
+                "axis": "T",
+                "long_name": "time",
+                "standard_name": "time",
+            },
+        )
+        result = ds.bounds.add_time_bounds(method="midpoint")
         # NOTE: The algorithm for generating time bounds doesn't extend the
         # upper bound into the next month.
         expected_time_bnds = xr.DataArray(
@@ -397,7 +501,7 @@ class TestAddBounds:
 
         assert result.time_bnds.identical(expected_time_bnds)
 
-    def test_returns_bounds_for_dataset_with_time_coords_as_cftime_objects(self):
+    def test_returns_bounds_for_cftime_time_coords_using_freq(self):
         ds = self.ds.copy()
         ds = ds.drop_dims("time")
         ds["time"] = xr.DataArray(
@@ -414,7 +518,7 @@ class TestAddBounds:
         )
         ds["time"].encoding["calendar"] = "noleap"
 
-        result = ds.bounds.add_bounds("T")
+        result = ds.bounds.add_time_bounds(method="freq")
         expected_time_bnds = xr.DataArray(
             name="time_bnds",
             data=np.array(
@@ -440,65 +544,131 @@ class TestAddBounds:
 
         assert result.time_bnds.identical(expected_time_bnds)
 
-    def test_create_monthly_bounds(self):
-        # reference dataset has bounds
+    def test_returns_bounds_for_cftime_time_coords_as_midpoints(self):
+        ds = self.ds.copy()
+        ds = ds.drop_dims("time")
+        ds["time"] = xr.DataArray(
+            name="time",
+            data=np.array(
+                [
+                    cftime.DatetimeNoLeap(1850, 1, 1),
+                    cftime.DatetimeNoLeap(1850, 2, 1),
+                    cftime.DatetimeNoLeap(1850, 3, 1),
+                ],
+            ),
+            dims=["time"],
+            attrs={
+                "axis": "T",
+                "long_name": "time",
+                "standard_name": "time",
+            },
+        )
+
+        result = ds.bounds.add_bounds("T")
+        expected_time_bnds = xr.DataArray(
+            name="time_bnds",
+            data=np.array(
+                [
+                    [
+                        cftime.DatetimeNoLeap(1849, 12, 16, 12),
+                        cftime.DatetimeNoLeap(1850, 1, 16, 12),
+                    ],
+                    [
+                        cftime.DatetimeNoLeap(1850, 1, 16, 12),
+                        cftime.DatetimeNoLeap(1850, 2, 15, 0),
+                    ],
+                    [
+                        cftime.DatetimeNoLeap(1850, 2, 15, 0),
+                        cftime.DatetimeNoLeap(1850, 3, 15, 0),
+                    ],
+                ],
+            ),
+            coords={"time": ds.time.assign_attrs({"bounds": "time_bnds"})},
+            dims=["time", "bnds"],
+            attrs={"xcdat_bounds": "True"},
+        )
+
+        assert result.time_bnds.identical(expected_time_bnds)
+
+    def test_add_bounds_for_time_coords_using_inferred_freq(self):
+        # get reference datasets
+        ds_subhrly_with_bnds = self.ds_subhourly_with_bnds.copy()
+        ds_hrly_with_bnds = self.ds_hourly_with_bnds.copy()
+        ds_daily_with_bnds = self.ds_daily_with_bnds.copy()
+        ds_monthly_with_bnds = self.ds_with_bnds.copy()
+        ds_yearly_with_bnds = self.ds_yearly_with_bnds.copy()
+
+        # drop bounds for testing
+        ds_subhrly_wo_bnds = ds_subhrly_with_bnds.drop_vars("time_bnds")
+        ds_hrly_wo_bnds = ds_hrly_with_bnds.drop_vars("time_bnds")
+        ds_daily_wo_bnds = ds_daily_with_bnds.drop_vars("time_bnds")
+        ds_monthly_wo_bnds = ds_monthly_with_bnds.drop_vars("time_bnds")
+        ds_yearly_wo_bnds = ds_yearly_with_bnds.drop_vars("time_bnds")
+
+        # test adding bounds
+        hourly_bounds = ds_hrly_wo_bnds.bounds.add_time_bounds(method="freq", freq=None)
+        daily_bounds = ds_daily_wo_bnds.bounds.add_time_bounds(method="freq", freq=None)
+        monthly_bounds = ds_monthly_wo_bnds.bounds.add_time_bounds(
+            method="freq", freq=None
+        )
+        yearly_bounds = ds_yearly_wo_bnds.bounds.add_time_bounds(
+            method="freq", freq=None
+        )
+
+        # sub hourly data is not supported
+        with pytest.raises(ValueError):
+            ds_subhrly_wo_bnds.bounds.add_time_bounds(method="freq", freq=None)
+
+        # ensure identical
+        assert hourly_bounds.identical(ds_hrly_with_bnds)
+        assert daily_bounds.identical(ds_daily_with_bnds)
+        assert monthly_bounds.identical(ds_monthly_with_bnds)
+        assert yearly_bounds.identical(ds_yearly_with_bnds)
+
+    def test_add_bounds_for_time_coords_with_different_frequencies(self):
+        # get reference datasets
+        ds_subhrly_with_bnds = self.ds_subhourly_with_bnds.copy()
+        ds_hrly_with_bnds = self.ds_hourly_with_bnds.copy()
+        ds_daily_with_bnds = self.ds_daily_with_bnds.copy()
+        ds_monthly_with_bnds = self.ds_with_bnds.copy()
+        ds_yearly_with_bnds = self.ds_yearly_with_bnds.copy()
+
+        # drop bounds for testing
+        ds_subhrly_wo_bnds = ds_subhrly_with_bnds.drop_vars("time_bnds")
+        ds_hrly_wo_bnds = ds_hrly_with_bnds.drop_vars("time_bnds")
+        ds_daily_wo_bnds = ds_daily_with_bnds.drop_vars("time_bnds")
+        ds_monthly_wo_bnds = ds_monthly_with_bnds.drop_vars("time_bnds")
+        ds_yearly_wo_bnds = ds_yearly_with_bnds.drop_vars("time_bnds")
+
+        # test adding bounds
+        hourly_bounds = ds_hrly_wo_bnds.bounds.add_time_bounds(
+            method="freq", freq="hour"
+        )
+        daily_bounds = ds_daily_wo_bnds.bounds.add_time_bounds(
+            method="freq", freq="day"
+        )
+        monthly_bounds = ds_monthly_wo_bnds.bounds.add_time_bounds(
+            method="freq", freq="month"
+        )
+        yearly_bounds = ds_yearly_wo_bnds.bounds.add_time_bounds(
+            method="freq", freq="year"
+        )
+
+        # sub hourly data is not supported
+        with pytest.raises(ValueError):
+            ds_subhrly_wo_bnds.bounds.add_time_bounds(method="freq", freq="hour")
+
+        # ensure identical
+        assert hourly_bounds.identical(ds_hrly_with_bnds)
+        assert daily_bounds.identical(ds_daily_with_bnds)
+        assert monthly_bounds.identical(ds_monthly_with_bnds)
+        assert yearly_bounds.identical(ds_yearly_with_bnds)
+
+    def test_add_monthly_bounds_for_end_of_month_set_to_true(self):
         ds_with_bnds = self.ds_with_bnds.copy()
-        # create test dataset
-        ds = self.ds_with_bnds.copy()
-        # drop bounds to see if get_monthly_time_bounds
-        # reproduces reference
-        ds = ds.drop_vars("time_bnds")
-        # generate time bounds
-        result = create_monthly_time_bounds(ds.time)
 
-        assert result.identical(ds_with_bnds.time_bnds)
-
-    def test_create_yearly_bounds(self):
-        # reference dataset has bounds
-        ds_with_bnds = self.ds_yearly_with_bnds.copy()
-        # create test dataset
-        ds = self.ds_yearly_with_bnds.copy()
-        # drop bounds to see if get_yearly_time_bounds
-        # reproduces reference
-        ds = ds.drop_vars("time_bnds")
-        # generate time bounds
-        result = create_yearly_time_bounds(ds.time)
-
-        assert result.identical(ds_with_bnds.time_bnds)
-
-    def test_create_daily_bounds(self):
-        # reference dataset has bounds
-        ds_with_bnds = self.ds_daily_with_bnds.copy()
-        # create test dataset
-        ds = self.ds_daily_with_bnds.copy()
-        # drop bounds to see if get_daily_time_bounds
-        # reproduces reference
-        ds = ds.drop_vars("time_bnds")
-        # generate time bounds
-        result = create_daily_time_bounds(ds.time)
-
-        assert result.identical(ds_with_bnds.time_bnds)
-
-    def test_create_hourly_bounds(self):
-        # reference dataset has bounds
-        ds_with_bnds = self.ds_hourly_with_bnds.copy()
-        # create test dataset
-        ds = self.ds_hourly_with_bnds.copy()
-        # drop bounds to see if get_daily_time_bounds
-        # reproduces reference
-        ds = ds.drop_vars("time_bnds")
-        # generate time bounds
-        result = create_daily_time_bounds(ds.time, freq=24)
-
-        assert result.identical(ds_with_bnds.time_bnds)
-
-    def test_create_monthly_bounds_for_eom_set_true(self):
-        # reference dataset
-        ds_with_bnds = self.ds_with_bnds.copy()
-        # get time axis
+        # Get time axis and create new axis with time set to first day of month.
         time = ds_with_bnds.time
-        # create new axis with time set to first day of month
-        # this is required for this test
         new_time = []
         for i, t in enumerate(time.values):
             y = t.year
@@ -515,45 +685,145 @@ class TestAddBounds:
         )
         time.encoding = {"calendar": "standard"}
         ds_with_bnds["time"] = time
+
         # test dataset
         ds = ds_with_bnds.drop_vars("time_bnds")
-        # expect time bounds minus one month
-        expected_time_bnds = ds_with_bnds.time_bnds
-        lower = _month_add(expected_time_bnds[:, 0], -1, "standard")
-        upper = _month_add(expected_time_bnds[:, 1], -1, "standard")
-        expected_time_bnds[:, 0] = lower
-        expected_time_bnds[:, 1] = upper
-        # test bounds generation
-        result = create_monthly_time_bounds(ds.time, end_of_month=True)
+        result = ds.bounds.add_time_bounds(
+            method="freq", freq="month", end_of_month=True
+        )
 
-        assert result.identical(expected_time_bnds)
+        expected = ds_with_bnds.copy()
+        # Expect time bounds minus one month
+        expected["time_bnds"] = xr.DataArray(
+            name="time_bnds",
+            data=np.array(
+                [
+                    [
+                        cftime.DatetimeGregorian(
+                            1999, 12, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 1, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 1, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 2, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 2, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 3, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 3, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 4, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 4, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 5, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 5, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 6, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 6, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 7, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 7, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 8, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 8, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 9, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 9, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 10, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 10, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 11, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 11, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2000, 12, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2000, 12, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2001, 1, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2001, 1, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2001, 2, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                    [
+                        cftime.DatetimeGregorian(
+                            2001, 11, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                        cftime.DatetimeGregorian(
+                            2001, 12, 1, 0, 0, 0, 0, has_year_zero=False
+                        ),
+                    ],
+                ],
+                dtype=object,
+            ),
+            dims=["time", "bnds"],
+            coords={"time": expected.time},
+            attrs={"xcdat_bounds": "True"},
+        )
 
-    def test_generic_create_time_bounds_function(self):
-        # get reference datasets
-        ds_subhrly_with_bnds = self.ds_subhourly_with_bnds.copy()
-        ds_hrly_with_bnds = self.ds_hourly_with_bnds.copy()
-        ds_daily_with_bnds = self.ds_daily_with_bnds.copy()
-        ds_monthly_with_bnds = self.ds_with_bnds.copy()
-        ds_yearly_with_bnds = self.ds_yearly_with_bnds.copy()
-
-        # drop bounds for testing
-        ds_subhrly_wo_bnds = ds_subhrly_with_bnds.drop_vars("time_bnds")
-        ds_hrly_wo_bnds = ds_hrly_with_bnds.drop_vars("time_bnds")
-        ds_daily_wo_bnds = ds_daily_with_bnds.drop_vars("time_bnds")
-        ds_monthly_wo_bnds = ds_monthly_with_bnds.drop_vars("time_bnds")
-        ds_yearly_wo_bnds = ds_yearly_with_bnds.drop_vars("time_bnds")
-
-        # test adding bounds
-        hourly_bounds = create_time_bounds(ds_hrly_wo_bnds.time)
-        daily_bounds = create_time_bounds(ds_daily_wo_bnds.time)
-        monthly_bounds = create_time_bounds(ds_monthly_wo_bnds.time)
-        yearly_bounds = create_time_bounds(ds_yearly_wo_bnds.time)
-        # sub hourly data is not supported
-        with pytest.raises(ValueError):
-            create_time_bounds(ds_subhrly_wo_bnds.time)
-
-        # ensure identical
-        assert hourly_bounds.identical(ds_hrly_with_bnds.time_bnds)
-        assert daily_bounds.identical(ds_daily_with_bnds.time_bnds)
-        assert monthly_bounds.identical(ds_monthly_with_bnds.time_bnds)
-        assert yearly_bounds.identical(ds_yearly_with_bnds.time_bnds)
+        assert result.identical(expected)

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -73,6 +73,16 @@ class TestAddMissingBounds:
         result = ds.bounds.add_missing_bounds()
         assert result.identical(self.ds_with_bnds)
 
+    def test_time_bounds_not_added_to_the_dataset_if_not_specified(self):
+        ds = self.ds_with_bnds.copy()
+        ds_no_time_bnds = ds.copy()
+
+        ds = ds.drop_vars(["time_bnds"])
+        ds_no_time_bnds = ds_no_time_bnds.drop_vars(["time_bnds"])
+
+        result = ds.bounds.add_missing_bounds()
+        assert result.identical(ds_no_time_bnds)
+
     def test_skips_adding_bounds_for_coords_that_are_1_dim_singleton(self):
         # Length <=1
         lon = xr.DataArray(

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -398,7 +398,7 @@ class TestAddBounds:
         )
         assert result.time_bnds.identical(expected_time_bnds)
 
-    def test_ignores_adding_bounds_for_singleton_coordinates_unrelated_unrelated_to_an_axis(
+    def test_ignores_adding_bounds_for_singleton_coordinate_unrelated_to_an_axis(
         self,
     ):
         ds = self.ds.copy()
@@ -495,7 +495,7 @@ class TestAddTimeBounds:
 
         assert ds.identical(result)
 
-    def test_ignores_adding_bounds_for_singleton_coordinates_unrelated_to_the_time_axis(
+    def test_ignores_adding_bounds_for_singleton_coordinate_unrelated_to_the_time_axis(
         self,
     ):
         ds = self.ds.copy()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2284,18 +2284,35 @@ class Test_PostProcessDataset:
         with pytest.raises(KeyError):
             _postprocess_dataset(ds, center_times=True)
 
-    def test_adds_missing_lat_and_lon_bounds(self):
+    def test_adds_missing_lat_and_lon_bounds_does_not_add_time_bounds(self):
         # Create expected dataset without bounds.
         ds = generate_dataset(decode_times=True, cf_compliant=False, has_bounds=False)
 
         data_vars = list(ds.data_vars.keys())
         assert "lat_bnds" not in data_vars
         assert "lon_bnds" not in data_vars
+        assert "time_bnds" not in data_vars
 
         result = _postprocess_dataset(ds, add_bounds=True)
         result_data_vars = list(result.data_vars.keys())
         assert "lat_bnds" in result_data_vars
         assert "lon_bnds" in result_data_vars
+        assert "time_bnds" not in result_data_vars
+
+    def test_adds_missing_lat_and_lon_and_time_bounds(self):
+        # Create expected dataset without bounds.
+        ds = generate_dataset(decode_times=True, cf_compliant=False, has_bounds=False)
+
+        data_vars = list(ds.data_vars.keys())
+        assert "lat_bnds" not in data_vars
+        assert "lon_bnds" not in data_vars
+        assert "time_bnds" not in data_vars
+
+        result = _postprocess_dataset(ds, add_bounds=True, bounds_axes=["X", "Y", "T"])
+        result_data_vars = list(result.data_vars.keys())
+        assert "lat_bnds" in result_data_vars
+        assert "lon_bnds" in result_data_vars
+        assert "time_bnds" in result_data_vars
 
     def test_orients_longitude_bounds_from_180_to_360_and_sorts_with_prime_meridian_cell(
         self,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -78,6 +78,16 @@ class TestOpenDataset:
 
         assert result.identical(expected)
 
+    def test_skips_adding_bounds(self):
+        ds = generate_dataset(decode_times=True, cf_compliant=True, has_bounds=False)
+        ds.to_netcdf(self.file_path)
+
+        result = open_dataset(self.file_path, add_bounds=False)
+        assert result.identical(ds)
+
+        result = open_dataset(self.file_path, add_bounds=None)
+        assert result.identical(ds)
+
     def test_decode_time_in_days(self):
         ds = generate_dataset(decode_times=False, cf_compliant=True, has_bounds=True)
         ds.to_netcdf(self.file_path)
@@ -625,6 +635,16 @@ class TestOpenMfDataset:
 
         expected = ds1.merge(ds2)
         assert result.identical(expected)
+
+    def test_skips_adding_bounds(self):
+        ds = generate_dataset(decode_times=True, cf_compliant=True, has_bounds=False)
+        ds.to_netcdf(self.file_path1)
+
+        result = open_mfdataset(self.file_path1, add_bounds=False)
+        assert result.identical(ds)
+
+        result = open_mfdataset(self.file_path1, add_bounds=None)
+        assert result.identical(ds)
 
     def test_raises_error_if_xml_does_not_have_root_directory_attr(self):
         ds1 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
@@ -2284,7 +2304,7 @@ class Test_PostProcessDataset:
         with pytest.raises(KeyError):
             _postprocess_dataset(ds, center_times=True)
 
-    def test_adds_missing_lat_and_lon_bounds_does_not_add_time_bounds(self):
+    def test_adds_missing_lat_and_lon_bounds_by_default(self):
         # Create expected dataset without bounds.
         ds = generate_dataset(decode_times=True, cf_compliant=False, has_bounds=False)
 
@@ -2293,7 +2313,7 @@ class Test_PostProcessDataset:
         assert "lon_bnds" not in data_vars
         assert "time_bnds" not in data_vars
 
-        result = _postprocess_dataset(ds, add_bounds=True)
+        result = _postprocess_dataset(ds, add_bounds=["X", "Y"])
         result_data_vars = list(result.data_vars.keys())
         assert "lat_bnds" in result_data_vars
         assert "lon_bnds" in result_data_vars
@@ -2308,7 +2328,7 @@ class Test_PostProcessDataset:
         assert "lon_bnds" not in data_vars
         assert "time_bnds" not in data_vars
 
-        result = _postprocess_dataset(ds, add_bounds=True, bounds_axes=["X", "Y", "T"])
+        result = _postprocess_dataset(ds, add_bounds=["X", "Y", "T"])
         result_data_vars = list(result.data_vars.keys())
         assert "lat_bnds" in result_data_vars
         assert "lon_bnds" in result_data_vars

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -7,7 +7,7 @@ from xarray.tests import requires_dask
 
 from tests.fixtures import generate_dataset
 from xcdat.logger import setup_custom_logger
-from xcdat.temporal import TemporalAccessor
+from xcdat.temporal import TemporalAccessor, _month_add
 
 logger = setup_custom_logger("xcdat.temporal", propagate=True)
 
@@ -3330,3 +3330,91 @@ class Test_Averager:
                     "custom_seasons": None,
                 },
             )
+
+
+class TestTemporalFunctions:
+    def test_month_add_plus_minus(self):
+
+        # add a single month
+        time_slice = cftime.DatetimeGregorian(2000, 1, 15, 0, 0, 0)
+        expected = cftime.DatetimeGregorian(2000, 2, 15, 0, 0, 0)
+        result = _month_add(time_slice, 1, "standard")
+
+        assert result == expected
+
+        # add 99 years and 5 months
+        time_slice = cftime.DatetimeGregorian(2000, 1, 15, 0, 0, 0)
+        expected = cftime.DatetimeGregorian(2099, 6, 15, 0, 0, 0)
+        result = _month_add(time_slice, 1193, "standard")
+
+        assert result == expected
+
+        # subtract 18 months
+        time_slice = cftime.DatetimeGregorian(2000, 1, 15, 0, 0, 0)
+        expected = cftime.DatetimeGregorian(1998, 7, 15, 0, 0, 0)
+        result = _month_add(time_slice, -18, "standard")
+
+        assert result == expected
+
+        # subtract a vector
+        ds = generate_dataset(decode_times=True, cf_compliant=False, has_bounds=True)
+
+        time_vector = ds.time
+        expected = np.array(
+            [
+                cftime.DatetimeGregorian(
+                    1998, 12, 16, 12, 0, 0, 0, has_year_zero=False
+                ),
+                cftime.DatetimeGregorian(1999, 1, 15, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(1999, 2, 16, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(1999, 3, 16, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(1999, 4, 16, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(1999, 5, 16, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(1999, 6, 16, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(1999, 7, 16, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(1999, 8, 16, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(1999, 9, 16, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(1999, 10, 16, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(
+                    1999, 11, 16, 12, 0, 0, 0, has_year_zero=False
+                ),
+                cftime.DatetimeGregorian(
+                    1999, 12, 16, 12, 0, 0, 0, has_year_zero=False
+                ),
+                cftime.DatetimeGregorian(2000, 1, 15, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(
+                    2000, 11, 16, 12, 0, 0, 0, has_year_zero=False
+                ),
+            ],
+            dtype=object,
+        )
+        result = _month_add(time_vector, -13, "standard")
+
+        assert np.alltrue(result == expected)
+
+        # add a vector
+        expected = np.array(
+            [
+                cftime.DatetimeGregorian(2005, 7, 16, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2005, 8, 15, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2005, 9, 16, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2005, 10, 16, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(
+                    2005, 11, 16, 12, 0, 0, 0, has_year_zero=False
+                ),
+                cftime.DatetimeGregorian(2005, 12, 16, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2006, 1, 16, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2006, 2, 16, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2006, 3, 16, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2006, 4, 16, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2006, 5, 16, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2006, 6, 16, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2006, 7, 16, 12, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2006, 8, 15, 0, 0, 0, 0, has_year_zero=False),
+                cftime.DatetimeGregorian(2007, 6, 16, 12, 0, 0, 0, has_year_zero=False),
+            ],
+            dtype=object,
+        )
+        result = _month_add(time_vector, 66, "standard")
+
+        assert np.alltrue(result == expected)

--- a/xcdat/__init__.py
+++ b/xcdat/__init__.py
@@ -6,6 +6,12 @@ from xcdat.axis import (  # noqa: F401
     swap_lon_axis,
 )
 from xcdat.bounds import BoundsAccessor  # noqa: F401
+from xcdat.bounds import (
+    create_daily_time_bounds,
+    create_monthly_time_bounds,
+    create_time_bounds,
+    create_yearly_time_bounds,
+)
 from xcdat.dataset import decode_time, open_dataset, open_mfdataset  # noqa: F401
 from xcdat.regridder.accessor import RegridderAccessor  # noqa: F401
 from xcdat.regridder.grid import (  # noqa: F401

--- a/xcdat/__init__.py
+++ b/xcdat/__init__.py
@@ -6,12 +6,6 @@ from xcdat.axis import (  # noqa: F401
     swap_lon_axis,
 )
 from xcdat.bounds import BoundsAccessor  # noqa: F401
-from xcdat.bounds import (
-    create_daily_time_bounds,
-    create_monthly_time_bounds,
-    create_time_bounds,
-    create_yearly_time_bounds,
-)
 from xcdat.dataset import decode_time, open_dataset, open_mfdataset  # noqa: F401
 from xcdat.regridder.accessor import RegridderAccessor  # noqa: F401
 from xcdat.regridder.grid import (  # noqa: F401

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -130,14 +130,17 @@ class BoundsAccessor:
         bounds to its coordinates if they don't exist. The coordinates must meet
         the following criteria in order to add bounds:
 
-          1. The axis for the coordinates are "X", "Y", "T", or "Z"
-          2. Coordinates are a single dimension, not multidimensional
-          3. Coordinates are a length > 1 (not singleton)
-          4. Bounds must not already exist.
-             * Determined by attempting to map the coordinate variable's
-             "bounds" attr (if set) to the bounds data variable of the same key.
-          5. Time axes must be composed of datetime-like objects (`np.datetime64`
-             or `cftime`).
+        1. The axis for the coordinates are "X", "Y", "T", or "Z"
+        2. Coordinates are a single dimension, not multidimensional
+        3. Coordinates are a length > 1 (not singleton)
+        4. Bounds must not already exist
+
+           * Coordinates are mapped to bounds using the "bounds" attr. For
+             example, bounds exist if ``ds.time.attrs["bounds"]`` is set to
+             ``"time_bnds"`` and ``ds.time_bnds`` is present in the dataset.
+
+        5. Time axes must be composed of datetime-like objects
+           (`np.datetime64` or `cftime`).
 
         If coordinates do not meet that criteria, bounds are not added for them.
 
@@ -261,12 +264,14 @@ class BoundsAccessor:
         To add bounds for an axis, its coordinates must be the following
         criteria:
 
-          1. The axis for the coordinates are "X", "Y", "T", or "Z"
-          2. Coordinates are single dimensional, not multidimensional
-          3. Coordinates are a length > 1 (not singleton)
-          4. Bounds must not already exist
-             * Determined by attempting to map the coordinate variable's
-             "bounds" attr (if set) to the bounds data variable of the same key
+        1. The axis for the coordinates are "X", "Y", "T", or "Z"
+        2. Coordinates are single dimensional, not multidimensional
+        3. Coordinates are a length > 1 (not singleton)
+        4. Bounds must not already exist
+
+           * Coordinates are mapped to bounds using the "bounds" attr. For
+             example, bounds exist if ``ds.time.attrs["bounds"]`` is set to
+             ``"time_bnds"`` and ``ds.time_bnds`` is present in the dataset.
 
         Parameters
         ----------
@@ -321,13 +326,16 @@ class BoundsAccessor:
         to add bounds for each of them if they don't exist. To add time bounds
         for the time axis, its coordinates must be the following criteria:
 
-          1. Coordinates are single dimensional, not multidimensional
-          2. Coordinates are a length > 1 (not singleton)
-          3. Bounds must not already exist
-             * Determined by attempting to map the coordinate variable's
-               "bounds" attr (if set) to the bounds data variable of the same key
-          4. If ``method=freq``, coordinates must be composed of datetime-like
-             objects (`np.datetime64` or `cftime`)
+        1. Coordinates are single dimensional, not multidimensional
+        2. Coordinates are a length > 1 (not singleton)
+        3. Bounds must not already exist
+
+           * Coordinates are mapped to bounds using the "bounds" attr. For
+             example, bounds exist if ``ds.time.attrs["bounds"]`` is set to
+             ``"time_bnds"`` and ``ds.time_bnds`` is present in the dataset.
+
+        4. If ``method=freq``, coordinates must be composed of datetime-like
+           objects (``np.datetime64`` or ``cftime``)
 
         Parameters
         ----------
@@ -336,9 +344,9 @@ class BoundsAccessor:
             "freq" or "midpoint".
 
             * "freq": Create time bounds as the start and end of each timestep's
-               period using either the inferred or specified time frequency
-               (``freq`` parameter). For example, the time bounds will be the
-               start and end of each month for each monthly coordinate point.
+              period using either the inferred or specified time frequency
+              (``freq`` parameter). For example, the time bounds will be the
+              start and end of each month for each monthly coordinate point.
             * "midpoint": Create time bounds using time coordinates as the
               midpoint between their upper and lower bounds.
 
@@ -362,11 +370,12 @@ class BoundsAccessor:
         end_of_month : bool, optional
             If ``freq=="month"``, this flag notes that the timepoint is saved
             at the end of the monthly interval (see Note), by default False.
-            Some timepoints are saved at the end of the interval, e.g., Feb. 1
-            00:00 for the time interval Jan. 1 00:00 - Feb. 1 00:00. Since this
-            method determines the month and year from the time vector, the
-            bounds will be set incorrectly if the timepoint is set to the end of
-            the time interval. For these cases, set ``end_of_month=True``.
+
+            * Some timepoints are saved at the end of the interval, e.g., Feb. 1
+              00:00 for the time interval Jan. 1 00:00 - Feb. 1 00:00. Since this
+              method determines the month and year from the time vector, the
+              bounds will be set incorrectly if the timepoint is set to the end of
+              the time interval. For these cases, set ``end_of_month=True``.
 
         Returns
         -------
@@ -418,11 +427,11 @@ class BoundsAccessor:
         loop over coordinates related to an axis and attempts to add bounds if
         they don't exist. If ancillary coordinates are present, "ValueError:
         Cannot generate bounds for coordinate variable 'height' which has a
-        length <= 1 (singleton)" is raised. For the purpose of adding bounds,
-        we temporarily drop any ancillary singletons from dimension 
-        coordinates before looping over those coordinates. Ancillary 
-        singletons will still be present in the final xr.Dataset object to 
-        maintain its integrity.
+        length <= 1 (singleton)" is raised. For the purpose of adding bounds, we
+        temporarily drop any ancillary singletons from dimension coordinates
+        before looping over those coordinates. Ancillary singletons will still
+        be present in the final Dataset object to maintain the Dataset's
+        integrity.
 
         Parameters
         ----------

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -115,7 +115,7 @@ class BoundsAccessor:
             )
         )
 
-    def add_missing_bounds(self) -> xr.Dataset:
+    def add_missing_bounds(self, axes: List[CFAxisKey] = ["X", "Y"]) -> xr.Dataset:
         """Adds missing coordinate bounds for supported axes in the Dataset.
 
         This function loops through the Dataset's axes and attempts to adds
@@ -129,12 +129,16 @@ class BoundsAccessor:
              * Determined by attempting to map the coordinate variable's
              "bounds" attr (if set) to the bounds data variable of the same key.
 
+        Parameters
+        ----------
+        axes : List[str], optional
+            List of CF axes that function should operate on, default ["X", "Y"].
+
         Returns
         -------
         xr.Dataset
         """
         ds = self._dataset.copy()
-        axes = CF_ATTR_MAP.keys()
 
         for axis in axes:
             try:

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -319,13 +319,13 @@ class BoundsAccessor:
 
         This method loops over the time axis coordinate variables and attempts
         to add bounds for each of them if they don't exist. To add time bounds
-        for an axis, its coordinates must be the following criteria:
+        for the time axis, its coordinates must be the following criteria:
 
           1. Coordinates are single dimensional, not multidimensional
           2. Coordinates are a length > 1 (not singleton)
           3. Bounds must not already exist
              * Determined by attempting to map the coordinate variable's
-             "bounds" attr (if set) to the bounds data variable of the same key
+               "bounds" attr (if set) to the bounds data variable of the same key
           4. If ``method=freq``, coordinates must be composed of datetime-like
              objects (`np.datetime64` or `cftime`)
 
@@ -412,14 +412,17 @@ class BoundsAccessor:
         dimension coordinates as ancillary coordinates. For example, the
         "height" singleton coordinate will be attached to "time" coordinates
         even though "height" is related to the "Z" axis, not the "T" axis.
+        Refer to [1]_ for more info on this Xarray behavior.
 
         This is an undesirable behavior in xCDAT because the add bounds methods
         loop over coordinates related to an axis and attempts to add bounds if
         they don't exist. If ancillary coordinates are present, "ValueError:
         Cannot generate bounds for coordinate variable 'height' which has a
-        length <= 1 (singleton)" is raised. To work around this Xarray behavior,
-        we drop the ancilliary singleton coordinates before adding bounds. Refer
-        to [1]_ for more info on this behavior.
+        length <= 1 (singleton)" is raised. For the purpose of adding bounds,
+        we temporarily drop any ancillary singletons from dimension 
+        coordinates before looping over those coordinates. Ancillary 
+        singletons will still be present in the final xr.Dataset object to 
+        maintain its integrity.
 
         Parameters
         ----------

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -10,11 +10,16 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from xarray.coding.cftime_offsets import get_date_type
+from xarray.core.common import contains_cftime_datetimes
 
 from xcdat.axis import CF_ATTR_MAP, CFAxisKey, get_dim_coords
 from xcdat.dataset import _get_data_var
 from xcdat.logger import setup_custom_logger
-from xcdat.temporal import _infer_freq, _month_add
+from xcdat.temporal import (
+    _contains_datetime_like_objects,
+    _get_datetime_like_type,
+    _infer_freq,
+)
 
 logger = setup_custom_logger(__name__)
 
@@ -61,7 +66,7 @@ class BoundsAccessor:
 
     Add missing coordinate bounds for supported axes in the Dataset:
 
-    >>> ds = ds.bounds.add_missing_bounds()
+    >>> ds = ds.bounds.add_missing_bounds(axes=["X", "Y", "T"])
 
     Get coordinate bounds if they exist:
 
@@ -118,7 +123,7 @@ class BoundsAccessor:
             )
         )
 
-    def add_missing_bounds(self, axes: List[CFAxisKey] = ["X", "Y"]) -> xr.Dataset:
+    def add_missing_bounds(self, axes: List[CFAxisKey]) -> xr.Dataset:  # noqa: C901
         """Adds missing coordinate bounds for supported axes in the Dataset.
 
         This function loops through the Dataset's axes and attempts to adds
@@ -131,12 +136,16 @@ class BoundsAccessor:
           4. Bounds must not already exist.
              * Determined by attempting to map the coordinate variable's
              "bounds" attr (if set) to the bounds data variable of the same key.
-          5. Time axes should be composed of `cftime` objects.
+          5. Time axes must be composed of datetime-like objects (`np.datetime64`
+             or `cftime`).
+
+        If coordinates do not meet that criteria, bounds are not added for them.
 
         Parameters
         ----------
-        axes : List[str], optional
-            List of CF axes that function should operate on, default ["X", "Y"].
+        axes : List[str]
+            List of CF axes that function should operate on. Options include
+            "X", "Y", "T", or "Z".
 
         Returns
         -------
@@ -153,16 +162,22 @@ class BoundsAccessor:
             for coord in coords.coords.values():
                 try:
                     self.get_bounds(axis, str(coord.name))
+
                     continue
                 except KeyError:
                     pass
 
                 try:
-                    bounds = self._create_bounds(axis, coord)
-                    ds[bounds.name] = bounds
-                    ds[coord.name].attrs["bounds"] = bounds.name
-                except ValueError:
+                    if axis in ["X", "Y", "Z"]:
+                        bounds = self._create_bounds(axis, coord)
+                    elif axis == "T":
+                        bounds = self._create_time_bounds(coord)
+                except (ValueError, TypeError) as e:
+                    logger.warning(e)
                     continue
+
+                ds[bounds.name] = bounds
+                ds[coord.name].attrs["bounds"] = bounds.name
 
         return ds
 
@@ -232,24 +247,26 @@ class BoundsAccessor:
         return bounds
 
     def add_bounds(self, axis: CFAxisKey) -> xr.Dataset:
-        """Add bounds for an axis using its coordinate points.
+        """Add bounds for an axis using its coordinates as midpoints.
 
         This method loops over the axis's coordinate variables and attempts to
-        add bounds for each of them if they don't exist. The coordinates must
-        meet the following criteria in order to add bounds:
+        add bounds for each of them if they don't exist. Each coordinate point
+        is the midpoint between their lower and upper bounds.
+
+        To add bounds for an axis, its coordinates must be the following
+        criteria:
 
           1. The axis for the coordinates are "X", "Y", "T", or "Z"
           2. Coordinates are single dimensional, not multidimensional
           3. Coordinates are a length > 1 (not singleton)
-          4. Bounds must not already exist.
+          4. Bounds must not already exist
              * Determined by attempting to map the coordinate variable's
-             "bounds" attr (if set) to the bounds data variable of the same key.
-          5. Time axes should be composed of `cftime` objects.
+             "bounds" attr (if set) to the bounds data variable of the same key
 
         Parameters
         ----------
         axis : CFAxisKey
-            The CF axis key ("X", "Y", "T", or "Z").
+            The CF axis key ("X", "Y", "T", "Z").
 
         Returns
         -------
@@ -257,15 +274,6 @@ class BoundsAccessor:
             The dataset with bounds added.
 
         Raises
-        ------
-        ValueError
-            If bounds already exist. They must be dropped first.
-
-        Notes
-        -----
-        For temporal coordinates ``add_bounds`` will attempt to set the bounds
-        to the start and end of each time step's period. Time axes are expected
-        to be composed of ``cftime`` objects.
         """
         ds = self._dataset.copy()
         self._validate_axis_arg(axis)
@@ -284,6 +292,95 @@ class BoundsAccessor:
                 continue
             except KeyError:
                 bounds = self._create_bounds(axis, coord)
+
+                ds[bounds.name] = bounds
+                ds[coord.name].attrs["bounds"] = bounds.name
+
+        return ds
+
+    def add_time_bounds(
+        self,
+        method: Literal["freq", "midpoint"],
+        freq: Optional[Literal["year", "month", "day", "hour"]] = None,
+        daily_subfreq: Optional[Literal[1, 2, 3, 4, 6, 8, 12, 24]] = None,
+        end_of_month: bool = False,
+    ) -> xr.Dataset:
+        """Add bounds for an axis using its coordinate points.
+
+        This method loops over the time axis coordinate variables and attempts
+        to add bounds for each of them if they don't exist. To add time bounds
+        for an axis, its coordinates must be the following criteria:
+
+          1. Coordinates are single dimensional, not multidimensional
+          2. Coordinates are a length > 1 (not singleton)
+          3. Bounds must not already exist
+             * Determined by attempting to map the coordinate variable's
+             "bounds" attr (if set) to the bounds data variable of the same key
+          4. If ``method=freq``, coordinates must be composed of datetime-like
+             objects (`np.datetime64` or `cftime`)
+
+        Parameters
+        ----------
+        method : {"freq", "midpoint"}
+            The method for creating time bounds for time coordinates, either
+            "freq" or "midpoint".
+
+            * "freq": Create time bounds as the start and end of each timestep's
+               period using either the inferred or specified time frequency
+               (``freq`` parameter). For example, the time bounds will be the
+               start and end of each month for each monthly coordinate point.
+            * "midpoint": Create time bounds using time coordinates as the
+              midpoint between their upper and lower bounds.
+
+        freq : {"year", "month", "day", "hour"}, optional
+            If ``method="freq"``, this parameter specifies the time frequency
+            for creating time bounds. By default None, which infers the
+            frequency using the time coordinates.
+        daily_subfreq : {1, 2, 3, 4, 6, 8, 12, 24}, optional
+            If ``freq=="hour"``, this parameter sets the number of timepoints
+            per day for time bounds, by default None.
+
+            * ``daily_subfreq=None`` infers the daily time frequency from the
+              time coordinates.
+            * ``daily_subfreq=1`` is daily
+            * ``daily_subfreq=2`` is twice daily
+            * ``daily_subfreq=4`` is 6-hourly
+            * ``daily_subfreq=8`` is 3-hourly
+            * ``daily_subfreq=12`` is 2-hourly
+            * ``daily_subfreq=24`` is hourly
+
+        end_of_month : bool, optional
+            If ``freq=="month"``, this flag notes that the timepoint is saved
+            at the end of the monthly interval (see Note), by default False.
+            Some timepoints are saved at the end of the interval, e.g., Feb. 1
+            00:00 for the time interval Jan. 1 00:00 - Feb. 1 00:00. Since this
+            method determines the month and year from the time vector, the
+            bounds will be set incorrectly if the timepoint is set to the end of
+            the time interval. For these cases, set ``end_of_month=True``.
+
+        Returns
+        -------
+        xr.Dataset
+            The dataset with time bounds added.
+        """
+        ds = self._dataset.copy()
+        coord_vars: Union[xr.DataArray, xr.Dataset] = get_dim_coords(self._dataset, "T")
+
+        for coord in coord_vars.coords.values():
+            # Check if the coord var has a "bounds" attr and the bounds actually
+            # exist in the Dataset. If it does not, then add the bounds.
+            try:
+                bounds_key = ds[coord.name].attrs["bounds"]
+                ds[bounds_key]
+
+                continue
+            except KeyError:
+                if method == "freq":
+                    bounds = self._create_time_bounds(
+                        coord, freq, daily_subfreq, end_of_month
+                    )
+                elif method == "midpoint":
+                    bounds = self._create_bounds("T", coord)
 
                 ds[bounds.name] = bounds
                 ds[coord.name].attrs["bounds"] = bounds.name
@@ -324,7 +421,10 @@ class BoundsAccessor:
         return list(set(keys))
 
     def _create_bounds(self, axis: CFAxisKey, coord_var: xr.DataArray) -> xr.DataArray:
-        """Creates bounds for an axis using its coordinate points.
+        """Creates bounds for an axis using coordinate points as midpoints.
+
+        This method uses each coordinate point as the midpoint between its
+        lower and upper bound.
 
         Parameters
         ----------
@@ -377,12 +477,8 @@ class BoundsAccessor:
         # `cftime` objects only support arithmetic using `timedelta` objects, so
         # the values of  `diffs` must be casted from `dtype="timedelta64[ns]"`
         # to `timedelta` objects.
-        if axis == "T" and issubclass(type(coord_var.values[0]), cftime.datetime):
-            bounds = create_time_bounds(coord_var)
-            return bounds
-
-        # width parameter: determines bounds location relative to midpoints
-        width = 0.5
+        if axis == "T" and contains_cftime_datetimes(xr.as_variable(coord_var)):
+            diffs = pd.to_timedelta(diffs)
 
         # FIXME: These lines produces the warning: `PerformanceWarning:
         # Adding/subtracting object-dtype array to TimedeltaArray not
@@ -391,7 +487,8 @@ class BoundsAccessor:
         # implementation.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=pd.errors.PerformanceWarning)
-            # Get lower and upper bounds by using the width relative to nearest point.
+
+            width = 0.5
             lower_bounds = coord_var - diffs[:-1] * width
             upper_bounds = coord_var + diffs[1:] * (1 - width)
 
@@ -428,6 +525,334 @@ class BoundsAccessor:
 
         return bounds
 
+    def _create_time_bounds(
+        self,
+        time: xr.DataArray,
+        freq: Optional[Literal["year", "month", "day", "hour"]] = None,
+        daily_subfreq: Optional[Literal[1, 2, 3, 4, 6, 8, 12, 24]] = None,
+        end_of_month: bool = False,
+    ) -> xr.DataArray:
+        """Creates time bounds for each timestep of the time coordinate axis.
+
+        This method creates time bounds as the start and end of each timestep's
+        period using either the inferred or specified time frequency (``freq``
+        parameter). For example, the time bounds will be the start and end of
+        each month for each monthly coordinate point.
+
+        Parameters
+        ----------
+        time : xr.DataArray
+            The temporal coordinate variable for the axis.
+        freq : {"year", "month", "day", "hour"}, optional
+            The time frequency for creating time bounds, by default None (infer
+            the frequency).
+        daily_subfreq : {1, 2, 3, 4, 6, 8, 12, 24}, optional
+            If ``freq=="hour"``, this parameter sets the number of timepoints
+            per day for bounds, by default None. If greater than 1, sub-daily
+            bounds are created.
+
+            * ``daily_subfreq=None`` infers the freq from the time coords (default)
+            * ``daily_subfreq=1`` is daily
+            * ``daily_subfreq=2`` is twice daily
+            * ``daily_subfreq=4`` is 6-hourly
+            * ``daily_subfreq=8`` is 3-hourly
+            * ``daily_subfreq=12`` is 2-hourly
+            * ``daily_subfreq=24`` is hourly
+
+        end_of_month : bool, optional
+            If `freq=="month"``, this flag notes that the timepoint is saved
+            at the end of the monthly interval (see Note), by default False.
+
+        Returns
+        -------
+        xr.DataArray
+            A DataArray storing bounds for the time axis.
+
+        Raises
+        ------
+        ValueError
+            If coordinates are a singleton.
+        TypeError
+            If time coordinates are not composed of datetime-like objects.
+
+        Note
+        ----
+        Some timepoints are saved at the end of the interval, e.g., Feb. 1 00:00
+        for the time interval Jan. 1 00:00 - Feb. 1 00:00. Since this function
+        determines the month and year from the time vector, the bounds will be set
+        incorrectly if the timepoint is set to the end of the time interval. For
+        these cases, set ``end_of_month=True``.
+        """
+        is_singleton = time.size <= 1
+        if is_singleton:
+            raise ValueError(
+                f"Cannot generate bounds for coordinate variable '{time.name}'"
+                " which has a length <= 1 (singleton)."
+            )
+
+        if not _contains_datetime_like_objects(time):
+            raise TypeError(
+                f"Bounds cannot be created for '{time.name}' coordinates because it is "
+                "not decoded as `cftime.datetime` or `np.datetime`. Try decoding "
+                f"'{time.name}' first then adding bounds."
+            )
+
+        freq = _infer_freq(time) if freq is None else freq  # type: ignore
+        timesteps = time.values
+
+        # Determine the object type for creating time bounds based on the
+        # object type/dtype of the time coordinates.
+        if _get_datetime_like_type(time) == np.datetime64:
+            # Cast time values from `np.datetime64` to `pd.Timestamp` (a
+            # sub-class of `np.datetime64`) in order to get access to the
+            # pandas time/date components which simplifies creating bounds.
+            # https://pandas.pydata.org/docs/user_guide/timeseries.html#time-date-components
+            timesteps = pd.to_datetime(timesteps)
+            obj_type = pd.Timestamp
+        elif _get_datetime_like_type(time) == cftime.datetime:
+            calendar = time.encoding["calendar"]
+            obj_type = get_date_type(calendar)
+
+        if freq == "year":
+            time_bnds = self._create_yearly_time_bounds(timesteps, obj_type)
+        elif freq == "month":
+            time_bnds = self._create_monthly_time_bounds(
+                timesteps, obj_type, end_of_month
+            )
+        elif freq == "day":
+            time_bnds = self._create_daily_time_bounds(timesteps, obj_type)
+        elif freq == "hour":
+            # Determine the daily frequency for generating time  bounds.
+            if daily_subfreq is None:
+                diff = time.values[1] - time.values[0]
+                hrs = diff.seconds / 3600
+                daily_subfreq = int(24 / hrs)  # type: ignore
+
+            time_bnds = self._create_daily_time_bounds(timesteps, obj_type, freq=daily_subfreq)  # type: ignore
+
+        # Create the bounds data array
+        da_time_bnds = xr.DataArray(
+            name=f"{time.name}_bnds",
+            data=time_bnds,
+            coords={time.name: time},
+            dims=[*time.dims, "bnds"],
+            attrs={"xcdat_bounds": "True"},
+        )
+
+        return da_time_bnds
+
+    def _create_yearly_time_bounds(
+        self,
+        timesteps: np.ndarray,
+        obj_type: Union[cftime.datetime, pd.Timestamp],
+    ) -> List[Union[cftime.datetime, pd.Timestamp]]:
+        """Creates time bounds for each timestep with the start and end of the year.
+
+        Bounds for each timestep correspond to Jan. 1 00:00:00 of the year of the
+        timestep and Jan. 1 00:00:00 of the subsequent year.
+
+        Parameters
+        ----------
+        timesteps : np.ndarray
+            An array of timesteps, represented as either `cftime.datetime` or
+            `pd.Timestamp` (casted from `np.datetime64[ns]` to support pandas
+            time/date components).
+        obj_type : Union[cftime.datetime, pd.Timestamp]
+            The object type for time bounds based on the dtype of
+            ``time_values``.
+
+        Returns
+        -------
+        List[Union[cftime.datetime, pd.Timestamp]]
+            A list of time bound values.
+        """
+        time_bnds: List[cftime.datetime] = []
+
+        for step in timesteps:
+            year = step.year
+
+            l_bnd = obj_type(year, 1, 1, 0, 0)
+            u_bnd = obj_type(year + 1, 1, 1, 0, 0)
+
+            time_bnds.append([l_bnd, u_bnd])
+
+        return time_bnds
+
+    def _create_monthly_time_bounds(
+        self,
+        timesteps: np.ndarray,
+        obj_type: Union[cftime.datetime, pd.Timestamp],
+        end_of_month: bool = False,
+    ) -> List[Union[cftime.datetime, pd.Timestamp]]:
+        """Creates time bounds for each timestep with the start and end of the month.
+
+        Bounds for each timestep correspond to 00:00:00 on the first of the month
+        and 00:00:00 on the first of the subsequent month.
+
+        Parameters
+        ----------
+        timesteps : np.ndarray
+            An array of timesteps, represented as either `cftime.datetime` or
+            `pd.Timestamp` (casted from `np.datetime64[ns]` to support pandas
+            time/date components).
+        obj_type : Union[cftime.datetime, pd.Timestamp]
+            The object type for time bounds based on the dtype of
+            ``time_values``.
+        end_of_month : bool, optional
+            Flag to note that the timepoint is saved at the end of the monthly
+            interval (see Note), by default False.
+
+        Returns
+        -------
+        List[Union[cftime.datetime, pd.Timestamp]]
+            A list of time bound values.
+
+        Note
+        ----
+        Some timepoints are saved at the end of the interval, e.g., Feb. 1 00:00
+        for the time interval Jan. 1 00:00 - Feb. 1 00:00. Since this function
+        determines the month and year from the time vector, the bounds will be set
+        incorrectly if the timepoint is set to the end of the time interval. For
+        these cases, set ``end_of_month=True``.
+        """
+        time_bnds = []
+
+        for step in timesteps:
+            # If end of time interval and first day of year then subtract one
+            # month so bounds will be calculated correctly.
+            if (end_of_month) & (step.day < 2):
+                step = self._add_months_to_timestep(step, obj_type, delta=-1)
+
+            year, month = step.year, step.month
+
+            l_bnd = obj_type(year, month, 1, 0, 0)
+            u_bnd = self._add_months_to_timestep(l_bnd, obj_type, delta=1)
+
+            time_bnds.append([l_bnd, u_bnd])
+
+        return time_bnds
+
+    def _add_months_to_timestep(
+        self,
+        timestep: Union[cftime.datetime, pd.Timestamp],
+        obj_type: Union[cftime.datetime, pd.Timestamp],
+        delta: int,
+    ) -> Union[cftime.datetime, pd.Timestamp]:
+        """Adds delta month(s) to a timestep.
+
+        The delta value can be positive or negative (for subtraction). Refer to [1]_
+        for logic.
+
+        Parameters
+        ----------
+        timestep : Union[cftime.datime, pd.Timestamp]
+            A timestep represented as ``cftime.datetime`` or ``pd.Timestamp``.
+        obj_type : Union[cftime.datetime, pd.Timestamp]
+                The object type for time bounds based on the dtype of
+                ``timestep``.
+        delta : int
+            Integer months to be added to times (can be positive or negative)
+
+        Returns
+        -------
+        Union[cftime.datetime, pd.Timestamp]
+
+        References
+        ----------
+        [1] https://stackoverflow.com/a/4131114
+        """
+        # Compute the new month and year with the delta month(s).
+        month = timestep.month - 1 + delta
+        year = timestep.year + month // 12
+        month = month % 12 + 1
+
+        # Re-use existing hour/minute/second/microsecond.
+        hour = timestep.hour
+        minute = timestep.minute
+        second = timestep.second
+        microsecond = timestep.microsecond
+
+        # If day is greater than days in month use days in month as day.
+        day = timestep.day
+        dim = obj_type(year, month, 1).daysinmonth
+        day = min(day, dim)
+
+        # Create the new timestep.
+        new_timestep = obj_type(year, month, day, hour, minute, second, microsecond)
+
+        return new_timestep
+
+    def _create_daily_time_bounds(
+        self,
+        timesteps: np.ndarray,
+        obj_type: Union[cftime.datetime, pd.Timestamp],
+        freq: Literal[1, 2, 3, 4, 6, 8, 12, 24] = 1,
+    ) -> List[Union[cftime.datetime, pd.Timestamp]]:
+        """Creates time bounds for each timestep with the start and end of the day.
+
+        Bounds for each timestep corresponds to 00:00:00 timepoint on the
+        current day and 00:00:00 on the subsequent day.
+
+        Parameters
+        ----------
+        timesteps : np.ndarray
+            An array of timesteps, represented as either `cftime.datetime` or
+            `pd.Timestamp` (casted from `np.datetime64[ns]` to support pandas
+            time/date components).
+        obj_type : Union[cftime.datetime, pd.Timestamp]
+            The object type for time bounds based on the dtype of
+            ``time_values``.
+        freq : {1, 2, 3, 4, 6, 8, 12, 24}, optional
+            Number of timepoints per day, by default 1. If greater than 1, sub-daily
+            bounds are created.
+
+            * ``freq=1`` is daily (default)
+            * ``freq=2`` is twice daily
+            * ``freq=4`` is 6-hourly
+            * ``freq=8`` is 3-hourly
+            * ``freq=12`` is 2-hourly
+            * ``freq=24`` is hourly
+
+        Returns
+        -------
+        List[Union[cftime.datetime, pd.Timestamp]]
+            A list of time bound values.
+
+        Raises
+        ------
+        ValueError
+            If an incorrect ``freq`` argument is passed. Should be 1, 2, 3, 4, 6, 8,
+            12, or 24.
+
+        Notes
+        -----
+        This function is intended to reproduce CDAT's ``setAxisTimeBoundsDaily``
+        method [3]_.
+
+        References
+        ----------
+        .. [3] https://github.com/CDAT/cdutil/blob/master/cdutil/times.py#L1093
+        """
+        if (freq > 24) | (np.mod(24, freq)):
+            raise ValueError(
+                "Incorrect `freq` argument. Supported values include 1, 2, 3, 4, 6, 8, 12, "
+                "and 24."
+            )
+
+        time_bnds = []
+
+        for step in timesteps:
+            y, m, d, h = step.year, step.month, step.day, step.hour
+
+            for f in range(freq):
+                if f * (24 // freq) <= h < (f + 1) * (24 // freq):
+                    l_bnd = obj_type(y, m, d, f * (24 // freq))
+                    u_bnd = l_bnd + datetime.timedelta(hours=(24 // freq))
+
+            time_bnds.append([l_bnd, u_bnd])
+
+        return time_bnds
+
     def _validate_axis_arg(self, axis: CFAxisKey):
         cf_axis_keys = CF_ATTR_MAP.keys()
 
@@ -438,229 +863,3 @@ class BoundsAccessor:
             )
 
         get_dim_coords(self._dataset, axis)
-
-
-def create_yearly_time_bounds(time: xr.DataArray) -> xr.DataArray:
-    """Creates time bounds for each timestep with the start and end of the year.
-
-    Bounds for each timestep correspond to Jan. 1 00:00:00 of the year of the
-    timestep and Jan. 1 00:00:00 of the subsequent year.
-
-    Parameters
-    ----------
-    time : xr.DataArray
-        The temporal coordinate variable for the axis.
-
-    Returns
-    -------
-    xr.DataArray
-        The monthly time bounds array.
-    """
-    # Get the calendar type from the time coordinates to determine the `cftime`
-    # object to represent bounds values.
-    calendar = time.encoding["calendar"]
-    cf_obj = get_date_type(calendar)
-
-    # Loop over the time values to generate a bounds DataArray.
-    time_bnds = []
-    for step in time.values:
-        year = step.year
-
-        l_bnd = cf_obj(year, 1, 1, 0, 0)
-        u_bnd = cf_obj(year + 1, 1, 1, 0, 0)
-
-        time_bnds.append([l_bnd, u_bnd])
-
-    da_time_bnds = xr.DataArray(
-        name=f"{time.name}_bnds",
-        data=time_bnds,
-        coords=dict(time=time),
-        dims=[*time.dims, "bnds"],
-        attrs={"xcdat_bounds": "True"},
-    )
-
-    return da_time_bnds
-
-
-def create_monthly_time_bounds(
-    time: xr.DataArray, end_of_month: bool = False
-) -> xr.DataArray:
-    """Creates time bounds for each timestep with the start and end of the month.
-
-    Bounds for each timestep correspond to 00:00:00 on the first of the month
-    and 00:00:00 on the first of the subsequent month.
-
-    Parameters
-    ----------
-    time : xr.DataArray
-        The temporal coordinate variable for the axis.
-    end_of_month : bool, optional
-        Flag to note that the timepoint is saved at the end of the monthly
-        interval (see Note), by default False.
-
-    Returns
-    -------
-    xr.DataArray
-        The monthly time bounds array
-
-    Note
-    ----
-    Some timepoints are saved at the end of the interval, e.g., Feb. 1 00:00
-    for the time interval Jan. 1 00:00 - Feb. 1 00:00. Since this function
-    determines the month and year from the time vector, the bounds will be set
-    incorrectly if the timepoint is set to the end of the time interval. For
-    these cases, set ``end_of_month=True``.
-    """
-    # Get the calendar type from the time coordinates to determine the `cftime`
-    # object to represent bounds values.
-    calendar = time.encoding["calendar"]
-    cf_obj = get_date_type(calendar)
-
-    # Loop over the time values to generate a bounds DataArray.
-    time_bnds = []
-    for step in time.values:
-        # If end of time interval and first day of year then subtract one month
-        # so bounds will be calculated correctly.
-        if (end_of_month) & (step.day < 2):
-            step = _month_add(step, -1, calendar)
-
-        year, month = step.year, step.month
-
-        l_bnd = cf_obj(year, month, 1, 0, 0)
-        u_bnd = _month_add(l_bnd, 1, calendar)
-
-        time_bnds.append([l_bnd, u_bnd])
-
-    da_time_bnds = xr.DataArray(
-        name=f"{time.name}_bnds",
-        data=time_bnds,
-        coords=dict(time=time),
-        dims=[*time.dims, "bnds"],
-        attrs={"xcdat_bounds": "True"},
-    )
-
-    return da_time_bnds
-
-
-def create_daily_time_bounds(
-    time: xr.DataArray, freq: Literal[1, 2, 3, 4, 6, 8, 12, 24] = 1
-) -> xr.DataArray:
-    """Creates time bounds for each timestep with the start and end of the day.
-
-    Bounds for each timestep corresponds to 00:00:00 timepoint on the
-    current day and 00:00:00 on the subsequent day.
-
-    Parameters
-    ----------
-    time : xr.DataArray
-        The temporal coordinate variable for the axis.
-    freq : Literal[1, 2, 3, 4, 6, 8, 12, 24], optional
-        Number of timepoints per day, by default 1. If greater than 1, sub-daily
-        bounds are created.
-
-         * ``freq=1`` is daily (default)
-         * ``freq=2`` is twice daily
-         * ``freq=4`` is 6-hourly
-         * ``freq=8`` is 3-hourly
-         * ``freq=12`` is 2-hourly
-         * ``freq=24`` is hourly
-
-    Returns
-    -------
-    xr.DataArray
-        The daily or sub-daily time bounds array
-
-    Raises
-    ------
-    ValueError
-        If an incorrect ``freq`` argument is passed. Should be 1, 2, 3, 4, 6, 8,
-        12, or 24.
-
-    Notes
-    -----
-    This function is intended to reproduce CDAT's ``setAxisTimeBoundsDaily``
-    method [3]_.
-
-    References
-    ----------
-    .. [3] https://github.com/CDAT/cdutil/blob/master/cdutil/times.py#L1093
-    """
-    if (freq > 24) | (np.mod(24, freq)):
-        raise ValueError(
-            "Incorrect `freq` argument. Supported values include 1, 2, 3, 4, 6, 8, 12, "
-            "and 24."
-        )
-
-    # Get the calendar type from the time coordinates to determine the `cftime`
-    # object to represent bounds values.
-    calendar = time.encoding["calendar"]
-    cf_obj = get_date_type(calendar)
-
-    # Loop over the time values to generate a bounds DataArray.
-    time_bnds = []
-    for step in time.values:
-        y, m, d, h = step.year, step.month, step.day, step.hour
-        for f in range(freq):
-            if f * (24 // freq) <= h < (f + 1) * (24 // freq):
-                l_bnd = cf_obj(y, m, d, f * (24 // freq))
-                u_bnd = l_bnd + datetime.timedelta(hours=(24 // freq))
-        time_bnds.append([l_bnd, u_bnd])
-
-    da_time_bnds = xr.DataArray(
-        name=f"{time.name}_bnds",
-        data=time_bnds,
-        coords=dict(time=time),
-        dims=[*time.dims, "bnds"],
-        attrs={"xcdat_bounds": "True"},
-    )
-
-    return da_time_bnds
-
-
-def create_time_bounds(time: xr.DataArray) -> xr.DataArray:
-    """Creates time bounds for each timestep of the time coordinate axis.
-
-    This function uses ``_infer_freq`` to determine the temporal resolution and
-    then calls ``get_yearly_time_bounds``, ``get_monthly_time_bounds``, or
-    ``get_daily_time_bounds`` as appropriate. See the docstrings for these
-    functions for more details.
-
-    Parameters
-    ----------
-    time : xr.DataArray
-        The temporal coordinate variable for the axis.
-
-    Returns
-    -------
-    xr.DataArray
-        The bounds for the time axis.
-
-    Examples
-    --------
-    # TODO
-    """
-    freq = _infer_freq(time)
-    if freq == "year":
-        time_bnds = create_yearly_time_bounds(time)
-    elif freq == "month":
-        time_bnds = create_monthly_time_bounds(time)
-    elif freq == "day":
-        time_bnds = create_daily_time_bounds(time)
-    elif freq == "hour":
-        # Determine the daily frequency for generating time  bounds.
-        diff = time.values[1] - time.values[0]
-        hrs = diff.seconds / 3600
-        daily_freq = int(24 / hrs)
-
-        time_bnds = create_daily_time_bounds(time, freq=daily_freq)  # type: ignore
-
-    # Create the bounds data array
-    time_bnds = xr.DataArray(
-        name=f"{time.name}_bnds",
-        data=time_bnds,
-        coords={time.name: time},
-        dims=[*time.dims, "bnds"],
-        attrs={"xcdat_bounds": "True"},
-    )
-
-    return time_bnds

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -2,7 +2,7 @@
 import collections
 import datetime
 import warnings
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 import cf_xarray as cfxr  # noqa: F401
 import cftime
@@ -261,6 +261,11 @@ class BoundsAccessor:
         ValueError
             If bounds already exist. They must be dropped first.
 
+        Notes
+        -----
+        For temporal coordinates ``add_bounds`` will attempt to set the bounds
+        to the start and end of each time step's period. Time axes are expected
+        to be composed of ``cftime`` objects.
         """
         ds = self._dataset.copy()
         self._validate_axis_arg(axis)
@@ -340,14 +345,15 @@ class BoundsAccessor:
 
         Notes
         -----
-        Based on [1]_ ``iris.coords._guess_bounds`` and [2]_ ``cf_xarray.accessor.add_bounds.``
-        For temporal coordinates ``_create_bounds`` will attempt to set the bounds to the start
-        and end of each time step's period. Time axes are expected to be composed of ``cftime``
-        objects.
+        Based on [1]_ ``iris.coords._guess_bounds`` and [2]_
+        ``cf_xarray.accessor.add_bounds``.
+
+        For temporal coordinates ``_create_bounds`` will attempt to set the
+        bounds to the start and end of each time step's period. Time axes are
+        expected to be composed of ``cftime`` objects.
 
         References
         ----------
-
         .. [1] https://scitools-iris.readthedocs.io/en/stable/generated/api/iris/coords.html#iris.coords.AuxCoord.guess_bounds
 
         .. [2] https://cf-xarray.readthedocs.io/en/latest/generated/xarray.Dataset.cf.add_bounds.html#
@@ -372,7 +378,7 @@ class BoundsAccessor:
         # the values of  `diffs` must be casted from `dtype="timedelta64[ns]"`
         # to `timedelta` objects.
         if axis == "T" and issubclass(type(coord_var.values[0]), cftime.datetime):
-            bounds = get_time_bounds(coord_var)
+            bounds = create_time_bounds(coord_var)
             return bounds
 
         # width parameter: determines bounds location relative to midpoints
@@ -434,37 +440,38 @@ class BoundsAccessor:
         get_dim_coords(self._dataset, axis)
 
 
-def get_yearly_time_bounds(time):
-    """Sets the time bounds to the start and end of the year
-    for each timestep (this corresponds to Jan. 1 00:00:00 of the
-    year of the timestep and Jan. 1 00:00:00 of the subsequent year.
+def create_yearly_time_bounds(time: xr.DataArray) -> xr.DataArray:
+    """Creates time bounds for each timestep with the start and end of the year.
+
+    Bounds for each timestep correspond to Jan. 1 00:00:00 of the year of the
+    timestep and Jan. 1 00:00:00 of the subsequent year.
+
+    Parameters
+    ----------
+    time : xr.DataArray
+        The temporal coordinate variable for the axis.
 
     Returns
     -------
-    time : xr.DataArray
-        The temporal coordinate variable for the axis.
     xr.DataArray
-        The monthly time bounds array
+        The monthly time bounds array.
     """
-    # get calendar
+    # Get the calendar type from the time coordinates to determine the `cftime`
+    # object to represent bounds values.
     calendar = time.encoding["calendar"]
-
-    # get cftime class to create new cftime objects
     cf_obj = get_date_type(calendar)
 
-    # loop over time values and compute bounds
+    # Loop over the time values to generate a bounds DataArray.
     time_bnds = []
     for step in time.values:
-        # get year
         year = step.year
-        # calculate bounds
+
         l_bnd = cf_obj(year, 1, 1, 0, 0)
         u_bnd = cf_obj(year + 1, 1, 1, 0, 0)
-        # store
+
         time_bnds.append([l_bnd, u_bnd])
 
-    # create dataarray
-    time_bnds = xr.DataArray(  # type: ignore
+    da_time_bnds = xr.DataArray(
         name=f"{time.name}_bnds",
         data=time_bnds,
         coords=dict(time=time),
@@ -472,21 +479,24 @@ def get_yearly_time_bounds(time):
         attrs={"xcdat_bounds": "True"},
     )
 
-    return time_bnds
+    return da_time_bnds
 
 
-def get_monthly_time_bounds(time, end_of_month=False):
-    """Sets the time bounds to the start and end of the month
-    for each timestep (this corresponds to 00:00:00 on the first
-    of the month and 00:00:00 on the first of the subsequent month.
+def create_monthly_time_bounds(
+    time: xr.DataArray, end_of_month: bool = False
+) -> xr.DataArray:
+    """Creates time bounds for each timestep with the start and end of the month.
+
+    Bounds for each timestep correspond to 00:00:00 on the first of the month
+    and 00:00:00 on the first of the subsequent month.
 
     Parameters
     ----------
     time : xr.DataArray
         The temporal coordinate variable for the axis.
-    end_of_month : bool, optional, default False
+    end_of_month : bool, optional
         Flag to note that the timepoint is saved at the end of the monthly
-        interval (see Note).
+        interval (see Note), by default False.
 
     Returns
     -------
@@ -496,35 +506,32 @@ def get_monthly_time_bounds(time, end_of_month=False):
     Note
     ----
     Some timepoints are saved at the end of the interval, e.g., Feb. 1 00:00
-    for the time interval Jan. 1 00:00 - Feb. 1 00:00. Since this routine
+    for the time interval Jan. 1 00:00 - Feb. 1 00:00. Since this function
     determines the month and year from the time vector, the bounds will be set
-    incorrectly if the timepoint is set to the end of the time interval. For these
-    cases, set end_of_month to True.
+    incorrectly if the timepoint is set to the end of the time interval. For
+    these cases, set ``end_of_month=True``.
     """
-    # get calendar
+    # Get the calendar type from the time coordinates to determine the `cftime`
+    # object to represent bounds values.
     calendar = time.encoding["calendar"]
-
-    # get cftime class to create new cftime objects
     cf_obj = get_date_type(calendar)
 
-    # loop over time values and compute bounds
+    # Loop over the time values to generate a bounds DataArray.
     time_bnds = []
     for step in time.values:
-        # if end of time interval and first day of year
-        # subtract one month so bounds will be calculated
-        # correctly
+        # If end of time interval and first day of year then subtract one month
+        # so bounds will be calculated correctly.
         if (end_of_month) & (step.day < 2):
             step = _month_add(step, -1, calendar)
-        # get year / month
+
         year, month = step.year, step.month
-        # calculate bounds
+
         l_bnd = cf_obj(year, month, 1, 0, 0)
         u_bnd = _month_add(l_bnd, 1, calendar)
-        # store
+
         time_bnds.append([l_bnd, u_bnd])
 
-    # create dataarray
-    time_bnds = xr.DataArray(  # type: ignore
+    da_time_bnds = xr.DataArray(
         name=f"{time.name}_bnds",
         data=time_bnds,
         coords=dict(time=time),
@@ -532,25 +539,31 @@ def get_monthly_time_bounds(time, end_of_month=False):
         attrs={"xcdat_bounds": "True"},
     )
 
-    return time_bnds
+    return da_time_bnds
 
 
-def get_daily_time_bounds(time, frequency=1):
-    """Sets the time bounds to the start and end of the day
-    for each timestep (this corresponds to 00:00:00 of the
-    timepoint day and 00:00:00 on the subsequent day.
+def create_daily_time_bounds(
+    time: xr.DataArray, freq: Literal[1, 2, 3, 4, 6, 8, 12, 24] = 1
+) -> xr.DataArray:
+    """Creates time bounds for each timestep with the start and end of the day.
 
-    This function will also set sub-daily bounds if the optional
-    frequency argument is greater than 1. For twice-daily data
-    frequency=2. For 6-hourly, 3-hourly, or hourly data, set
-    frequency to 4, 8, and 24, respectively.
+    Bounds for each timestep corresponds to 00:00:00 timepoint on the
+    current day and 00:00:00 on the subsequent day.
 
     Parameters
     ----------
     time : xr.DataArray
         The temporal coordinate variable for the axis.
-    frequency : int, optional, default 1
-        Flag to note set the number of timepoints per day.
+    freq : Literal[1, 2, 3, 4, 6, 8, 12, 24], optional
+        Number of timepoints per day, by default 1. If greater than 1, sub-daily
+        bounds are created.
+
+         * ``freq=1`` is daily (default)
+         * ``freq=2`` is twice daily
+         * ``freq=4`` is 6-hourly
+         * ``freq=8`` is 3-hourly
+         * ``freq=12`` is 2-hourly
+         * ``freq=24`` is hourly
 
     Returns
     -------
@@ -560,44 +573,40 @@ def get_daily_time_bounds(time, frequency=1):
     Raises
     ------
     ValueError
-        If an incorrect ``frequency`` argument is passed. Should be
-        2, 3, 4, 6, 8, 12, or 24.
+        If an incorrect ``freq`` argument is passed. Should be 1, 2, 3, 4, 6, 8,
+        12, or 24.
 
     Notes
     -----
-    This function is intended to reproduce CDAT's setAxisTimeBoundsDaily
-    method [1]_.
+    This function is intended to reproduce CDAT's ``setAxisTimeBoundsDaily``
+    method [3]_.
 
     References
     ----------
-    [1] https://github.com/CDAT/cdutil/blob/master/cdutil/times.py#L1093
+    .. [3] https://github.com/CDAT/cdutil/blob/master/cdutil/times.py#L1093
     """
-    # get calendar
-    calendar = time.encoding["calendar"]
+    if (freq > 24) | (np.mod(24, freq)):
+        raise ValueError(
+            "Incorrect `freq` argument. Supported values include 1, 2, 3, 4, 6, 8, 12, "
+            "and 24."
+        )
 
-    # get cftime class to create new cftime objects
+    # Get the calendar type from the time coordinates to determine the `cftime`
+    # object to represent bounds values.
+    calendar = time.encoding["calendar"]
     cf_obj = get_date_type(calendar)
 
-    # loop over time values and compute bounds
+    # Loop over the time values to generate a bounds DataArray.
     time_bnds = []
-    if (frequency > 24) | (np.mod(24, frequency)):
-        raise ValueError(
-            "Incorrect `frequency` argument."
-            " Supported values include 2, 3, "
-            "4, 6, 8, 12, and 24."
-        )
     for step in time.values:
-        # get year / month
         y, m, d, h = step.year, step.month, step.day, step.hour
-        for f in range(frequency):
-            if f * (24 // frequency) <= h < (f + 1) * (24 // frequency):
-                l_bnd = cf_obj(y, m, d, f * (24 // frequency))
-                u_bnd = l_bnd + datetime.timedelta(hours=(24 // frequency))
-        # store
+        for f in range(freq):
+            if f * (24 // freq) <= h < (f + 1) * (24 // freq):
+                l_bnd = cf_obj(y, m, d, f * (24 // freq))
+                u_bnd = l_bnd + datetime.timedelta(hours=(24 // freq))
         time_bnds.append([l_bnd, u_bnd])
 
-    # create dataarray
-    time_bnds = xr.DataArray(  # type: ignore
+    da_time_bnds = xr.DataArray(
         name=f"{time.name}_bnds",
         data=time_bnds,
         coords=dict(time=time),
@@ -605,46 +614,45 @@ def get_daily_time_bounds(time, frequency=1):
         attrs={"xcdat_bounds": "True"},
     )
 
-    return time_bnds
+    return da_time_bnds
 
 
-def get_time_bounds(time):
-    """Sets the time bounds for a time coordinate axis.
+def create_time_bounds(time: xr.DataArray) -> xr.DataArray:
+    """Creates time bounds for each timestep of the time coordinate axis.
+
+    This function uses ``_infer_freq`` to determine the temporal resolution and
+    then calls ``get_yearly_time_bounds``, ``get_monthly_time_bounds``, or
+    ``get_daily_time_bounds`` as appropriate. See the docstrings for these
+    functions for more details.
 
     Parameters
     ----------
     time : xr.DataArray
         The temporal coordinate variable for the axis.
-    frequency : int, optional, default 1
-        Flag to note set the number of timepoints per day.
 
     Returns
     -------
     xr.DataArray
         The bounds for the time axis.
 
-    Notes
-    -----
-    Function uses `_infer_freq` to determine the temporal resolution
-    and the calls `get_yearly_time_bounds`, `get_monthly_time_bounds`,
-    or `get_daily_time_bounds` as appropriate. See these functions for
-    more details.
+    Examples
+    --------
+    # TODO
     """
     freq = _infer_freq(time)
     if freq == "year":
-        time_bnds = get_yearly_time_bounds(time)
-    if freq == "month":
-        time_bnds = get_monthly_time_bounds(time)
-    if freq == "day":
-        time_bnds = get_daily_time_bounds(time)
-    if freq == "hour":
-        time_bnds = get_daily_time_bounds(time)
-        # get number of time steps per day
+        time_bnds = create_yearly_time_bounds(time)
+    elif freq == "month":
+        time_bnds = create_monthly_time_bounds(time)
+    elif freq == "day":
+        time_bnds = create_daily_time_bounds(time)
+    elif freq == "hour":
+        # Determine the daily frequency for generating time  bounds.
         diff = time.values[1] - time.values[0]
         hrs = diff.seconds / 3600
         daily_freq = int(24 / hrs)
-        # get sub-daily time bounds
-        time_bnds = get_daily_time_bounds(time, frequency=daily_freq)
+
+        time_bnds = create_daily_time_bounds(time, freq=daily_freq)  # type: ignore
 
     # Create the bounds data array
     time_bnds = xr.DataArray(

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -348,8 +348,8 @@ class BoundsAccessor:
         Notes
         -----
         Based on [1]_ ``iris.coords._guess_bounds`` and [2]_ ``cf_xarray.accessor.add_bounds.``
-        For temporal coordinates `_create_bounds` will attempt to set the bounds to the start
-        and end of each time step's period. Time axes are expected to be composed of `cftime`
+        For temporal coordinates ``_create_bounds`` will attempt to set the bounds to the start
+        and end of each time step's period. Time axes are expected to be composed of ``cftime``
         objects.
 
         References

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -231,9 +231,7 @@ class BoundsAccessor:
 
         return bounds
 
-    def add_bounds(
-        self, axis: CFAxisKey, bounds: Optional[xr.DataArray] = None
-    ) -> xr.Dataset:
+    def add_bounds(self, axis: CFAxisKey) -> xr.Dataset:
         """Add bounds for an axis using its coordinate points.
 
         This method loops over the axis's coordinate variables and attempts to
@@ -252,8 +250,6 @@ class BoundsAccessor:
         ----------
         axis : CFAxisKey
             The CF axis key ("X", "Y", "T", or "Z").
-        bounds : xr.DataArray, optional
-            DataArray of bounds to add
 
         Returns
         -------
@@ -282,10 +278,7 @@ class BoundsAccessor:
 
                 continue
             except KeyError:
-                if bounds is not None:
-                    pass
-                else:
-                    bounds = self._create_bounds(axis, coord)
+                bounds = self._create_bounds(axis, coord)
 
                 ds[bounds.name] = bounds
                 ds[coord.name].attrs["bounds"] = bounds.name

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -60,10 +60,12 @@ def open_dataset(
         ["X", "Y"]. Set to ``None`` or ``False`` to not try to add any missing
         bounds.
 
-        * Supported CF axes include "X", "Y", "Z", and "T".
-        * Bounds are required for many xCDAT features.
-        * If desired, use the ``add_time_bounds()`` method if you require
-          more granular configuration for how "T" bounds are generated.
+        * This parameter simply calls :py:func:`xarray.Dataset.bounds.add_missing_bounds`
+        * Supported CF axes include "X", "Y", "Z", and "T"
+        * Bounds are required for many xCDAT features
+        * If desired, use :py:func:`xarray.Dataset.bounds.add_time_bounds`
+          if you require more granular configuration for how "T" bounds
+          are generated
 
     decode_times: bool, optional
         If True, attempt to decode times encoded in the standard NetCDF
@@ -102,7 +104,6 @@ def open_dataset(
 
     References
     ----------
-
     .. [1] https://xarray.pydata.org/en/stable/generated/xarray.open_dataset.html
     """
     ds = xr.open_dataset(path, decode_times=False, **kwargs)  # type: ignore
@@ -145,10 +146,12 @@ def open_mfdataset(
         ["X", "Y"]. Set to ``None`` or ``False`` to not try to add any missing
         bounds.
 
-        * Supported CF axes include "X", "Y", "Z", and "T".
-        * Bounds are required for many xCDAT features.
-        * If desired, use the ``add_time_bounds()`` method if you require
-          more granular configuration for how "T" bounds are generated.
+        * This parameter simply calls :py:func:`xarray.Dataset.bounds.add_missing_bounds`
+        * Supported CF axes include "X", "Y", "Z", and "T"
+        * Bounds are required for many xCDAT features
+        * If desired, use :py:func:`xarray.Dataset.bounds.add_time_bounds`
+          if you require more granular configuration for how "T" bounds
+          are generated
 
     data_var: Optional[str], optional
         The key of the data variable to keep in the Dataset, by default None.
@@ -540,10 +543,12 @@ def _postprocess_dataset(
         ["X", "Y"]. Set to ``None`` or ``False`` to not try to add any missing
         bounds.
 
-        * Supported CF axes include "X", "Y", "Z", and "T".
-        * Bounds are required for many xCDAT features.
-        * If desired, use the ``add_time_bounds()`` method if you require
-          more granular configuration for how "T" bounds are generated.
+        * This parameter simply calls :py:func:`xarray.Dataset.bounds.add_missing_bounds`
+        * Supported CF axes include "X", "Y", "Z", and "T"
+        * Bounds are required for many xCDAT features
+        * If desired, use :py:func:`xarray.Dataset.bounds.add_time_bounds`
+          if you require more granular configuration for how "T" bounds
+          are generated
 
     lon_orient: Optional[Tuple[float, float]], optional
         The orientation to use for the Dataset's longitude axis (if it exists),

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -41,7 +41,7 @@ def open_dataset(
     path: str,
     data_var: Optional[str] = None,
     add_bounds: bool = True,
-    axes: Optional[List[str]] = ["X", "Y"],
+    bounds_axes: Optional[List[str]] = ["X", "Y"],
     decode_times: bool = True,
     center_times: bool = False,
     lon_orient: Optional[Tuple[float, float]] = None,
@@ -60,7 +60,7 @@ def open_dataset(
         If True, add bounds for supported axes (X, Y, T) if they are missing in
         the Dataset, by default True. Bounds are required for many xCDAT
         features.
-    axes : List[str], optional
+    bounds_axes : List[str], optional
         List of CF axes to add bounds to (if missing), default ["X", "Y"].
     decode_times: bool, optional
         If True, attempt to decode times encoded in the standard NetCDF
@@ -111,7 +111,9 @@ def open_dataset(
         except KeyError as err:
             logger.warning(err)
 
-    ds = _postprocess_dataset(ds, data_var, center_times, add_bounds, axes, lon_orient)
+    ds = _postprocess_dataset(
+        ds, data_var, center_times, add_bounds, bounds_axes, lon_orient
+    )
 
     return ds
 
@@ -120,7 +122,7 @@ def open_mfdataset(
     paths: Paths,
     data_var: Optional[str] = None,
     add_bounds: bool = True,
-    axes: Optional[List[str]] = ["X", "Y"],
+    bounds_axes: Optional[List[str]] = ["X", "Y"],
     decode_times: bool = True,
     center_times: bool = False,
     lon_orient: Optional[Tuple[float, float]] = None,
@@ -143,7 +145,7 @@ def open_mfdataset(
         If True, add bounds for supported axes (X, Y, T) if they are missing in
         the Dataset, by default True. Bounds are required for many xCDAT
         features.
-    axes : List[str], optional
+    bounds_axes : List[str], optional
         List of CF axes to add bounds to (if missing), default ["X", "Y"].
     data_var: Optional[str], optional
         The key of the data variable to keep in the Dataset, by default None.
@@ -227,7 +229,9 @@ def open_mfdataset(
         **kwargs,  # type: ignore
     )
 
-    ds = _postprocess_dataset(ds, data_var, center_times, add_bounds, axes, lon_orient)
+    ds = _postprocess_dataset(
+        ds, data_var, center_times, add_bounds, bounds_axes, lon_orient
+    )
 
     return ds
 
@@ -516,7 +520,7 @@ def _postprocess_dataset(
     data_var: Optional[str] = None,
     center_times: bool = False,
     add_bounds: bool = True,
-    axes: Optional[List[str]] = ["X", "Y"],
+    bounds_axes: Optional[List[str]] = ["X", "Y"],
     lon_orient: Optional[Tuple[float, float]] = None,
 ) -> xr.Dataset:
     """Post-processes a Dataset object.
@@ -565,7 +569,7 @@ def _postprocess_dataset(
         ds = center_times_func(dataset)
 
     if add_bounds:
-        ds = ds.bounds.add_missing_bounds(axes=axes)
+        ds = ds.bounds.add_missing_bounds(axes=bounds_axes)
 
     if lon_orient is not None:
         ds = swap_lon_axis(ds, to=lon_orient, sort_ascending=True)

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -41,6 +41,7 @@ def open_dataset(
     path: str,
     data_var: Optional[str] = None,
     add_bounds: bool = True,
+    axes: Optional[List[str]] = ["X", "Y"],
     decode_times: bool = True,
     center_times: bool = False,
     lon_orient: Optional[Tuple[float, float]] = None,
@@ -59,6 +60,8 @@ def open_dataset(
         If True, add bounds for supported axes (X, Y, T) if they are missing in
         the Dataset, by default True. Bounds are required for many xCDAT
         features.
+    axes : List[str], optional
+        List of CF axes to add bounds to (if missing), default ["X", "Y"].
     decode_times: bool, optional
         If True, attempt to decode times encoded in the standard NetCDF
         datetime format into cftime.datetime objects. Otherwise, leave them
@@ -108,7 +111,7 @@ def open_dataset(
         except KeyError as err:
             logger.warning(err)
 
-    ds = _postprocess_dataset(ds, data_var, center_times, add_bounds, lon_orient)
+    ds = _postprocess_dataset(ds, data_var, center_times, add_bounds, axes, lon_orient)
 
     return ds
 
@@ -117,6 +120,7 @@ def open_mfdataset(
     paths: Paths,
     data_var: Optional[str] = None,
     add_bounds: bool = True,
+    axes: Optional[List[str]] = ["X", "Y"],
     decode_times: bool = True,
     center_times: bool = False,
     lon_orient: Optional[Tuple[float, float]] = None,
@@ -139,6 +143,8 @@ def open_mfdataset(
         If True, add bounds for supported axes (X, Y, T) if they are missing in
         the Dataset, by default True. Bounds are required for many xCDAT
         features.
+    axes : List[str], optional
+        List of CF axes to add bounds to (if missing), default ["X", "Y"].
     data_var: Optional[str], optional
         The key of the data variable to keep in the Dataset, by default None.
     decode_times: bool, optional
@@ -221,7 +227,7 @@ def open_mfdataset(
         **kwargs,  # type: ignore
     )
 
-    ds = _postprocess_dataset(ds, data_var, center_times, add_bounds, lon_orient)
+    ds = _postprocess_dataset(ds, data_var, center_times, add_bounds, axes, lon_orient)
 
     return ds
 
@@ -510,6 +516,7 @@ def _postprocess_dataset(
     data_var: Optional[str] = None,
     center_times: bool = False,
     add_bounds: bool = True,
+    axes: Optional[List[str]] = ["X", "Y"],
     lon_orient: Optional[Tuple[float, float]] = None,
 ) -> xr.Dataset:
     """Post-processes a Dataset object.
@@ -558,7 +565,7 @@ def _postprocess_dataset(
         ds = center_times_func(dataset)
 
     if add_bounds:
-        ds = ds.bounds.add_missing_bounds()
+        ds = ds.bounds.add_missing_bounds(axes=axes)
 
     if lon_orient is not None:
         ds = swap_lon_axis(ds, to=lon_orient, sort_ascending=True)

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -62,6 +62,11 @@ def open_dataset(
         features.
     bounds_axes : List[str], optional
         List of CF axes to add bounds to (if missing), default ["X", "Y"].
+        Supported CF axes include "X", "Y", "Z", and "T". Bounds are required
+        for many xCDAT features. As an alternative to passing "T" to generate
+        time bounds here, it is recommended to use the ``add_time_bounds()``
+        bounds accessor method if you need more granular configuration. For more
+        information, refer to ``xcdat.Bounds.BoundsAccessor.add_time_bounds()``.
     decode_times: bool, optional
         If True, attempt to decode times encoded in the standard NetCDF
         datetime format into cftime.datetime objects. Otherwise, leave them
@@ -102,7 +107,6 @@ def open_dataset(
 
     .. [1] https://xarray.pydata.org/en/stable/generated/xarray.open_dataset.html
     """
-
     ds = xr.open_dataset(path, decode_times=False, **kwargs)  # type: ignore
 
     if decode_times:
@@ -147,6 +151,11 @@ def open_mfdataset(
         features.
     bounds_axes : List[str], optional
         List of CF axes to add bounds to (if missing), default ["X", "Y"].
+        Supported CF axes include "X", "Y", "Z", and "T". Bounds are required
+        for many xCDAT features. As an alternative to passing "T" to generate
+        time bounds here, it is recommended to use the ``add_time_bounds()``
+        bounds accessor method if you need more granular configuration. For more
+        information, refer to ``xcdat.Bounds.BoundsAccessor.add_time_bounds()``.
     data_var: Optional[str], optional
         The key of the data variable to keep in the Dataset, by default None.
     decode_times: bool, optional

--- a/xcdat/regridder/accessor.py
+++ b/xcdat/regridder/accessor.py
@@ -78,7 +78,7 @@ class RegridderAccessor:
 
         ds = xr.Dataset(coords, attrs=self._ds.attrs)
 
-        ds = ds.bounds.add_missing_bounds()
+        ds = ds.bounds.add_missing_bounds(axes=["X", "Y"])
 
         return ds
 

--- a/xcdat/regridder/grid.py
+++ b/xcdat/regridder/grid.py
@@ -508,7 +508,7 @@ def create_grid(
 
     grid = xr.Dataset(data_vars=data_vars, coords={"lat": lat, "lon": lon})
 
-    grid = grid.bounds.add_missing_bounds()
+    grid = grid.bounds.add_missing_bounds(axes=["X", "Y"])
 
     return grid
 

--- a/xcdat/regridder/regrid2.py
+++ b/xcdat/regridder/regrid2.py
@@ -150,7 +150,7 @@ class Regrid2Regridder(BaseRegridder):
         # preserve non-spatial bounds
         output_ds = preserve_bounds(ds, self._output_grid, output_ds)
 
-        output_ds = output_ds.bounds.add_missing_bounds()
+        output_ds = output_ds.bounds.add_missing_bounds(axes=["X", "Y"])
 
         return output_ds
 

--- a/xcdat/regridder/xesmf.py
+++ b/xcdat/regridder/xesmf.py
@@ -200,6 +200,6 @@ class XESMFRegridder(BaseRegridder):
         # preserve non-spatial bounds
         output_ds = preserve_bounds(ds, self._output_grid, output_ds)
 
-        output_ds = output_ds.bounds.add_missing_bounds()
+        output_ds = output_ds.bounds.add_missing_bounds(axes=["X", "Y"])
 
         return output_ds

--- a/xcdat/spatial.py
+++ b/xcdat/spatial.py
@@ -102,7 +102,7 @@ class SpatialAccessor:
         axis : List[SpatialAxis]
             List of axis dimensions to average over, by default ["X", "Y"].
             Valid axis keys include "X" and "Y".
-        weights : Union[Literal["generate"], xr.DataArray], optional
+        weights : {"generate", xr.DataArray}, optional
             If "generate", then weights are generated. Otherwise, pass a
             DataArray containing the regional weights used for weighted
             averaging. ``weights`` must include the same spatial axis dimensions

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1754,6 +1754,7 @@ def _infer_freq(time_coords: xr.DataArray) -> Frequency:
     Frequency
         The time frequency.
     """
+    # TODO: Raise exception if the frequency cannot be inferred.
     min_delta = pd.to_timedelta(np.diff(time_coords).min(), unit="ns")
 
     if min_delta < pd.Timedelta(days=1):

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -166,6 +166,10 @@ class TemporalAccessor:
         frequencies, the distribution of weights will be equal so
         ``weighted=True`` is the same as ``weighted=False``.
 
+        Time bounds are used for inferring the time series frequency and for
+        generating weights (refer to the ``weighted`` parameter documentation
+        below).
+
         Parameters
         ----------
         data_var: str
@@ -218,6 +222,9 @@ class TemporalAccessor:
         season_config: SeasonConfigInput = DEFAULT_SEASON_CONFIG,
     ):
         """Returns a Dataset with average of a data variable by time group.
+
+        Time bounds are used for generating weights to calculate weighted group
+        averages (refer to the ``weighted`` parameter documentation below).
 
         Parameters
         ----------
@@ -361,6 +368,9 @@ class TemporalAccessor:
         season_config: SeasonConfigInput = DEFAULT_SEASON_CONFIG,
     ):
         """Returns a Dataset with the climatology of a data variable.
+
+        Time bounds are used for generating weights to calculate weighted
+        climatology (refer to the ``weighted`` parameter documentation below).
 
         Parameters
         ----------
@@ -526,6 +536,8 @@ class TemporalAccessor:
         temperature) and the long-term average value for that time interval
         (e.g., the average surface temperature over the last 30 Januaries).
 
+        Time bounds are used for generating weights to calculate weighted
+        climatology (refer to the ``weighted`` parameter documentation below).
 
         Parameters
         ----------

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -115,6 +115,11 @@ class TemporalAccessor:
     An accessor class that provides temporal attributes and methods on xarray
     Datasets through the ``.temporal`` attribute.
 
+    This accessor class requires the dataset's time coordinates to be decoded as
+    ``datetime.datetime`` or ``cftime.datetime`` objects. The dataset must also
+    have time bounds to generate weights for weighted calculations and to infer
+    the grouping time frequency in ``average()`` (single-snap shot average).
+
     Examples
     --------
 
@@ -664,7 +669,7 @@ class TemporalAccessor:
         # Group averaging is only required if the dataset's frequency (input)
         # differs from the `freq` arg (output).
         ds_obs = ds.copy()
-        inferred_freq = self._infer_freq()
+        inferred_freq = _infer_freq(ds[self.dim])
         if inferred_freq != freq:
             ds_obs = ds_obs.temporal.group_average(
                 data_var,


### PR DESCRIPTION
## Description
PR is intended to reproduce CDAT functionality (e.g., `setAxisTimeBoundsMonthly()`) to produce accurate time bounds for datasets with missing bounds. 

As cleanup tasks, this PR will also a) remove the width parameter from generic bound creation routines, b) only autogenerate bounds for lat/lon (others axes, e.g., time, must be specified). 

- Closes #412
- Closes #426 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
