### PR TITLE
[PR] Exclude alternative missing values from horizontal regridding of regrid2

### DIFF
--- a/xcdat/regridder/regrid2.py
+++ b/xcdat/regridder/regrid2.py
@@ -77,13 +77,13 @@ class Regrid2Regridder(BaseRegridder):
         if nan_replace is None:
             nan_replace = input_data_var.encoding.get("missing_value", 1e20)
 
-        input_data_var = input_data_var.fillna(nan_replace)
+        # exclude alternative of NaN values if there are any
+        input_data_var = input_data_var.where(input_data_var != nan_replace)    
 
+        # horizontal regrid
         output_data = _regrid(
             input_data_var, src_lat_bnds, src_lon_bnds, dst_lat_bnds, dst_lon_bnds
         )
-
-        output_data[output_data == nan_replace] = np.nan
 
         output_ds = _build_dataset(
             ds,


### PR DESCRIPTION
## Description
Exclude alternative fillValue or missing values (e.g., 1e20) from horizontal regridding process or regrid2, so they won't influence to the regridded field. 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
