### PR TITLE
Make xESMF a required dependency

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -16,10 +16,8 @@ dependencies:
     - pandas
     - python-dateutil
     - xarray >=2022.02.0 # This version of Xarray drops support for Python 3.8.
-    - xgcm
-    # Optional - enables additional features.
-    # =========================================
     - xesmf >=0.7.0 # Constrained because https://github.com/pangeo-data/xESMF/issues/212.
+    - xgcm
     # Quality Assurance
     # ==================
     - types-python-dateutil

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -16,10 +16,10 @@ dependencies:
     - pandas
     - python-dateutil
     - xarray >=2022.02.0 # This version of Xarray drops support for Python 3.8.
+    - xesmf >=0.7.0 # Constrained because https://github.com/pangeo-data/xESMF/issues/212.
     - xgcm
     # Optional - enables additional features.
     # =========================================
-    - xesmf >=0.7.0 # Constrained because https://github.com/pangeo-data/xESMF/issues/212.
     - matplotlib-base >=3.7.0
     - nc-time-axis=1.4.1
     # Documentation

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -48,21 +48,13 @@ Installation
    The advantage with following this approach is that Mamba will attempt to resolve
    dependencies (e.g. ``python >= 3.8``) for compatibility.
 
-   To create an ``xcdat`` Mamba environment with ``xesmf`` (a recommended dependency),
+   To create an ``xcdat`` Mamba environment,
    run:
 
    .. code-block:: bash
 
-       >>> mamba create -n <ENV_NAME> -c conda-forge xcdat xesmf
+       >>> mamba create -n <ENV_NAME> -c conda-forge xcdat
        >>> mamba activate <ENV_NAME>
-
-   Note that ``xesmf`` is an optional dependency, which is required for using ``xesmf``
-   based horizontal regridding APIs in ``xcdat``. ``xesmf`` is not currently supported
-   on `Windows`_ because it depends on ``esmpy``, which also does not support Windows.
-   Windows users can try `WSL2`_ as a workaround.
-
-.. _Windows: https://github.com/conda-forge/esmf-feedstock/issues/64
-.. _WSL2: https://docs.microsoft.com/en-us/windows/wsl/install
 
 2. Install ``xcdat`` in an existing Mamba environment (`mamba install`_)
 
@@ -72,9 +64,7 @@ Installation
    .. code-block:: bash
 
        >>> mamba activate <ENV_NAME>
-       >>> mamba install -c conda-forge xcdat xesmf
-
-   Note: As above, ``xesmf`` is an optional dependency.
+       >>> mamba install -c conda-forge xcdat
 
 3. [Optional] Some packages that are commonly used with ``xcdat`` can be installed
    either in step 1 or step 2 above:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,5 @@
 """Unit test package for xcdat."""
 from xarray.core.options import set_options
-from xarray.tests import _importorskip, requires_dask  # noqa: F401
+from xarray.tests import requires_dask  # noqa: F401
 
 set_options(warn_for_unclosed_files=False)
-
-has_xesmf, requires_xesmf = _importorskip("xesmf")

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -9,11 +9,8 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from tests import fixtures, has_xesmf, requires_xesmf
-from xcdat.regridder import accessor, base, grid, regrid2, xgcm
-
-if has_xesmf:
-    from xcdat.regridder import xesmf
+from tests import fixtures
+from xcdat.regridder import accessor, base, grid, regrid2, xesmf, xgcm
 
 np.set_printoptions(threshold=sys.maxsize, suppress=True)
 
@@ -688,7 +685,6 @@ class TestRegrid2Regridder:
         assert north[0], north[-1] == (60, 90)
 
 
-@requires_xesmf
 class TestXESMFRegridder:
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -696,13 +692,6 @@ class TestXESMFRegridder:
             decode_times=True, cf_compliant=False, has_bounds=True
         )
         self.new_grid = grid.create_uniform_grid(-90, 90, 4.0, -180, 180, 5.0)
