### PR TITLE
Typo fix for doc

### DIFF
--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -406,7 +406,7 @@ class TemporalAccessor:
         reference_period : Optional[Tuple[str, str]], optional
             The climatological reference period, which is a subset of the entire
             time series. This parameter accepts a tuple of strings in the format
-            'yyyy-mm-dd'. For example, ``('1850-01-01', 1899-12-31')``. If no
+            'yyyy-mm-dd'. For example, ``('1850-01-01', '1899-12-31')``. If no
             value is provided, the climatological reference period will be the
             full period covered by the dataset.
         season_config: SeasonConfigInput, optional
@@ -575,7 +575,7 @@ class TemporalAccessor:
             The climatological reference period, which is a subset of the entire
             time series and used for calculating departures. This parameter
             accepts a tuple of strings in the format 'yyyy-mm-dd'. For example,
-            ``('1850-01-01', 1899-12-31')``. If no value is provided, the
+            ``('1850-01-01', '1899-12-31')``. If no value is provided, the
             climatological reference period will be the full period covered by
             the dataset.
         season_config: SeasonConfigInput, optional


### PR DESCRIPTION
## Description

Typo fix for doc: https://xcdat.readthedocs.io/en/latest/generated/xarray.Dataset.temporal.climatology.html, description for `reference_period`. 

`('1850-01-01', 1899-12-31')` --> `('1850-01-01', '1899-12-31')` (missed single quotation mark in front of 1899 added)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
