### PR TITLE
Deprecate CDML/XML support in `open_mfdataset()`

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -408,6 +408,22 @@ class TestOpenMfDataset:
 
         result.identical(expected)
 
+    def test_opens_datasets_from_xml_raises_deprecation_warning(self):
+        ds1 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
+        ds1.to_netcdf(self.file_path1)
+        ds2 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
+        ds2 = ds2.rename_vars({"ts": "tas"})
+        ds2.to_netcdf(self.file_path2)
+
+        # Create the XML file
+        xml_path = f"{self.dir}/datasets.xml"
+        page = etree.Element("dataset", directory=str(self.dir))
+        doc = etree.ElementTree(page)
+        doc.write(xml_path, xml_declaration=True, encoding="utf-16")
+
+        with pytest.warns(DeprecationWarning):
+            open_mfdataset(xml_path, decode_times=True)
+
     def test_opens_datasets_from_xml_using_pathlib_path(self):
         ds1 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
         ds1.to_netcdf(self.file_path1)
@@ -430,7 +446,7 @@ class TestOpenMfDataset:
         with pytest.raises(ValueError):
             open_mfdataset(str(self.dir), decode_times=True)
 
-    def test_opens_netcdf_files_in_a_directory(self):
+    def test_opens_netcdf_files_from_string_directory(self):
         ds1 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
         ds1.to_netcdf(self.file_path1)
         ds2 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
@@ -438,6 +454,18 @@ class TestOpenMfDataset:
         ds2.to_netcdf(self.file_path2)
 
         result = open_mfdataset(str(self.dir), decode_times=True)
+        expected = ds1.merge(ds2)
+
+        result.identical(expected)
+
+    def test_opens_netcdf_files_from_pathlib_path_directory(self):
+        ds1 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
+        ds1.to_netcdf(self.file_path1)
+        ds2 = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
+        ds2 = ds2.rename_vars({"ts": "tas"})
+        ds2.to_netcdf(self.file_path2)
+
+        result = open_mfdataset(self.dir, decode_times=True)
         expected = ds1.merge(ds2)
 
         result.identical(expected)

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -1,8 +1,12 @@
 """Dataset module for functions related to an xarray.Dataset."""
+from __future__ import annotations
+
 import os
 import pathlib
+import warnings
 from datetime import datetime
 from functools import partial
+from io import BufferedIOBase
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 import numpy as np
@@ -10,9 +14,11 @@ import xarray as xr
 from dateutil import parser
 from dateutil import relativedelta as rd
 from lxml import etree
+from xarray.backends.common import AbstractDataStore
 from xarray.coding.cftime_offsets import get_date_type
 from xarray.coding.times import convert_times, decode_cf_datetime
 from xarray.coding.variables import lazy_elemwise_func, pop_to, unpack_for_decoding
+from xarray.core.types import NestedSequence
 from xarray.core.variable import as_variable
 
 from xcdat import bounds as bounds_accessor  # noqa: F401