-
-    @pytest.mark.xfail
-    def test_raises_error_if_xesmf_is_not_installed(self):
-        # TODO Find a way to mock the value of `_has_xesmf` to False or
-        # to remove the `xesmf` module entirely
-        with pytest.raises(ModuleNotFoundError):
-            xesmf.XESMFRegridder(self.ds, self.new_grid, "bilinear")
 
     def test_vertical_placeholder(self):
         ds = self.ds.copy()
@@ -1198,7 +1187,6 @@ class TestAccessor:
 
         xr.testing.assert_allclose(mask.ts, grid.mask)
 
-    @requires_xesmf
     def test_horizontal(self):
         output_grid = grid.create_gaussian_grid(32)
 
@@ -1348,7 +1336,6 @@ class TestAccessor:
         ):
             self.ac.vertical("ts", mock_data, tool="dummy", target_data=None)  # type: ignore
 
-    @requires_xesmf
     @pytest.mark.filterwarnings("ignore:.*invalid value.*divide.*:RuntimeWarning")
     def test_convenience_methods(self):
         ds = fixtures.generate_dataset(
@@ -1364,18 +1351,6 @@ class TestAccessor:
         output_regrid2 = ds.regridder.horizontal_regrid2("ts", out_grid)
 
         assert output_regrid2.ts.shape == (15, 32, 65)
-
-    @pytest.mark.xfail
-    def test_raises_error_if_xesmf_is_not_installed(self):
-        # TODO Find a way to mock the value of `_has_xesmf` to False or
-        # to remove the `xesmf` module entirely
-        ds = fixtures.generate_dataset(
-            decode_times=True, cf_compliant=False, has_bounds=True
-        )
-
-        out_grid = grid.create_gaussian_grid(32)
-        with pytest.raises(ModuleNotFoundError):
-            ds.regridder.horizontal_xesmf("ts", out_grid, method="bilinear")
 
 
 class TestBase:

--- a/xcdat/regridder/__init__.py
+++ b/xcdat/regridder/__init__.py
@@ -1,8 +1,5 @@
 from xcdat.regridder.accessor import RegridderAccessor
 from xcdat.regridder.regrid2 import Regrid2Regridder
+from xcdat.regridder.xesmf import XESMFRegridder
 from xcdat.regridder.xgcm import XGCMRegridder
 from xcdat.utils import _has_module
-
-_has_xesmf = _has_module("xesmf")
-if _has_xesmf:
-    from xcdat.regridder.xesmf import XESMFRegridder

--- a/xcdat/regridder/xesmf.py
+++ b/xcdat/regridder/xesmf.py
@@ -1,21 +1,9 @@
 from typing import Any, Optional
 
 import xarray as xr
+import xesmf as xe
 
 from xcdat.regridder.base import BaseRegridder, _preserve_bounds
-from xcdat.utils import _has_module
-
-# TODO: Test this conditional.
-_has_xesmf = _has_module("xesmf")
-if _has_xesmf:  # pragma: no cover
-    import xesmf as xe
-else:  # pragma: no cover
-    raise ModuleNotFoundError(
-        "The `xesmf` package is required for horizontal regridding with `xesmf`. Make "
-        "sure your platform supports `xesmf` and it is installed in your conda "
-        "environment."
-    )
-
 
 VALID_METHODS = [
     "bilinear",


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #562 
- Move xESMF to the "base" section in the conda env yml files
- Remove all code related to `_has_xesmf()` and move xESMF related imports outside of conditional statements
- Remove conditiondal statements related to xESMF that are no longer needed
- Remove mentions of xESMF being an optional dependency in the getting-started documentation page
- Update tests

## Todo
- [x] Test installation on xCDAT with xESMF in a conda env on Windows to ensure it builds and `xesmf` imports work -- tested on my personal Windows PC and it works
- [x] Make xESMF a required dependency in the conda-forge feedstock (https://github.com/conda-forge/xcdat-feedstock/issues/27)
- [x] Remove any code that detects whether or not xESMF exists in the env since it should always exist in the env
- [x] Update [getting-started](https://xcdat.readthedocs.io/en/stable/getting-started.html) documentation to remove mentions of xESMF as an optional dependency


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
