### PR TITLE
Fix `create_grid` breaking with tuple containing `None`

### DIFF
--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -885,13 +885,21 @@ class TestGrid:
         ):
             grid.create_grid()
 
-    def test_create_grid(self):
+    def test_create_grid_with_coords(self):
         new_grid = grid.create_grid(x=self.lon, y=self.lat)
 
         assert np.array_equal(new_grid.lat, self.lat)
         assert np.array_equal(new_grid.lon, self.lon)
 
-    def test_create_grid_with_bounds(self):
+    def test_create_grid_with_tuple_of_coords_and_no_bounds(self):
+        # This case happens if `create_axis` is used without creating bounds,
+        # which will return a tuple of (xr.DataArray, None).
+        new_grid = grid.create_grid(x=(self.lon, None), y=(self.lat, None))
+
+        assert np.array_equal(new_grid.lat, self.lat)
+        assert np.array_equal(new_grid.lon, self.lon)
+
+    def test_create_grid_with_tuple_of_coords_and_bounds(self):
         new_grid = grid.create_grid(
             x=(self.lon, self.lon_bnds), y=(self.lat, self.lat_bnds)
         )

--- a/xcdat/regridder/grid.py
+++ b/xcdat/regridder/grid.py
@@ -529,28 +529,30 @@ def create_grid(
     axes = {"x": x, "y": y, "z": z}
     ds = xr.Dataset(attrs={} if attrs is None else attrs.copy())
 
-    for key, item in axes.items():
+    for axis, item in axes.items():
         if item is None:
             continue
 
         if isinstance(item, (tuple, list)):
             if len(item) != 2:
                 raise ValueError(
-                    f"Argument {key!r} should be an xr.DataArray representing "
+                    f"Argument {axis!r} should be an xr.DataArray representing "
                     "coordinates or a tuple (xr.DataArray, xr.DataArray) representing "
                     "coordinates and bounds."
                 )
 
-            axis, bnds = item[0].copy(deep=True), item[1].copy(deep=True)  # type: ignore[union-attr]
+            coords = item[0].copy(deep=True)
 
-            # ensure bnds attribute is set
-            axis.attrs["bounds"] = bnds.name
+            if item[1] is not None:
+                bnds = item[1].copy(deep=True)
 
-            ds = ds.assign({bnds.name: bnds})
+                coords.attrs["bounds"] = bnds.name
+
+                ds = ds.assign({bnds.name: bnds})
         else:
-            axis = item.copy(deep=True)
+            coords = item.copy(deep=True)
 
-        ds = ds.assign_coords({axis.name: axis})
+        ds = ds.assign_coords({coords.name: coords})
 
     return ds
 


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #536 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
