### PR TITLE
Fix Python deprecation comment in conda env yml files

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -15,7 +15,7 @@ dependencies:
     - numpy >=1.23.0 # This version of numpy includes support for Python 3.11.
     - pandas
     - python-dateutil
-    - xarray >=2022.02.0 # This version of Xarray drops support for Python 3.9.
+    - xarray >=2022.02.0 # This version of Xarray drops support for Python 3.8.
     - xgcm
     # Optional - enables additional features.
     # =========================================

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -15,7 +15,7 @@ dependencies:
     - numpy >=1.23.0 # This version of numpy includes support for Python 3.11.
     - pandas
     - python-dateutil
-    - xarray >=2022.02.0 # This version of Xarray drops support for Python 3.9.
+    - xarray >=2022.02.0 # This version of Xarray drops support for Python 3.8.
     - xgcm
     # Optional - enables additional features.
     # =========================================


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

Fix a comment about the xarray version set in the conda env yml files deprecating Python 3.8.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
