### PR TITLE
Add support for custom seasons spanning calendar years

### DIFF
--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -577,7 +577,7 @@ class TestGroupAverage:
         result = ds.temporal.group_average(
             "ts",
             "season",
-            season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
+            season_config={"dec_mode": "DJF", "drop_incomplete_seasons": True},
         )
         expected = ds.copy()
         # Drop the incomplete DJF seasons
@@ -615,7 +615,7 @@ class TestGroupAverage:
                 "freq": "season",
                 "weighted": "True",
                 "dec_mode": "DJF",
-                "drop_incomplete_djf": "True",
+                "drop_incomplete_seasons": "True",
             },
         )
 
@@ -629,7 +629,7 @@ class TestGroupAverage:
         result = ds.temporal.group_average(
             "ts",
             "season",
-            season_config={"dec_mode": "DJF", "drop_incomplete_djf": False},
+            season_config={"dec_mode": "DJF", "drop_incomplete_seasons": False},
         )
         expected = ds.copy()
         expected = expected.drop_dims("time")
@@ -666,7 +666,7 @@ class TestGroupAverage:
                 "freq": "season",
                 "weighted": "True",
                 "dec_mode": "DJF",
-                "drop_incomplete_djf": "False",
+                "drop_incomplete_seasons": "False",
             },
         )
 
@@ -818,7 +818,7 @@ class TestGroupAverage:
 
         xr.testing.assert_identical(result, expected)
 
-    def test_weighted_seasonal_averages_drops_incomplete_seasons(self):
+    def test_weighted_custom_seasonal_averages_drops_incomplete_seasons(self):
         ds = self.ds.copy()
         ds["time"].values[:] = np.array(
             [
@@ -831,28 +831,26 @@ class TestGroupAverage:
             dtype="datetime64[ns]",
         )
 
-        custom_seasons = [
-            ["Nov", "Dec", "Jan", "Feb", "Mar"],
-        ]
+        custom_seasons = [["Nov", "Dec"], ["Feb", "Mar", "Apr"]]
 
         result = ds.temporal.group_average(
             "ts",
             "season",
             season_config={
+                "drop_incomplete_seasons": True,
                 "custom_seasons": custom_seasons,
-                # "drop_incomplete_seasons": True,
             },
         )
         expected = ds.copy()
         expected = expected.drop_dims("time")
         expected["ts"] = xr.DataArray(
             name="ts",
-            data=np.array([[[1.3933333]]]),
+            data=np.array([[[1.5]]]),
             coords={
                 "lat": expected.lat,
                 "lon": expected.lon,
                 "time": xr.DataArray(
-                    data=np.array([cftime.datetime(2001, 1, 1)], dtype=object),
+                    data=np.array([cftime.datetime(2000, 12, 1)], dtype=object),
                     dims=["time"],
                     attrs={
                         "axis": "T",
@@ -868,13 +866,12 @@ class TestGroupAverage:
                 "operation": "temporal_avg",
                 "mode": "group_average",
                 "freq": "season",
-                "custom_seasons": ["NovDecJanFebMar"],
+                "custom_seasons": ["NovDec", "FebMarApr"],
                 "weighted": "True",
             },
         )
 
-        xr.testing.assert_allclose(result, expected)
-        assert result.ts.attrs == expected.ts.attrs
+        assert result.identical(expected)
 
     def test_weighted_custom_seasonal_averages_with_seasons_spanning_calendar_years(
         self,
@@ -1214,7 +1211,7 @@ class TestClimatology:
         result = ds.temporal.climatology(
             "ts",
             "season",
-            season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
+            season_config={"dec_mode": "DJF", "drop_incomplete_seasons": True},
         )
 
         expected = ds.copy()
@@ -1256,7 +1253,7 @@ class TestClimatology:
                 "freq": "season",
                 "weighted": "True",
                 "dec_mode": "DJF",
-                "drop_incomplete_djf": "True",
+                "drop_incomplete_seasons": "True",
             },
         )
 
@@ -1269,7 +1266,7 @@ class TestClimatology:
         result = ds.temporal.climatology(
             "ts",
             "season",
-            season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
+            season_config={"dec_mode": "DJF", "drop_incomplete_seasons": True},
         )
 
         expected = ds.copy()
@@ -1311,7 +1308,7 @@ class TestClimatology:
                 "freq": "season",
                 "weighted": "True",
                 "dec_mode": "DJF",
-                "drop_incomplete_djf": "True",
+                "drop_incomplete_seasons": "True",
             },
         )
 
@@ -1432,7 +1429,7 @@ class TestClimatology:
         xr.testing.assert_identical(result, expected)
 
     @pytest.mark.xfail
-    def test_weighted_custom_seasonal_climatology_with_seasons_spanning_calendar_years_and_drop_incomplete_seasons(
+    def test_weighted_custom_seasonal_climatology_with_seasons_spanning_calendar_years(
         self,
     ):
         ds = self.ds.copy()
@@ -2076,7 +2073,7 @@ class TestDepartures:
             "ts",
             "season",
             weighted=True,
-            season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
+            season_config={"dec_mode": "DJF", "drop_incomplete_seasons": True},
         )
 
         expected = ds.copy()
@@ -2113,7 +2110,7 @@ class TestDepartures:
                 "freq": "season",
                 "weighted": "True",
                 "dec_mode": "DJF",
-                "drop_incomplete_djf": "True",
+                "drop_incomplete_seasons": "True",
             },
         )
 
@@ -2127,7 +2124,7 @@ class TestDepartures:
             "season",
             weighted=True,
             keep_weights=True,
-            season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
+            season_config={"dec_mode": "DJF", "drop_incomplete_seasons": True},
         )
 
         expected = ds.copy()
@@ -2164,7 +2161,7 @@ class TestDepartures:
                 "freq": "season",
                 "weighted": "True",
                 "dec_mode": "DJF",
-                "drop_incomplete_djf": "True",
+                "drop_incomplete_seasons": "True",
             },
         )
         expected["time_wts"] = xr.DataArray(
@@ -2202,7 +2199,7 @@ class TestDepartures:
             "ts",
             "season",
             weighted=False,
-            season_config={"dec_mode": "DJF", "drop_incomplete_djf": True},
+            season_config={"dec_mode": "DJF", "drop_incomplete_seasons": True},
         )
 
         expected = ds.copy()
@@ -2239,7 +2236,7 @@ class TestDepartures:
                 "freq": "season",
                 "weighted": "False",
                 "dec_mode": "DJF",
-                "drop_incomplete_djf": "True",
+                "drop_incomplete_seasons": "True",
             },
         )
 
@@ -3462,7 +3459,7 @@ class Test_Averager:
                 weighted=True,
                 season_config={
                     "dec_mode": "DJF",
-                    "drop_incomplete_djf": False,
+                    "drop_incomplete_seasons": False,
                     "custom_seasons": None,
                 },
             )
