### PR TITLE
Fix multi-file dataset spatial average orientation and weights when lon bounds span prime meridian 

### DIFF
--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -269,26 +269,17 @@ class TestGetWeights:
             decode_times=True, cf_compliant=False, has_bounds=True
         )
 
-    def test_bounds_reordered_when_upper_indexed_first(self):
+    def test_value_error_thrown_for_multiple_out_of_order_lon_bounds(self):
         domain_bounds = xr.DataArray(
             name="lon_bnds",
-            data=np.array(
-                [[-89.375, -90], [0.0, -89.375], [0.0, 89.375], [89.375, 90]]
-            ),
+            data=np.array([[3, 1], [5, 3], [5, 7], [7, 9]]),
             coords={"lat": self.ds.lat},
             dims=["lat", "bnds"],
         )
-        result = self.ds.spatial._force_domain_order_low_to_high(domain_bounds)
-
-        expected_domain_bounds = xr.DataArray(
-            name="lon_bnds",
-            data=np.array(
-                [[-90, -89.375], [-89.375, 0.0], [0.0, 89.375], [89.375, 90]]
-            ),
-            coords={"lat": self.ds.lat},
-            dims=["lat", "bnds"],
-        )
-        assert result.identical(expected_domain_bounds)
+        # Check _get_longitude_weights raises error when there are
+        # > 1 out-of-order bounds for the dataset.
+        with pytest.raises(ValueError):
+            self.ds.spatial._get_longitude_weights(domain_bounds, region_bounds=None)
 
     def test_raises_error_if_dataset_has_multiple_bounds_variables_for_an_axis(self):
         ds = self.ds.copy()

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -180,6 +180,24 @@ class TestAverage:
 
         assert result.identical(expected)
 
+    def test_spatial_average_for_domain_wrapping_p_meridian_non_cf_conventions(
+        self,
+    ):
+        ds = self.ds.copy()
+
+        # get spatial average for original dataset
+        ref = ds.spatial.average("ts").ts
+
+        # change first bound from -0.9375 to 359.0625
+        lon_bnds = ds.lon_bnds.copy()
+        lon_bnds[0, 0] = 359.0625
+        ds["lon_bnds"] = lon_bnds
+
+        # check spatial average with new (bad) bound
+        result = ds.spatial.average("ts").ts
+
+        assert result.identical(ref)
+
     @requires_dask
     def test_spatial_average_for_lat_region_and_keep_weights_with_dask(self):
         ds = self.ds.copy().chunk(2)

--- a/xcdat/spatial.py
+++ b/xcdat/spatial.py
@@ -418,20 +418,15 @@ class SpatialAccessor:
         p_meridian_index: Optional[np.ndarray] = None
         d_bounds = domain_bounds.copy()
 
-        # check if there is more than one potential prime meridian cell
-        # there should only be one for rectilinear data
-        pmcells = np.where(domain_bounds[:, 1] - domain_bounds[:, 0] < 0)[0]
-        if len(pmcells) > 1:
+        pm_cells = np.where(domain_bounds[:, 1] - domain_bounds[:, 0] < 0)[0]
+        if len(pm_cells) > 1:
             raise ValueError(
-                "More than one longitude bound is out of order. Only one bound \n\
-                              spanning the prime meridian is permitted"
+                "More than one longitude bound is out of order. Only one bound "
+                "value spanning the prime meridian is permitted in data on "
+                "a rectilinear grid."
             )
-        # convert longitude bounds to 360 degree domain
         d_bounds: xr.DataArray = self._swap_lon_axis(d_bounds, to=360)  # type: ignore
-        # check for bounds spanning prime meridian
         p_meridian_index = _get_prime_meridian_index(d_bounds)
-        # if bounds span a prime meridian, ensure bounds are organized to span 0-360
-        # (without losing weight)
         if p_meridian_index is not None:
             d_bounds = _align_lon_bounds_to_360(d_bounds, p_meridian_index)
 

--- a/xcdat/spatial.py
+++ b/xcdat/spatial.py
@@ -281,12 +281,6 @@ class SpatialAccessor:
                     "to reference a specific data variable's axis bounds."
                 )
 
-            # The logic for generating longitude weights depends on the
-            # bounds being ordered such that d_bounds[:, 0] < d_bounds[:, 1].
-            # They are re-ordered (if need be) for the purpose of creating
-            # weights.
-            d_bounds = self._force_domain_order_low_to_high(d_bounds)
-
             r_bounds = axis_bounds[key]["region"]
 
             weights = axis_bounds[key]["weights_method"](d_bounds, r_bounds)
