### PR TITLE
Add defaults to add_missing_bounds()

### DIFF
--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -78,8 +78,8 @@ class TestAddMissingBounds:
         result = ds_no_bnds.bounds.add_missing_bounds(axes=["X", "Y", "Z"])
         assert result.identical(ds)
 
-    def test_adds_default_bounds_to_the_dataset_using_midpoints(self):
-        ds = generate_lev_dataset()
+    def test_adds_default_bounds_to_the_dataset_using_time_frequency(self):
+        ds = generate_dataset_by_frequency(freq="month")
         ds_no_bnds = ds.drop_vars(["time_bnds", "lat_bnds", "lon_bnds"])
 
         result = ds_no_bnds.bounds.add_missing_bounds()

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -78,6 +78,13 @@ class TestAddMissingBounds:
         result = ds_no_bnds.bounds.add_missing_bounds(axes=["X", "Y", "Z"])
         assert result.identical(ds)
 
+    def test_adds_default_bounds_to_the_dataset_using_midpoints(self):
+        ds = generate_lev_dataset()
+        ds_no_bnds = ds.drop_vars(["time_bnds", "lat_bnds", "lon_bnds"])
+
+        result = ds_no_bnds.bounds.add_missing_bounds()
+        assert result.identical(ds)
+
     def test_adds_t_bounds_to_the_dataset_using_time_frequency(self):
         ds = generate_dataset_by_frequency(freq="month")
         ds_no_bnds = ds.drop_vars(["time_bnds"])

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -123,7 +123,9 @@ class BoundsAccessor:
             )
         )
 
-    def add_missing_bounds(self, axes: List[CFAxisKey]) -> xr.Dataset:  # noqa: C901
+    def add_missing_bounds(  # noqa: C901
+        self, axes: List[CFAxisKey] = ["X", "Y", "T"]  # noqa: C901
+    ) -> xr.Dataset:  # noqa: C901
         """Adds missing coordinate bounds for supported axes in the Dataset.
 
         This function loops through the Dataset's axes and attempts to adds


### PR DESCRIPTION
## Description
This PR adds a default value for the axes argument in add_missing_bounds(). 

- Closes #563 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