@@ -3478,7 +3475,7 @@ class Test_Averager:
                 weighted=True,
                 season_config={
                     "dec_mode": "DJF",
-                    "drop_incomplete_djf": False,
+                    "drop_incomplete_seasons": False,
                     "custom_seasons": None,
                 },
             )
@@ -3490,7 +3487,7 @@ class Test_Averager:
                 weighted=True,
                 season_config={
                     "dec_mode": "DJF",
-                    "drop_incomplete_djf": False,
+                    "drop_incomplete_seasons": False,
                     "custom_seasons": None,
                 },
             )
@@ -3502,7 +3499,7 @@ class Test_Averager:
                 weighted=True,
                 season_config={
                     "dec_mode": "DJF",
-                    "drop_incomplete_djf": False,
+                    "drop_incomplete_seasons": False,
                     "custom_seasons": None,
                 },
             )
@@ -3528,7 +3525,7 @@ class Test_Averager:
                 weighted=True,
                 season_config={
                     "dec_mode": "unsupported",
-                    "drop_incomplete_djf": False,
+                    "drop_incomplete_seasons": False,
                     "custom_seasons": None,
                 },
             )

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -762,6 +762,21 @@ class TestGroupAverage:
                 season_config={"custom_seasons": custom_seasons},
             )
 
+    def test_raises_error_with_dataset_that_has_no_complete_seasons(self):
+        ds = self.ds.copy()
+        ds = ds.isel(time=slice(0, 1))
+        custom_seasons = [["Dec", "Jan"]]
+
+        with pytest.raises(RuntimeError):
+            ds.temporal.group_average(
+                "ts",
+                "season",
+                season_config={
+                    "custom_seasons": custom_seasons,
+                    "drop_incomplete_seasons": True,
+                },
+            )
+
     def test_weighted_custom_seasonal_averages(self):
         ds = self.ds.copy()
 

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -67,7 +67,7 @@ SeasonConfigInput = TypedDict(
     "SeasonConfigInput",
     {
         "dec_mode": Literal["DJF", "JFD"],
-        "drop_incomplete_djf": bool,
+        "drop_incomplete_seasons": bool,
         "custom_seasons": Optional[List[List[str]]],
     },
     total=False,
@@ -77,7 +77,7 @@ SeasonConfigAttr = TypedDict(
     "SeasonConfigAttr",
     {
         "dec_mode": Literal["DJF", "JFD"],
-        "drop_incomplete_djf": bool,
+        "drop_incomplete_seasons": bool,
         "custom_seasons": Optional[Dict[str, List[str]]],
     },
     total=False,
@@ -85,7 +85,7 @@ SeasonConfigAttr = TypedDict(
 
 DEFAULT_SEASON_CONFIG: SeasonConfigInput = {
     "dec_mode": "DJF",
-    "drop_incomplete_djf": False,
+    "drop_incomplete_seasons": False,
     "custom_seasons": None,
 }
 
@@ -296,11 +296,18 @@ class TemporalAccessor:
                     Xarray labels the season with December as "DJF", but it is
                     actually "JFD".
 
-            * "drop_incomplete_djf" (bool, by default False)
-                If the "dec_mode" is "DJF", this flag drops (True) or keeps
-                (False) time coordinates that fall under incomplete DJF seasons
-                Incomplete DJF seasons include the start year Jan/Feb and the
-                end year Dec.
+            * "drop_incomplete_seasons" (bool, by default False)
+                Seasons are considered incomplete if they do not have all of
+                the required months to form the season. For example, if we have
+                the time coordinates ["2000-11-16", "2000-12-16", "2001-01-16",
+                "2001-02-16"] and we want to group seasons by "ND" ("Nov",
+                "Dec") and "JFM" ("Jan", "Feb", "Mar").
+
+                * ["2000-11-16", "2000-12-16"] is considered a complete "ND"
+                  season since both "Nov" and "Dec" are present.
+                * ["2001-01-16", "2001-02-16"] is considered an incomplete "JFM"
+                  season because it only has "Jan" and "Feb". Therefore, these
+                  time coordinates are dropped.
 
             Configs for custom seasons:
 
@@ -350,7 +357,7 @@ class TemporalAccessor:
         >>>     "season",
         >>>     season_config={
         >>>         "dec_mode": "DJF",
-        >>>         "drop_incomplete_season": True
+        >>>         "drop_incomplete_seasons": True
         >>>     }
         >>> )
         >>> ds_season.ts
@@ -386,7 +393,7 @@ class TemporalAccessor:
             'freq': 'season',
             'weighted': 'True',
             'dec_mode': 'DJF',
-            'drop_incomplete_djf': 'False'
+            'drop_incomplete_seasons': 'False'
         }
         """
         self._set_data_var_attrs(data_var)
@@ -461,6 +468,21 @@ class TemporalAccessor:
             predefined seasons are passed, configs for custom seasons are
             ignored and vice versa.
 
+            General configs:
+
+            * "drop_incomplete_seasons" (bool, by default False)
+                Seasons are considered incomplete if they do not have all of
+                the required months to form the season. For example, if we have
+                the time coordinates ["2000-11-16", "2000-12-16", "2001-01-16",
+                "2001-02-16"] and we want to group seasons by "ND" ("Nov",
+                "Dec") and "JFM" ("Jan", "Feb", "Mar").
+
+                * ["2000-11-16", "2000-12-16"] is considered a complete "ND"
+                  season since both "Nov" and "Dec" are present.
+                * ["2001-01-16", "2001-02-16"] is considered an incomplete "JFM"
+                  season because it only has "Jan" and "Feb". Therefore, these
+                  time coordinates are dropped.
+
             Configs for predefined seasons:
 
             * "dec_mode" (Literal["DJF", "JFD"], by default "DJF")
@@ -470,12 +492,6 @@ class TemporalAccessor:
                 * "JFD": season includes the same year December.
                     Xarray labels the season with December as "DJF", but it is
                     actually "JFD".
-
-            * "drop_incomplete_djf" (bool, by default False)
-                If the "dec_mode" is "DJF", this flag drops (True) or keeps
-                (False) time coordinates that fall under incomplete DJF seasons
-                Incomplete DJF seasons include the start year Jan/Feb and the
-                end year Dec.
 
             Configs for custom seasons:
 
@@ -529,7 +545,7 @@ class TemporalAccessor:
         >>>     "season",
         >>>     season_config={
         >>>         "dec_mode": "DJF",
-        >>>         "drop_incomplete_season": True
+        >>>         "drop_incomplete_seasons": True
         >>>     }
         >>> )
         >>> ds_season.ts
@@ -565,7 +581,7 @@ class TemporalAccessor:
             'freq': 'season',
             'weighted': 'True',
             'dec_mode': 'DJF',
-            'drop_incomplete_djf': 'False'
+            'drop_incomplete_seasons': 'False'
         }
         """
         self._set_data_var_attrs(data_var)
@@ -648,6 +664,21 @@ class TemporalAccessor:
             predefined seasons are passed, configs for custom seasons are
             ignored and vice versa.
 
+            General configs:
+
+            * "drop_incomplete_seasons" (bool, by default False)
+                Seasons are considered incomplete if they do not have all of
+                the required months to form the season. For example, if we have
+                the time coordinates ["2000-11-16", "2000-12-16", "2001-01-16",
+                "2001-02-16"] and we want to group seasons by "ND" ("Nov",
+                "Dec") and "JFM" ("Jan", "Feb", "Mar").
+
+                * ["2000-11-16", "2000-12-16"] is considered a complete "ND"
+                  season since both "Nov" and "Dec" are present.
+                * ["2001-01-16", "2001-02-16"] is considered an incomplete "JFM"
+                  season because it only has "Jan" and "Feb". Therefore, these
+                  time coordinates are dropped.
+
             Configs for predefined seasons:
 
             * "dec_mode" (Literal["DJF", "JFD"], by default "DJF")
@@ -657,12 +688,6 @@ class TemporalAccessor:
                 * "JFD": season includes the same year December.
                     Xarray labels the season with December as "DJF", but it is
                     actually "JFD".
-
-            * "drop_incomplete_djf" (bool, by default False)
-                If the "dec_mode" is "DJF", this flag drops (True) or keeps
-                (False) time coordinates that fall under incomplete DJF seasons
-                Incomplete DJF seasons include the start year Jan/Feb and the
-                end year Dec.
 
             Configs for custom seasons:
 
@@ -731,7 +756,7 @@ class TemporalAccessor:
             'frequency': 'season',
             'weighted': 'True',
             'dec_mode': 'DJF',
-            'drop_incomplete_djf': 'False'
+            'drop_incomplete_seasons': 'False'
         }
         """
         # 1. Set the attributes for this instance of `TemporalAccessor`.
@@ -941,9 +966,12 @@ class TemporalAccessor:
                 )
         custom_seasons = season_config.get("custom_seasons", None)
         dec_mode = season_config.get("dec_mode", "DJF")
-        drop_incomplete_djf = season_config.get("drop_incomplete_djf", False)
 
         self._season_config: SeasonConfigAttr = {}
+        self._season_config["drop_incomplete_seasons"] = season_config.get(
+            "drop_incomplete_seasons", False
+        )
+
         if custom_seasons is None:
             if dec_mode not in ("DJF", "JFD"):
                 raise ValueError(
@@ -952,8 +980,6 @@ class TemporalAccessor:
                 )
             self._season_config["dec_mode"] = dec_mode
 
-            if dec_mode == "DJF":
-                self._season_config["drop_incomplete_djf"] = drop_incomplete_djf
         else:
             self._season_config["custom_seasons"] = self._form_seasons(custom_seasons)
 
@@ -1032,10 +1058,9 @@ class TemporalAccessor:
         """
         if (
             self._freq == "season"
-            and self._season_config.get("dec_mode") == "DJF"
-            and self._season_config.get("drop_incomplete_djf") is True
+            and self._season_config.get("drop_incomplete_seasons") is True
         ):