@@ -38,9 +44,9 @@ Paths = Union[
 
 
 def open_dataset(
-    path: str,
+    filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
     data_var: Optional[str] = None,
-    add_bounds: Union[List[CFAxisKey], None, Literal[False]] = ["X", "Y"],
+    add_bounds: List[CFAxisKey] | None | Literal[False] = ["X", "Y"],
     decode_times: bool = True,
     center_times: bool = False,
     lon_orient: Optional[Tuple[float, float]] = None,
@@ -50,12 +56,16 @@ def open_dataset(
 
     Parameters
     ----------
-    path : str
-        Path to Dataset.
+    filename_or_obj : str, Path, file-like or DataStore
+        Strings and Path objects are interpreted as a path to a netCDF file
+        or an OpenDAP URL and opened with python-netCDF4, unless the filename
+        ends with .gz, in which case the file is gunzipped and opened with
+        scipy.io.netcdf (only netCDF3 supported). Byte-strings or file-like
+        objects are opened by scipy.io.netcdf (netCDF3) or h5py (netCDF4/HDF).
     data_var: Optional[str], optional
         The key of the non-bounds data variable to keep in the Dataset,
         alongside any existing bounds data variables, by default None.
-    add_bounds: Union[List[CFAxisKey], None, Literal[False]]
+    add_bounds: List[CFAxisKey] | None | Literal[False]
         List of CF axes to try to add bounds for (if missing), default
         ["X", "Y"]. Set to ``None`` or ``False`` to not try to add any missing
         bounds.
@@ -78,9 +88,8 @@ def open_dataset(
         coordinates, by default False.
     lon_orient: Optional[Tuple[float, float]], optional
         The orientation to use for the Dataset's longitude axis (if it exists).
-        Either `(-180, 180)` or `(0, 360)`, by default None.
-
-        Supported options:
+        Either `(-180, 180)` or `(0, 360)`, by default None. Supported options
+        include:
 
           * None:  use the current orientation (if the longitude axis exists)
           * (-180, 180): represents [-180, 180) in math notation
@@ -106,7 +115,7 @@ def open_dataset(
     ----------
     .. [1] https://xarray.pydata.org/en/stable/generated/xarray.open_dataset.html
     """
-    ds = xr.open_dataset(path, decode_times=False, **kwargs)  # type: ignore
+    ds = xr.open_dataset(filename_or_obj, decode_times=False, **kwargs)  # type: ignore
 
     if decode_times:
         try:
@@ -120,13 +129,13 @@ def open_dataset(
 
 
 def open_mfdataset(
-    paths: Paths,
+    paths: str | NestedSequence[str | os.PathLike],
     data_var: Optional[str] = None,
-    add_bounds: Union[List[CFAxisKey], None, Literal[False]] = ["X", "Y"],
+    add_bounds: List[CFAxisKey] | None | Literal[False] = ["X", "Y"],
     decode_times: bool = True,
     center_times: bool = False,
     lon_orient: Optional[Tuple[float, float]] = None,
-    data_vars: Union[Literal["minimal", "different", "all"], List[str]] = "minimal",
+    data_vars: Literal["minimal", "different", "all"] | List[str] = "minimal",
     preprocess: Optional[Callable] = None,
     **kwargs: Dict[str, Any],
 ) -> xr.Dataset:
@@ -134,14 +143,30 @@ def open_mfdataset(
 
     Parameters
     ----------
-    paths : Union[str, pathlib.Path, List[str], List[pathlib.Path], \
-         List[List[str]], List[List[pathlib.Path]]]
-        Either a string glob in the form ``"path/to/my/files/*.nc"`` or an
-        explicit list of files to open. Paths can be given as strings or as
-        pathlib Paths. If concatenation along more than one dimension is desired,
-        then ``paths`` must be a nested list-of-lists (see ``combine_nested``
-        for details). (A string glob will be expanded to a 1-dimensional list.)
-    add_bounds: Union[List[CFAxisKey], None, Literal[False]]
+    paths : str | NestedSequence[str | os.PathLike]
+        Paths to dataset files. Paths can be given as strings or as pathlib.Path
+        objects. Supported options include:
+
+          * Directory path (e.g., ``"path/to/files"``), which is converted
+            to a string glob of `*.nc` files
+          * String glob (e.g., ``"path/to/files/*.nc"``), which is expanded
+            to a 1-dimensional list of file paths
+          * File path to dataset (e.g., ``"path/to/files/file1.nc"``)
+          * List of file paths (e.g., ``["path/to/files/file1.nc", ...]``).
+            If concatenation along more than one dimension is desired, then
+            ``paths`` must be a nested list-of-lists (see [2]_
+            ``xarray.combine_nested`` for details).
+          * File path to an XML file with a ``directory`` attribute (e.g.,
+            ``"path/to/files"``). If ``directory`` is set to a blank string
+            (""), then the current directory is substituted ("."). This option
+            is intended to support the CDAT CDML dialect of XML files, but it
+            can work with any XML file that has the ``directory`` attribute.
+            Refer to [4]_ for more information on CDML. NOTE: This feature is
+            deprecated in v0.6.0 and will be removed in the subsequent release.
+            CDAT (including cdms2/CDML) is in maintenance only mode and marked
+            for end-of-life by the end of 2023.
+
+    add_bounds: List[CFAxisKey] | None | Literal[False]
         List of CF axes to try to add bounds for (if missing), default
         ["X", "Y"]. Set to ``None`` or ``False`` to not try to add any missing
         bounds.
@@ -166,15 +191,13 @@ def open_mfdataset(
         coordinates, by default False.
     lon_orient: Optional[Tuple[float, float]], optional
         The orientation to use for the Dataset's longitude axis (if it exists),
-        by default None.
-
-        Supported options:
+        by default None. Supported options include:
 
           * None:  use the current orientation (if the longitude axis exists)
           * (-180, 180): represents [-180, 180) in math notation
           * (0, 360): represents [0, 360) in math notation
 
-    data_vars: Union[Literal["minimal", "different", "all"], List[str]], optional
+    data_vars: {"minimal", "different", "all" or list of str}, optional
         These data variables will be concatenated together:
           * "minimal": Only data variables in which the dimension already
             appears are included, the default value.
@@ -201,7 +224,7 @@ def open_mfdataset(
         ``ds.encoding["source"]``.
     kwargs : Dict[str, Any]
         Additional arguments passed on to ``xarray.open_mfdataset``. Refer to
-        the [2]_ xarray docs for accepted keyword arguments.
+        the [3]_ xarray docs for accepted keyword arguments.
 
     Returns
     -------
@@ -215,15 +238,32 @@ def open_mfdataset(
     in-memory copy you are manipulating in xarray is modified: the original file
     on disk is never touched.
 
+    The CDAT "Climate Data Markup Language" (CDML) is a deprecated dialect of
+    XML with a defined set of attributes. CDML is still used by current and
+    former users of CDAT. To enable CDML users to adopt xCDAT more easily in
+    their workflows, xCDAT can parse XML/CDML files for the ``directory``
+    and ``cdms_filemap`` attributes to generate a glob or list of file paths.
+    Refer to [4]_ for more information on CDML. NOTE: This feature is
+    deprecated in v0.6.0 and will be removed in the subsequent release.
+    CDAT (including cdms2/CDML) is in maintenance only mode and marked
+    for end-of-life by the end of 2023.
+
     References
     ----------
-    .. [2] https://xarray.pydata.org/en/stable/generated/xarray.open_mfdataset.html
+    .. [2] https://docs.xarray.dev/en/stable/generated/xarray.combine_nested.html
+    .. [3] https://xarray.pydata.org/en/stable/generated/xarray.open_mfdataset.html
+    .. [4] https://cdms.readthedocs.io/en/latest/manual/cdms_6.html
     """
-    if not isinstance(paths, list):
-        if _is_paths_to_xml(paths):
+    if isinstance(paths, str) or isinstance(paths, pathlib.Path):
+        if os.path.isdir(paths):
+            paths = _parse_dir_for_nc_glob(paths)
+        elif _is_xml_filepath(paths):
+            warnings.warn(
+                "`open_mfdataset()` will no longer support CDML/XML paths after "
+                "v0.6.0 because CDAT is marked for end-of-life at the end of 2023.",
+                DeprecationWarning,
+            )
             paths = _parse_xml_for_nc_glob(paths)
-        elif os.path.isdir(paths):
-            paths = _parse_dir_for_nc_glob(paths)  # type: ignore
 
     preprocess = partial(_preprocess, decode_times=decode_times, callable=preprocess)
 
@@ -244,7 +284,7 @@ def decode_time(dataset: xr.Dataset) -> xr.Dataset:
     """Decodes CF and non-CF time coordinates and time bounds using ``cftime``.
 
     By default, ``xarray`` only supports decoding time with CF compliant units
-    [3]_. This function enables also decoding time with non-CF compliant units.
+    [5]_. This function enables also decoding time with non-CF compliant units.
     It skips decoding time coordinates that have already been decoded as
     ``"datetime64[ns]"`` or ``cftime.datetime``.
 
@@ -279,13 +319,13 @@ def decode_time(dataset: xr.Dataset) -> xr.Dataset:
     -----
     Time coordinates are represented by ``cftime.datetime`` objects because
     it is not restricted by the ``pandas.Timestamp`` range (years 1678 through
-    2262). Refer to [4]_ and [5]_ for more information on this limitation.
+    2262). Refer to [6]_ and [7]_ for more information on this limitation.
 
     References
     -----
-    .. [3] https://cfconventions.org/cf-conventions/cf-conventions.html#time-coordinate
-    .. [4] https://docs.xarray.dev/en/stable/user-guide/weather-climate.html#non-standard-calendars-and-dates-outside-the-timestamp-valid-range
-    .. [5] https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timestamp-limitations
+    .. [5] https://cfconventions.org/cf-conventions/cf-conventions.html#time-coordinate
+    .. [6] https://docs.xarray.dev/en/stable/user-guide/weather-climate.html#non-standard-calendars-and-dates-outside-the-timestamp-valid-range
+    .. [7] https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timestamp-limitations
 
     Examples
     --------
@@ -381,12 +421,12 @@ def decode_time(dataset: xr.Dataset) -> xr.Dataset:
     return ds
 
 
-def _is_paths_to_xml(paths: Union[str, pathlib.Path]) -> bool:
+def _is_xml_filepath(paths: str | pathlib.Path) -> bool:
     """Checks if the ``paths`` argument is a path to an XML file.
 
     Parameters
     ----------
-    paths : Union[str, pathlib.Path]
+    paths : str | pathlib.Path
         A string or pathlib.Path represnting a file path.
 
     Returns
@@ -399,33 +439,25 @@ def _is_paths_to_xml(paths: Union[str, pathlib.Path]) -> bool:
         return paths.parts[-1].endswith("xml")
 
 
-def _parse_xml_for_nc_glob(xml_path: Union[str, pathlib.Path]) -> str:
-    """Parses a CDAT XML file for a glob of `*.nc` paths.
+def _parse_xml_for_nc_glob(xml_path: str | pathlib.Path) -> str | List[str]:
+    """
+    Parses an XML file for the ``directory`` attr to return a string glob or
+    list of string file paths.
 
-    The CDAT "Climate Data Markup Language" (CDML) is a dialect of XML with a
-    defined set of attributes. The "directory" attribute pointing to a directory
-    of `.nc` files is extracted from the specified XML file. Refer to [6]_ for
-    more information on CDML.
+    If a ``cdms_filemap`` attribute also exists, then additional parsing
+    is performed.
 
     Parameters
     ----------
-    xml_path : Union[str, pathlib.Path]
-        The CDML XML file path.
+    xml_path : str | pathlib.Path
+        The XML file path.
 
     Returns
     -------
-    str
-        A glob of `*.nc` paths in the directory.
+    str | List[str]
+        A string glob of `*.nc` paths or a list of file paths (if specified
+        with a ``cdms_filemap`` attribute).
 
-    Notes
-    -----
-    CDML is a deprecated XML dialect that is still used by current and former
-    users in the CDAT community. xCDAT supports CDML to enable these users to
-    more easily integrate xCDAT into their existing CDML/CDAT-based workflows.
-
-    References
-    ----------
-    .. [6] https://cdms.readthedocs.io/en/latest/manual/cdms_6.html
     """
     # `resolve_entities=False` and `no_network=True` guards against XXE attacks.
     # Source: https://rules.sonarsource.com/python/RSPEC-2755
@@ -445,17 +477,17 @@ def _parse_xml_for_nc_glob(xml_path: Union[str, pathlib.Path]) -> str:
     return glob_path
 
 
-def _parse_dir_for_nc_glob(dir_path: str) -> str:
+def _parse_dir_for_nc_glob(dir_path: str | pathlib.Path) -> str:
     """Parses a directory for a glob of `*.nc` paths.
 
     Parameters
     ----------
-    dir_path : str
+    dir_path : str | pathlib.Path
         The directory.
 
     Returns
     -------
-    str
+    str | pathlib.Path
         A glob of `*.nc` paths in the directory.
     """
     file_list = os.listdir(dir_path)
@@ -465,9 +497,10 @@ def _parse_dir_for_nc_glob(dir_path: str) -> str:
             f"The directory {dir_path} has no netcdf (`.nc`) files to open."
         )
 
-    glob_path = dir_path + "/*.nc"
+    if isinstance(dir_path, pathlib.Path):
+        dir_path = str(dir_path)
 
-    return glob_path
+    return os.path.join(dir_path, "*.nc")
 
 
 def _preprocess(
@@ -477,7 +510,6 @@ def _preprocess(
 
     This function accepts a user specified preprocess function, which is
     executed before additional internal preprocessing functions.
-
 
     An internal call to ``decode_time()`` is performed, which decodes
     both CF and non-CF time coordinates and bounds (if they exist). By default,
@@ -523,7 +555,7 @@ def _postprocess_dataset(
     dataset: xr.Dataset,
     data_var: Optional[str] = None,
     center_times: bool = False,
-    add_bounds: Union[List[CFAxisKey], None, Literal[False]] = ["X", "Y"],
+    add_bounds: List[CFAxisKey] | None | Literal[False] = ["X", "Y"],
     lon_orient: Optional[Tuple[float, float]] = None,
 ) -> xr.Dataset:
     """Post-processes a Dataset object.
@@ -538,7 +570,7 @@ def _postprocess_dataset(
         If True, center time coordinates using the midpoint between its upper
         and lower bounds. Otherwise, use the provided time coordinates, by
         default False.
-    add_bounds: Union[List[CFAxisKey], None, Literal[False]]
+    add_bounds: List[CFAxisKey] | None | Literal[False]
         List of CF axes to try to add bounds for (if missing), default
         ["X", "Y"]. Set to ``None`` or ``False`` to not try to add any missing
         bounds.

--- a/xcdat/dataset.py
+++ b/xcdat/dataset.py
@@ -44,7 +44,7 @@ Paths = Union[
 
 
 def open_dataset(
-    filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
+    path: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
     data_var: Optional[str] = None,
     add_bounds: List[CFAxisKey] | None | Literal[False] = ["X", "Y"],
     decode_times: bool = True,
@@ -56,7 +56,7 @@ def open_dataset(
 
     Parameters
     ----------
-    filename_or_obj : str, Path, file-like or DataStore
+    path : str, Path, file-like or DataStore
         Strings and Path objects are interpreted as a path to a netCDF file
         or an OpenDAP URL and opened with python-netCDF4, unless the filename
         ends with .gz, in which case the file is gunzipped and opened with
@@ -115,7 +115,7 @@ def open_dataset(
     ----------
     .. [1] https://xarray.pydata.org/en/stable/generated/xarray.open_dataset.html
     """
-    ds = xr.open_dataset(filename_or_obj, decode_times=False, **kwargs)  # type: ignore
+    ds = xr.open_dataset(path, decode_times=False, **kwargs)  # type: ignore
 
     if decode_times:
         try:


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #502 
- Update docstrings in `dataset.py` functions to make them easier to read

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