@@ -323,33 +317,6 @@ class SpatialAccessor:
 
             # Check the axis coordinate variable exists in the Dataset.
             get_dim_coords(self._dataset, key)
-
-    def _force_domain_order_low_to_high(self, domain_bounds: xr.DataArray):
-        """Reorders the ``domain_bounds`` low-to-high.
-
-        This method ensures all lower bound values are less than the upper bound
-        values (``domain_bounds[:, 1] < domain_bounds[:, 1]``).
-
-        Parameters
-        ----------
-        domain_bounds: xr.DataArray
-            The bounds of an axis.
-
-        Returns
-        ------
-        xr.DataArray
-            The bounds of an axis (re-ordered if applicable).
-        """
-        index_bad_cells = np.where(domain_bounds[:, 1] - domain_bounds[:, 0] < 0)[0]
-
-        if len(index_bad_cells) > 0:
-            new_domain_bounds = domain_bounds.copy()
-            new_domain_bounds[index_bad_cells, 0] = domain_bounds[index_bad_cells, 1]
-            new_domain_bounds[index_bad_cells, 1] = domain_bounds[index_bad_cells, 0]
-
-            return new_domain_bounds
-
-        return domain_bounds
 
     def _validate_region_bounds(self, axis: SpatialAxis, bounds: RegionAxisBounds):
         """Validates the ``bounds`` arg based on a set of criteria.
@@ -441,12 +408,34 @@ class SpatialAccessor:
         -------
         xr.DataArray
             The longitude axis weights.
+
+        Raises
+        ------
+        ValueError
+            If the there are multiple instances in which the
+            domain_bounds[:, 0] > domain_bounds[:, 1]
         """
         p_meridian_index: Optional[np.ndarray] = None
         d_bounds = domain_bounds.copy()
 
+        # check if there is more than one potential prime meridian cell
+        # there should only be one for rectilinear data
+        pmcells = np.where(domain_bounds[:, 1] - domain_bounds[:, 0] < 0)[0]
+        if len(pmcells) > 1:
+            raise ValueError(
+                "More than one longitude bound is out of order. Only one bound \n\
+                              spanning the prime meridian is permitted"
+            )
+        # convert longitude bounds to 360 degree domain
+        d_bounds: xr.DataArray = self._swap_lon_axis(d_bounds, to=360)  # type: ignore
+        # check for bounds spanning prime meridian
+        p_meridian_index = _get_prime_meridian_index(d_bounds)
+        # if bounds span a prime meridian, ensure bounds are organized to span 0-360
+        # (without losing weight)
+        if p_meridian_index is not None:
+            d_bounds = _align_lon_bounds_to_360(d_bounds, p_meridian_index)
+
         if region_bounds is not None:
-            d_bounds: xr.DataArray = self._swap_lon_axis(d_bounds, to=360)  # type: ignore
             r_bounds: np.ndarray = self._swap_lon_axis(
                 region_bounds, to=360
             )  # type:ignore
@@ -454,10 +443,6 @@ class SpatialAccessor:
             is_region_circular = r_bounds[1] - r_bounds[0] == 0
             if is_region_circular:
                 r_bounds = np.array([0.0, 360.0])
-
-            p_meridian_index = _get_prime_meridian_index(d_bounds)
-            if p_meridian_index is not None:
-                d_bounds = _align_lon_bounds_to_360(d_bounds, p_meridian_index)
 
             d_bounds = self._scale_domain_to_region(d_bounds, r_bounds)
 


### PR DESCRIPTION
## Description
In #494, `.spatial.get_weights` and `.spatial.average()` do not work for multifile datasets when the longitude bounds span the prime meridian. This PR updates that logic to fix issues.

Issues and root causes:

> The next issue was that the longitude bounds wrap around a prime meridian in this dataset. This creates problems, because weights are determined by the difference between the longitude bound values (and a prime meridian introduces a discontinuity, e.g., `[359.6, 0.35]` in this case). The logic to correct this does not work for multifile datasets (which led to the error `xarray can't set arrays with multiple array indices to dask yet.` which came from a function `_force_domain_order_low_to_high`).
> 
> I also noticed that the `_force_domain_order_low_to_high` could produce incorrect weights for datasets that wrap a prime meridian (this didn't occur because of the above issues). 
> 
> I've addressed the multifile dataset issue and the prime meridian issues in PR #495, which will hopefully be included in our next release.
> 
> _Originally posted by @pochedls in https://github.com/xCDAT/xcdat/issues/494#issuecomment-1577568022_
>             

- Closes #494
- Closes #500 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
