### PR TITLE
Fixes handling multiple z axes when vertically regridding

### DIFF
--- a/xcdat/regridder/base.py
+++ b/xcdat/regridder/base.py
@@ -41,7 +41,14 @@ def _preserve_bounds(
     xr.Dataset
         Target Dataset with preserved bounds.
     """
-    input_ds = input_ds.drop_dims([input_ds.cf[x].name for x in ignore_dims])
+    for x in ignore_dims:
+        try:
+            input_ds = input_ds.drop_dims([input_ds.cf[x].name])
+        except KeyError:
+            to_drop = set(input_ds.cf[[x]].coords.keys()).intersection(
+                set(input_ds.coords.keys())
+            )
+            input_ds = input_ds.drop_dims(list(to_drop))
 
     for ds in (output_grid, input_ds):
         for axis in ("X", "Y", "Z", "T"):

--- a/xcdat/regridder/xgcm.py
+++ b/xcdat/regridder/xgcm.py
@@ -62,7 +62,7 @@ class XGCMRegridder(BaseRegridder):
         grid_positions : Optional[Dict[str, str]]
             Mapping of dimension positions, by default None. If ``None`` then an
             attempt is made to derive this argument.
-        periodic : bool
+        periodic : Optional[bool]
             Whether the grid is periodic, by default False.
         extra_init_options : Optional[Dict[str, Any]]
             Extra options passed to the ``xgcm.Grid`` constructor, by default
@@ -213,7 +213,7 @@ class XGCMRegridder(BaseRegridder):
         # when the order of dimensions are mismatched, the output data will be
         # transposed to match the input dimension order
         if output_da.dims != ds[data_var].dims:
-            input_coord_z = get_dim_coords(ds, "Z")
+            input_coord_z = get_dim_coords(ds[data_var], "Z")
 
             output_order = [
                 x.replace(input_coord_z.name, output_coord_z.name)  # type: ignore[attr-defined]
@@ -236,18 +236,29 @@ class XGCMRegridder(BaseRegridder):
         if self._method == "conservative":
             raise RuntimeError(
                 "Conservative regridding requires a second point position, pass these "
-                "manually"
+                "manually."
             )
 
         try:
             coord_z = get_dim_coords(self._input_grid, "Z")
         except KeyError:
-            raise RuntimeError("Could not determine 'Z' coordinate in input dataset")
+            raise RuntimeError("Could not determine `Z` coordinate in dataset.")
+
+        if isinstance(coord_z, xr.Dataset):
+            coords = ", ".join(sorted(list(coord_z.coords.keys())))  # type: ignore[arg-type]
+
+            raise RuntimeError(
+                "Could not determine the `Z` coordinate "
+                "in the input grid. Found multiple axes "
+                f"({coords}), ensure there is only a single "
+                "`Z` axis in the input grid.",
+                list(coord_z.coords.keys()),
+            )
 
         try:
             bounds_z = self._input_grid.bounds.get_bounds("Z")
         except KeyError:
-            raise RuntimeError("Could not determine 'Z' bounds in input dataset")
+            raise RuntimeError("Could not determine `Z` bounds in dataset.")
 
         # handle simple point positions based on point and bounds
         if (coord_z[0] > bounds_z[0][0] and coord_z[0] < bounds_z[0][1]) or (


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
- Fixes correctly dropping extra `Z` coordinates when using the accessory method.
- Raises exception if multiple `Z` coordinates are present in input grid.

- Closes #519 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