-            ds = self._drop_incomplete_djf(ds)
+            ds = self._drop_incomplete_seasons(ds)
 
         if (
             self._freq == "day"
@@ -1051,53 +1076,63 @@ class TemporalAccessor:
 
         return ds
 
-    def _drop_incomplete_djf(self, dataset: xr.Dataset) -> xr.Dataset:
-        """Drops incomplete DJF seasons within a continuous time series.
+    def _drop_incomplete_seasons(self, ds: xr.Dataset) -> xr.Dataset:
+        """Drops incomplete seasons within a continuous time series.
 
-        This method assumes that the time series is continuous and removes the
-        leading and trailing incomplete seasons (e.g., the first January and
-        February of a time series that are not complete, because the December of
-        the previous year is missing). This method does not account for or
-        remove missing time steps anywhere else.
+        Seasons are considered incomplete if they do not have all of the
+        required months to form the season. For example, if we have the time
+        coordinates ["2000-11-16", "2000-12-16", "2001-01-16", "2001-02-16"]
+        and we want to group seasons by "ND" ("Nov", "Dec") and "JFM" ("Jan",
+        "Feb", "Mar").
+          - ["2000-11-16", "2000-12-16"] is considered a complete "ND" season
+            since both "Nov" and "Dec" are present.
+          - ["2001-01-16", "2001-02-16"] is considered an incomplete "JFM"
+            season because it only has "Jan" and "Feb". Therefore, these
+            time coordinates are dropped.
 
         Parameters
         ----------
-        dataset : xr.Dataset
-            The dataset with some possibly incomplete DJF seasons.
+        df : pd.DataFrame
+            A DataFrame of seasonal datetime components with potentially
+            incomplete seasons.
 
         Returns
         -------
-        xr.Dataset
-            The dataset with only complete DJF seasons.
+        pd.DataFrame
+            A DataFrame of seasonal datetime components with only complete
+            seasons.
         """
-        # Separate the dataset into two datasets, one with and one without
-        # the time dimension. This is necessary because the xarray .where()
-        # method concatenates the time dimension to non-time dimension data
-        # vars, which is not a desired behavior.
-        ds = dataset.copy()
-        ds_time = ds.get([v for v in ds.data_vars if self.dim in ds[v].dims])  # type: ignore
-        ds_no_time = ds.get([v for v in ds.data_vars if self.dim not in ds[v].dims])  # type: ignore
+        # Algorithm
+        # Prereq - This needs to be done AFTER time coordinates are labeled
+        # and BEFORE obsoelete columns are dropped because custom seasons can be
+        # assigned to the time coordiantes first.
+        # 1. Get the count of months per season (pre-defined seasons by xarray
+        # all have 3), otherwise use custom seasons count
+        # 2. Label all time coordinates by groups
+        # 3. Group the time coordinates by group and the get count
+        # 4. Drop time coordinates where count != expected count for season
+        ds_new = ds.copy()
+        time_coords = ds[self.dim].copy()
 
-        start_year, end_year = (
-            ds[self.dim].dt.year.values[0],
-            ds[self.dim].dt.year.values[-1],
-        )
-        incomplete_seasons = (
-            f"{int(start_year):04d}-01",
-            f"{int(start_year):04d}-02",
-            f"{int(end_year):04d}-12",
-        )
+        # Transform the time coords into a DataFrame of seasonal datetime
+        # components based on the grouping mode.
+        df = self._get_df_dt_components(time_coords, drop_obsolete_cols=False)
 
-        for year_month in incomplete_seasons:
-            try:
-                coord_pt = ds.loc[dict(time=year_month)][self.dim][0]
-                ds_time = ds_time.where(ds_time[self.dim] != coord_pt, drop=True)
-            except (KeyError, IndexError):
-                continue
+        # Add a column for the expected count of months for that season
+        # For example, "NovDec" is split into ["Nov", "Dec"] which equals an
+        # expected count of 2 months.
+        df["expected_months"] = df["season"].str.split(r"(?<=.)(?=[A-Z])").str.len()
+        # Add a column for the actual count of months for that season.
+        df["actual_months"] = df.groupby(["season"])["year"].transform("count")
 
-        ds_final = xr.merge((ds_time, ds_no_time))
+        # Get the incomplete seasons and drop the time coordinates that are in
+        # those incomplete seasons.
+        indexes_to_drop = df[df["expected_months"] != df["actual_months"]].index
+        if len(indexes_to_drop) > 0:
+            coords_to_drop = time_coords.values[indexes_to_drop]
+            ds_new = ds_new.where(~time_coords.isin(coords_to_drop), drop=True)
 
-        return ds_final
+        return ds_new
 
     def _drop_leap_days(self, ds: xr.Dataset):
         """Drop leap days from time coordinates.
@@ -1291,9 +1326,9 @@ class TemporalAccessor:
         This methods labels time coordinates for grouping by first extracting
         specific xarray datetime components from time coordinates and storing
         them in a pandas DataFrame. After processing (if necessary) is performed
-        on the DataFrame, it is converted to a numpy array of datetime
-        objects. This numpy serves as the data source for the final
-        DataArray of labeled time coordinates.
+        on the DataFrame, it is converted to a numpy array of datetime objects.
+        This numpy array serves as the data source for the final DataArray of
+        labeled time coordinates.
 
         Parameters
         ----------
@@ -1329,7 +1364,9 @@ class TemporalAccessor:
         >>> Coordinates:
         >>> * time     (time) datetime64[ns] 2000-01-01T00:00:00 ... 2000-04-01T00:00:00
         """
-        df_dt_components: pd.DataFrame = self._get_df_dt_components(time_coords)
+        df_dt_components: pd.DataFrame = self._get_df_dt_components(
+            time_coords, drop_obsolete_cols=True
+        )
         dt_objects = self._convert_df_to_dt(df_dt_components)
 
         time_grouped = xr.DataArray(
@@ -1343,7 +1380,9 @@ class TemporalAccessor:
 
         return time_grouped
 
-    def _get_df_dt_components(self, time_coords: xr.DataArray) -> pd.DataFrame:
+    def _get_df_dt_components(
+        self, time_coords: xr.DataArray, drop_obsolete_cols: bool
+    ) -> pd.DataFrame:
         """Returns a DataFrame of xarray datetime components.
 
         This method extracts the applicable xarray datetime components from each
@@ -1364,6 +1403,12 @@ class TemporalAccessor:
         ----------
         time_coords : xr.DataArray
             The time coordinates.
+        drop_obsolete_cols : bool
+            Drop obsolete columns after processing seasonal DataFrame when
+            ``self._freq="season"``. Set to False to keep datetime columns
+            needed for preprocessing the dataset (e.g,. removing incomplete
+            seasons), and set to True to remove obsolete columns when needing
+            to group time coordinates.
 
         Returns
         -------
@@ -1394,11 +1439,14 @@ class TemporalAccessor:
             if self._mode in ["climatology", "departures"]:
                 df["year"] = time_coords[f"{self.dim}.year"].values
                 df["month"] = time_coords[f"{self.dim}.month"].values
-
-            if self._mode == "group_average":
+            elif self._mode == "group_average":
                 df["month"] = time_coords[f"{self.dim}.month"].values
 
             df = self._process_season_df(df)
+
+            if drop_obsolete_cols:
+                df = self._drop_obsolete_columns(df)
+                df = self._map_seasons_to_mid_months(df)
 
         return df
 
@@ -1408,13 +1456,13 @@ class TemporalAccessor:
 
         Parameters
         ----------
-        df : pd.DataFrame
-            A DataFrame of xarray datetime components.
+        df : xr.DataArray
+            A DataFrame of seasonal datetime components.
 
         Returns
         -------
         pd.DataFrame
-            A DataFrame of processed xarray datetime components.
+            A DataFrame of seasonal datetime components.
         """
         df_new = df.copy()
         custom_seasons = self._season_config.get("custom_seasons")
@@ -1427,8 +1475,6 @@ class TemporalAccessor:
             if dec_mode == "DJF":
                 df_new = self._shift_decembers(df_new)
 
-        df_new = self._drop_obsolete_columns(df_new)
-        df_new = self._map_seasons_to_mid_months(df_new)
         return df_new
 
     def _map_months_to_custom_seasons(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -1743,17 +1789,16 @@ class TemporalAccessor:
         )
 
         if self._freq == "season":
+            data_var.attrs["drop_incomplete_seasons"] = self._season_config.get(
+                "drop_incomplete_seasons"
+            )
+
             custom_seasons = self._season_config.get("custom_seasons")
-
-            if custom_seasons is None:
-                dec_mode = self._season_config.get("dec_mode")
-                drop_incomplete_djf = self._season_config.get("drop_incomplete_djf")
-
-                data_var.attrs["dec_mode"] = dec_mode
-                if dec_mode == "DJF":
-                    data_var.attrs["drop_incomplete_djf"] = str(drop_incomplete_djf)
-            else:
+            if custom_seasons is not None:
                 data_var.attrs["custom_seasons"] = list(custom_seasons.keys())
+            else:
+                dec_mode = self._season_config.get("dec_mode")
+                data_var.attrs["dec_mode"] = dec_mode
 
         return data_var
 

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1,5 +1,6 @@
 """Module containing temporal functions."""
 
+import warnings
 from datetime import datetime
 from itertools import chain
 from typing import Dict, List, Literal, Optional, Tuple, TypedDict, Union, get_args
@@ -66,6 +67,7 @@ TIME_GROUPS: Dict[Mode, Dict[Frequency, Tuple[DateTimeComponent, ...]]] = {
 SeasonConfigInput = TypedDict(
     "SeasonConfigInput",
     {
+        "drop_incomplete_djf": bool,
         "drop_incomplete_seasons": bool,
         "dec_mode": Literal["DJF", "JFD"],
         "custom_seasons": Optional[List[List[str]]],
@@ -76,6 +78,7 @@ SeasonConfigInput = TypedDict(
 SeasonConfigAttr = TypedDict(
     "SeasonConfigAttr",
     {
+        "drop_incomplete_djf": bool,
         "drop_incomplete_seasons": bool,
         "dec_mode": Literal["DJF", "JFD"],
         "custom_seasons": Optional[Dict[str, List[str]]],
@@ -249,6 +252,11 @@ class TemporalAccessor:
         Time bounds are used for generating weights to calculate weighted group
         averages (refer to the ``weighted`` parameter documentation below).
 
+        .. deprecated:: v0.7.0
+            The ``season_config`` dictionary argument ``"drop_incomplete_djf"``
+            is being deprecated. Please use ``"drop_incomplete_seasons"``
+            instead.
+
         Parameters
         ----------
         data_var: str
@@ -419,6 +427,11 @@ class TemporalAccessor:
         Data is grouped into the labeled time point for the averaging operation.
         Time bounds are used for generating weights to calculate weighted
         climatology (refer to the ``weighted`` parameter documentation below).
+
+        .. deprecated:: v0.7.0
+            The ``season_config`` dictionary argument ``"drop_incomplete_djf"``
+            is being deprecated. Please use ``"drop_incomplete_seasons"``
+            instead.
 
         Parameters
         ----------
@@ -610,6 +623,11 @@ class TemporalAccessor:
 
         Time bounds are used for generating weights to calculate weighted
         climatology (refer to the ``weighted`` parameter documentation below).
+
+        .. deprecated:: v0.7.0
+            The ``season_config`` dictionary argument ``"drop_incomplete_djf"``
+            is being deprecated. Please use ``"drop_incomplete_seasons"``
+            instead.
 
         Parameters
         ----------
@@ -962,9 +980,20 @@ class TemporalAccessor:
         dec_mode = season_config.get("dec_mode", "DJF")
 
         self._season_config: SeasonConfigAttr = {}
-        self._season_config["drop_incomplete_seasons"] = season_config.get(
-            "drop_incomplete_seasons", False
-        )
+
+        # TODO: Deprecate `drop_incomplete_djf`.
+        drop_incomplete_djf = season_config.get("drop_incomplete_djf", None)
+        if drop_incomplete_djf is not None:
+            warnings.warn(
+                "The `season_config` argument 'drop_incomplete_djf' is being "
+                "deprecated. Please use 'drop_incomplete_seasons' instead.",
+                DeprecationWarning,
+            )
+            self._season_config["drop_incomplete_seasons"] = drop_incomplete_djf
+        else:
+            self._season_config["drop_incomplete_seasons"] = season_config.get(
+                "drop_incomplete_seasons", False
+            )
 
         if custom_seasons is None:
             if dec_mode not in ("DJF", "JFD"):

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1030,15 +1030,15 @@ class TemporalAccessor:
 
             # TODO: Deprecate incomplete_djf.
             drop_incomplete_djf = season_config.get("drop_incomplete_djf", False)
-            if drop_incomplete_djf is not False:
-                warnings.warn(
-                    "The `season_config` argument 'drop_incomplete_djf' is being "
-                    "deprecated. Please use 'drop_incomplete_seasons' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
             if dec_mode == "DJF":
+                if drop_incomplete_djf is not False:
+                    warnings.warn(
+                        "The `season_config` argument 'drop_incomplete_djf' is being "
+                        "deprecated. Please use 'drop_incomplete_seasons' instead.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+
                 self._season_config["drop_incomplete_djf"] = drop_incomplete_djf
 
     def _is_valid_reference_period(self, reference_period: Tuple[str, str]):

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -335,7 +335,6 @@ class TemporalAccessor:
                 representing a custom season.
 
                 * Month strings must be in the three letter format (e.g., 'Jan')
-                * Each month must be included once in a custom season
                 * Order of the months in each custom season does not matter
                 * Custom seasons can vary in length
 
@@ -529,7 +528,6 @@ class TemporalAccessor:
                 representing a custom season.
 
                 * Month strings must be in the three letter format (e.g., 'Jan')
-                * Each month must be included once in a custom season
                 * Order of the months in each custom season does not matter
                 * Custom seasons can vary in length
 
@@ -739,7 +737,6 @@ class TemporalAccessor:
                 representing a custom season.
 
                 * Month strings must be in the three letter format (e.g., 'Jan')
-                * Each month must be included once in a custom season
                 * Order of the months in each custom season does not matter
                 * Custom seasons can vary in length
 
@@ -1381,6 +1378,11 @@ class TemporalAccessor:
         pd.DataFrame
             A DataFrame of seasonal datetime components with only complete
             seasons.
+
+        Notes
+        -----
+        TODO: Refactor this method to use pure Xarray/NumPy operations, rather
+        than Pandas.
         """
         # Transform the time coords into a DataFrame of seasonal datetime
         # components based on the grouping mode.

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -997,10 +997,6 @@ class TemporalAccessor:
         predefined_months = list(MONTH_INT_TO_STR.values())
         input_months = list(chain.from_iterable(custom_seasons))
 
-        if len(input_months) != len(predefined_months):
-            raise ValueError(
-                "Exactly 12 months were not passed in the list of custom seasons."
-            )
         if len(input_months) != len(set(input_months)):
             raise ValueError(
                 "Duplicate month(s) were found in the list of custom seasons."

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -67,6 +67,8 @@ TIME_GROUPS: Dict[Mode, Dict[Frequency, Tuple[DateTimeComponent, ...]]] = {
 SeasonConfigInput = TypedDict(
     "SeasonConfigInput",
     {
+        # TODO: Deprecate incomplete_djf.
+        "drop_incomplete_djf": bool,
         "drop_incomplete_seasons": bool,
         "dec_mode": Literal["DJF", "JFD"],
         "custom_seasons": Optional[List[List[str]]],
@@ -77,6 +79,8 @@ SeasonConfigInput = TypedDict(
 SeasonConfigAttr = TypedDict(
     "SeasonConfigAttr",
     {
+        # TODO: Deprecate incomplete_djf.
+        "drop_incomplete_djf": bool,
         "drop_incomplete_seasons": bool,
         "dec_mode": Literal["DJF", "JFD"],
         "custom_seasons": Optional[Dict[str, List[str]]],
@@ -85,6 +89,8 @@ SeasonConfigAttr = TypedDict(
 )
 
 DEFAULT_SEASON_CONFIG: SeasonConfigInput = {
+    # TODO: Deprecate incomplete_djf.
+    "drop_incomplete_djf": False,
     "drop_incomplete_seasons": False,
     "dec_mode": "DJF",
     "custom_seasons": None,
@@ -287,23 +293,32 @@ class TemporalAccessor:
         keep_weights : bool, optional
             If calculating averages using weights, keep the weights in the
             final dataset output, by default False.
-        season_config: SeasonConfigInput, optional
+        season_config : SeasonConfigInput, optional
             A dictionary for "season" frequency configurations. If configs for
             predefined seasons are passed, configs for custom seasons are
             ignored and vice versa.
 
             * "drop_incomplete_seasons" (bool, by default False)
                 Seasons are considered incomplete if they do not have all of
-                the required months to form the season. For example, if we have
+                the required months to form the season. This argument supersedes
+                "drop_incomplete_djf". For example, if we have
                 the time coordinates ["2000-11-16", "2000-12-16", "2001-01-16",
                 "2001-02-16"] and we want to group seasons by "ND" ("Nov",
                 "Dec") and "JFM" ("Jan", "Feb", "Mar").
 
                 * ["2000-11-16", "2000-12-16"] is considered a complete "ND"
-                  season since both "Nov" and "Dec" are present.
+                    season since both "Nov" and "Dec" are present.
                 * ["2001-01-16", "2001-02-16"] is considered an incomplete "JFM"
-                  season because it only has "Jan" and "Feb". Therefore, these
-                  time coordinates are dropped.
+                    season because it only has "Jan" and "Feb". Therefore, these
+                    time coordinates are dropped.
+
+            * "drop_incomplete_djf" (bool, by default False)
+                If the "dec_mode" is "DJF", this flag drops (True) or keeps
+                (False) time coordinates that fall under incomplete DJF seasons
+                Incomplete DJF seasons include the start year Jan/Feb and the
+                end year Dec. This argument is superceded by
+                "drop_incomplete_seasons" and will be deprecated in a future
+                release.
 
             * "dec_mode" (Literal["DJF", "JFD"], by default "DJF")
                 The mode for the season that includes December in the list of
@@ -472,23 +487,32 @@ class TemporalAccessor:
             'yyyy-mm-dd'. For example, ``('1850-01-01', '1899-12-31')``. If no
             value is provided, the climatological reference period will be the
             full period covered by the dataset.
-        season_config: SeasonConfigInput, optional
+        season_config : SeasonConfigInput, optional
             A dictionary for "season" frequency configurations. If configs for
             predefined seasons are passed, configs for custom seasons are
             ignored and vice versa.
 
             * "drop_incomplete_seasons" (bool, by default False)
                 Seasons are considered incomplete if they do not have all of
-                the required months to form the season. For example, if we have
+                the required months to form the season. This argument supersedes
+                "drop_incomplete_djf". For example, if we have
                 the time coordinates ["2000-11-16", "2000-12-16", "2001-01-16",
                 "2001-02-16"] and we want to group seasons by "ND" ("Nov",
                 "Dec") and "JFM" ("Jan", "Feb", "Mar").
 
                 * ["2000-11-16", "2000-12-16"] is considered a complete "ND"
-                  season since both "Nov" and "Dec" are present.
+                    season since both "Nov" and "Dec" are present.
                 * ["2001-01-16", "2001-02-16"] is considered an incomplete "JFM"
-                  season because it only has "Jan" and "Feb". Therefore, these
-                  time coordinates are dropped.
+                    season because it only has "Jan" and "Feb". Therefore, these
+                    time coordinates are dropped.
+
+            * "drop_incomplete_djf" (bool, by default False)
+                If the "dec_mode" is "DJF", this flag drops (True) or keeps
+                (False) time coordinates that fall under incomplete DJF seasons
+                Incomplete DJF seasons include the start year Jan/Feb and the
+                end year Dec. This argument is superceded by
+                "drop_incomplete_seasons" and will be deprecated in a future
+                release.
 
             * "dec_mode" (Literal["DJF", "JFD"], by default "DJF")
                 The mode for the season that includes December in the list of
@@ -669,7 +693,7 @@ class TemporalAccessor:
             ``('1850-01-01', '1899-12-31')``. If no value is provided, the
             climatological reference period will be the full period covered by
             the dataset.
-        season_config: SeasonConfigInput, optional
+        season_config : SeasonConfigInput, optional
             A dictionary for "season" frequency configurations. If configs for
             predefined seasons are passed, configs for custom seasons are
             ignored and vice versa.
@@ -678,16 +702,25 @@ class TemporalAccessor:
 
             * "drop_incomplete_seasons" (bool, by default False)
                 Seasons are considered incomplete if they do not have all of
-                the required months to form the season. For example, if we have
+                the required months to form the season. This argument supersedes
+                "drop_incomplete_djf". For example, if we have
                 the time coordinates ["2000-11-16", "2000-12-16", "2001-01-16",
                 "2001-02-16"] and we want to group seasons by "ND" ("Nov",
                 "Dec") and "JFM" ("Jan", "Feb", "Mar").
 
                 * ["2000-11-16", "2000-12-16"] is considered a complete "ND"
-                  season since both "Nov" and "Dec" are present.
+                    season since both "Nov" and "Dec" are present.
                 * ["2001-01-16", "2001-02-16"] is considered an incomplete "JFM"
-                  season because it only has "Jan" and "Feb". Therefore, these
-                  time coordinates are dropped.
+                    season because it only has "Jan" and "Feb". Therefore, these
+                    time coordinates are dropped.
+
+            * "drop_incomplete_djf" (bool, by default False)
+                If the "dec_mode" is "DJF", this flag drops (True) or keeps
+                (False) time coordinates that fall under incomplete DJF seasons
+                Incomplete DJF seasons include the start year Jan/Feb and the
+                end year Dec. This argument is superceded by
+                "drop_incomplete_seasons" and will be deprecated in a future
+                release.
 
             Configs for predefined seasons:
 
@@ -967,44 +1000,46 @@ class TemporalAccessor:
             self._is_valid_reference_period(reference_period)
             self._reference_period = reference_period
 
-        # "season" frequency specific configuration attributes.
+        self._set_season_config_attr(season_config)
+
+    def _set_season_config_attr(self, season_config: SeasonConfigInput):
         for key in season_config.keys():
-            # TODO: Deprecate `drop_incomplete_djf`.
-            valid_keys = list(DEFAULT_SEASON_CONFIG.keys()) + ["drop_incomplete_djf"]
-            if key not in valid_keys:
+            if key not in DEFAULT_SEASON_CONFIG:
                 raise KeyError(
                     f"'{key}' is not a supported season config. Supported "
                     f"configs include: {DEFAULT_SEASON_CONFIG.keys()}."
                 )
-        custom_seasons = season_config.get("custom_seasons", None)
-        dec_mode = season_config.get("dec_mode", "DJF")
 
         self._season_config: SeasonConfigAttr = {}
+        self._season_config["drop_incomplete_seasons"] = season_config.get(
+            "drop_incomplete_seasons", False
+        )
 
-        # TODO: Deprecate `drop_incomplete_djf`.
-        drop_incomplete_djf = season_config.get("drop_incomplete_djf", None)
-        if drop_incomplete_djf is not None:
-            warnings.warn(
-                "The `season_config` argument 'drop_incomplete_djf' is being "
-                "deprecated. Please use 'drop_incomplete_seasons' instead.",
-                DeprecationWarning,
-            )
-            self._season_config["drop_incomplete_seasons"] = drop_incomplete_djf  # type: ignore
+        custom_seasons = season_config.get("custom_seasons", None)
+        if custom_seasons is not None:
+            self._season_config["custom_seasons"] = self._form_seasons(custom_seasons)
         else:
-            self._season_config["drop_incomplete_seasons"] = season_config.get(
-                "drop_incomplete_seasons", False
-            )
-
-        if custom_seasons is None:
+            dec_mode = season_config.get("dec_mode", "DJF")
             if dec_mode not in ("DJF", "JFD"):
                 raise ValueError(
                     "Incorrect 'dec_mode' key value for `season_config`. "
                     "Supported modes include 'DJF' or 'JFD'."
                 )
+
             self._season_config["dec_mode"] = dec_mode
 
-        else:
-            self._season_config["custom_seasons"] = self._form_seasons(custom_seasons)
+            # TODO: Deprecate incomplete_djf.
+            drop_incomplete_djf = season_config.get("drop_incomplete_djf", False)
+            if drop_incomplete_djf is not False:
+                warnings.warn(
+                    "The `season_config` argument 'drop_incomplete_djf' is being "
+                    "deprecated. Please use 'drop_incomplete_seasons' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
+            if dec_mode == "DJF":
+                self._season_config["drop_incomplete_djf"] = drop_incomplete_djf
 
     def _is_valid_reference_period(self, reference_period: Tuple[str, str]):
         try:
@@ -1095,17 +1130,27 @@ class TemporalAccessor:
                 ds = self._subset_coords_for_custom_seasons(ds, months)
 
         if (
-            self._freq == "season"
-            and self._season_config["drop_incomplete_seasons"] is True
-        ):
-            ds = self._drop_incomplete_seasons(ds)
-
-        if (
             self._freq == "day"
             and self._mode in ["climatology", "departures"]
             and self.calendar in ["gregorian", "proleptic_gregorian", "standard"]
         ):
             ds = self._drop_leap_days(ds)
+
+        if (
+            self._freq == "season"
+            and self._season_config["drop_incomplete_seasons"] is True
+        ):
+            ds = self._drop_incomplete_seasons(ds)
+
+        # TODO: Deprecate incomplete_djf. Only run this is drop_incomplete_seasons
+        # is False and drop_incomplete_djf is True.
+        if (
+            self._freq == "season"
+            and self._season_config.get("dec_mode") == "DJF"
+            and self._season_config.get("drop_incomplete_djf") is True
+            and self._season_config.get("drop_incomplete_seasons") is False
+        ):
+            ds = self._drop_incomplete_djf(ds)
 
         if self._mode == "climatology" and self._reference_period is not None:
             ds = ds.sel(
@@ -1140,11 +1185,58 @@ class TemporalAccessor:
             k: coords_by_month[k] for k in month_ints if k in coords_by_month
         }
         month_to_time_idx = sorted(
-            list(chain.from_iterable(month_to_time_idx.values()))
-        )  # type: ignore
+            list(chain.from_iterable(month_to_time_idx.values()))  # type: ignore
+        )
         ds_new = ds.isel({f"{self.dim}": month_to_time_idx})
 
         return ds_new
+
+    def _drop_incomplete_djf(self, dataset: xr.Dataset) -> xr.Dataset:
+        """Drops incomplete DJF seasons within a continuous time series.
+
+        This method assumes that the time series is continuous and removes the
+        leading and trailing incomplete seasons (e.g., the first January and
+        February of a time series that are not complete, because the December of
+        the previous year is missing). This method does not account for or
+        remove missing time steps anywhere else.
+
+        Parameters
+        ----------
+        dataset : xr.Dataset
+            The dataset with some possibly incomplete DJF seasons.
+        Returns
+        -------
+        xr.Dataset
+            The dataset with only complete DJF seasons.
+        """
+        # Separate the dataset into two datasets, one with and one without
+        # the time dimension. This is necessary because the xarray .where()
+        # method concatenates the time dimension to non-time dimension data
+        # vars, which is not a desired behavior.
+        ds = dataset.copy()
+        ds_time = ds.get([v for v in ds.data_vars if self.dim in ds[v].dims])  # type: ignore
+        ds_no_time = ds.get([v for v in ds.data_vars if self.dim not in ds[v].dims])  # type: ignore
+
+        start_year, end_year = (
+            ds[self.dim].dt.year.values[0],
+            ds[self.dim].dt.year.values[-1],
+        )
+        incomplete_seasons = (
+            f"{int(start_year):04d}-01",
+            f"{int(start_year):04d}-02",
+            f"{int(end_year):04d}-12",
+        )
+
+        for year_month in incomplete_seasons:
+            try:
+                coord_pt = ds.loc[dict(time=year_month)][self.dim][0]
+                ds_time = ds_time.where(ds_time[self.dim] != coord_pt, drop=True)
+            except (KeyError, IndexError):
+                continue
+
+        ds_final = xr.merge((ds_time, ds_no_time))
+
+        return ds_final
 
     def _drop_incomplete_seasons(self, ds: xr.Dataset) -> xr.Dataset:
         """Drops incomplete seasons within a continuous time series.
@@ -1196,6 +1288,9 @@ class TemporalAccessor:
             # without the time dimension because the xarray `.where()` method
             # concatenates the time dimension to non-time dimension data vars,
             # which is an undesired behavior.
+            # FIXME: Figure out if this code block is still necessary
+            # https://github.com/pydata/xarray/issues/1234
+            # https://github.com/pydata/xarray/issues/8796#issuecomment-1974878267
             ds_no_time = ds.get([v for v in ds.data_vars if self.dim not in ds[v].dims])  # type: ignore
             ds_time = ds.get([v for v in ds.data_vars if self.dim in ds[v].dims])  # type: ignore
 
@@ -1226,7 +1321,7 @@ class TemporalAccessor:
         -------
         xr.Dataset
         """
-        ds = ds.sel(  # type: ignore
+        ds = ds.sel(
             **{self.dim: ~((ds[self.dim].dt.month == 2) & (ds[self.dim].dt.day == 29))}
         )
         return ds
@@ -1865,9 +1960,15 @@ class TemporalAccessor:
         )
 
         if self._freq == "season":
-            data_var.attrs["drop_incomplete_seasons"] = str(
-                self._season_config["drop_incomplete_seasons"]
-            )
+            drop_incomplete_seasons = self._season_config["drop_incomplete_seasons"]
+            drop_incomplete_djf = self._season_config.get("drop_incomplete_djf", False)
+
+            # TODO: Deprecate drop_incomplete_djf. This attr is only set if the
+            # user does not set drop_incomplete_seasons.
+            if drop_incomplete_seasons is False and drop_incomplete_djf is not False:
+                data_var.attrs["drop_incomplete_djf"] = str(drop_incomplete_djf)
+            else:
+                data_var.attrs["drop_incomplete_seasons"] = str(drop_incomplete_seasons)
 
             custom_seasons = self._season_config.get("custom_seasons")
             if custom_seasons is not None:

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1509,11 +1509,17 @@ class TemporalAccessor:
         custom_seasons = self._season_config["custom_seasons"]
 
         span_months: List[int] = []
+
+        # Loop over the custom seasons and get the list of months for the
+        # current season. Convert those months to their integer representations.
+        # If 1 ("Jan") is in the list of months and it is NOT the first element,
+        # then get all elements before it (aka the spanning months).
         for months in custom_seasons.values():  # type: ignore
             month_nums = [MONTH_STR_TO_INT[month] for month in months]
             try:
                 jan_index = month_nums.index(1)
-                span_months = span_months + month_nums[:jan_index]
+                if jan_index != 0:
+                    span_months = span_months + month_nums[:jan_index]
                 break
             except ValueError:
                 continue

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1135,11 +1135,13 @@ class TemporalAccessor:
         """
         month_ints = sorted([MONTH_STR_TO_INT[month] for month in months])
 
-        coords_by_month = ds.time.groupby(f"{self.dim}.month").groups
+        coords_by_month = ds[self.dim].groupby(f"{self.dim}.month").groups
         month_to_time_idx = {
             k: coords_by_month[k] for k in month_ints if k in coords_by_month
         }
-        month_to_time_idx = sorted(list(chain.from_iterable(month_to_time_idx.values())))  # type: ignore
+        month_to_time_idx = sorted(
+            list(chain.from_iterable(month_to_time_idx.values()))
+        )  # type: ignore
         ds_new = ds.isel({f"{self.dim}": month_to_time_idx})
 
         return ds_new
@@ -1224,7 +1226,9 @@ class TemporalAccessor:
         -------
         xr.Dataset
         """
-        ds = ds.sel(**{self.dim: ~((ds.time.dt.month == 2) & (ds.time.dt.day == 29))})
+        ds = ds.sel(  # type: ignore
+            **{self.dim: ~((ds[self.dim].dt.month == 2) & (ds[self.dim].dt.day == 29))}
+        )
         return ds
 
     def _average(self, ds: xr.Dataset, data_var: str) -> xr.DataArray:

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -250,7 +250,7 @@ class TemporalAccessor:
         Time bounds are used for generating weights to calculate weighted group
         averages (refer to the ``weighted`` parameter documentation below).
 
-        .. deprecated:: v0.7.0
+        .. deprecated:: v0.8.0
             The ``season_config`` dictionary argument ``"drop_incomplete_djf"``
             is being deprecated. Please use ``"drop_incomplete_seasons"``
             instead.
@@ -1182,7 +1182,14 @@ class TemporalAccessor:
         # Get the incomplete seasons and drop the time coordinates that are in
         # those incomplete seasons.
         indexes_to_drop = df[df["expected_months"] != df["actual_months"]].index
-        if len(indexes_to_drop) > 0:
+
+        if len(indexes_to_drop) == len(time_coords):
+            raise RuntimeError(
+                "No time coordinates remain with `drop_incomplete_seasons=True`. "
+                "Check the dataset has at least one complete season and/or "
+                "specify `drop_incomplete_seasons=False` instead."
+            )
+        elif len(indexes_to_drop) > 0:
             # The dataset needs to be split into a dataset with and a dataset
             # without the time dimension because the xarray `.where()` method
             # concatenates the time dimension to non-time dimension data vars,

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -426,7 +426,7 @@ class TemporalAccessor:
         Time bounds are used for generating weights to calculate weighted
         climatology (refer to the ``weighted`` parameter documentation below).
 
-        .. deprecated:: v0.7.0
+        .. deprecated:: v0.8.0
             The ``season_config`` dictionary argument ``"drop_incomplete_djf"``
             is being deprecated. Please use ``"drop_incomplete_seasons"``
             instead.
@@ -622,7 +622,7 @@ class TemporalAccessor:
         Time bounds are used for generating weights to calculate weighted
         climatology (refer to the ``weighted`` parameter documentation below).
 
-        .. deprecated:: v0.7.0
+        .. deprecated:: v0.8.0
             The ``season_config`` dictionary argument ``"drop_incomplete_djf"``
             is being deprecated. Please use ``"drop_incomplete_seasons"``
             instead.

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1286,9 +1286,8 @@ class TemporalAccessor:
         elif len(indexes_to_drop) > 0:
             # The dataset needs to be split into a dataset with and a dataset
             # without the time dimension because the xarray `.where()` method
-            # concatenates the time dimension to non-time dimension data vars,
-            # which is an undesired behavior.
-            # FIXME: Figure out if this code block is still necessary
+            # adds the time dimension to non-time dimension data vars when
+            # broadcasting, which is a behavior we do not desire.
             # https://github.com/pydata/xarray/issues/1234
             # https://github.com/pydata/xarray/issues/8796#issuecomment-1974878267
             ds_no_time = ds.get([v for v in ds.data_vars if self.dim not in ds[v].dims])  # type: ignore


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #416 
- Closes #684 

## TODO:

- [x] Support custom seasons that span calendar years (`_shift_spanning_months()`)
   - Requires detecting order of the months in a season. Currently, order does not matter.
   - For example, for `custom_season = ["Nov", "Dec", "Jan", "Feb", "Mar"]`:
     - `["Nov", "Dec"]` are from the previous year since they are listed before `"Jan"`
     - `["Jan", "Feb", "Mar"]` are from the current year
     -  Therefore, ``["Nov", "Dec"]`` need to be shifted a year forward for correct
        grouping.
- [x] Detect and drop incomplete seasons (`_drop_incomplete_seasons()`)
   - Right now xCDAT only detects incomplete "DJF" seasons with [`_drop_incomplete_djf()`](https://github.com/xCDAT/xcdat/blob/1efb8074e2cbec99c2b410b001c979926d8a44df/xcdat/temporal.py#L929-L971)
   - Replace boolean config `drop_incomplete_djf` with `drop_incomplete_season`
   - A possible solution for detecting incomplete seasons is to check if a season has all of the required months. If the count of months for that season does not match the expected count, then drop that season.
- [x] Remove requirement for all 12 months to be included in a custom season
- [x] Refactor logic for shifting months to use Xarray instead of Pandas 
- [ ]  The current logic maps the custom season to its middle month, represented as `cftime` time coordinates. Does it make sense to also keep the custom seasons with the time coordinates, similar to what Xarray does?
  ```python
    <xarray.DataArray 'season' (season: 2)> Size: 32B
    array(['DJFM', 'AMJ'], dtype='<U4')
    Coordinates:
      * season   (season) <U4 32B 'DJFM' 'AMJ'
  ``` 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)

## Additional Context

- [Google Slides](https://docs.google.com/presentation/d/1Fj_Ura2gHWZsz8bUlt30ma2rOpsR24W7eO5EW7RyN6s/edit#slide=id.g3013e3537c5_1_38) explaining logic

- Refactoring this PR to use https://github.com/pydata/xarray/pull/9524 will most likely require addressing #217, which involves extensive refactoring in how the time coordinates are pre-processed based on the averaging mode and frequency. As of `xarray >=2024.09.0`, Xarray supports grouping by multiple variables too.
- https://docs.xarray.dev/en/stable/user-guide/groupby.html#grouping-by-multiple-variables