### PR TITLE
Add weight threshold option for spatial averaging 

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 import xarray as xr
 
-from xcdat.utils import compare_datasets, str_to_bool
+from xcdat.utils import _validate_min_weight, compare_datasets, str_to_bool
 
 
 class TestCompareDatasets:
@@ -103,3 +103,23 @@ class TestStrToBool:
 
         with pytest.raises(ValueError):
             str_to_bool("1")
+
+
+class TestValidateMinWeight:
+    def test_pass_None_returns_0(self):
+        result = _validate_min_weight(None)
+
+        assert result == 0
+
+    def test_returns_error_if_less_than_0(self):
+        with pytest.raises(ValueError):
+            _validate_min_weight(-1)
+
+    def test_returns_error_if_greater_than_1(self):
+        with pytest.raises(ValueError):
+            _validate_min_weight(1.1)
+
+    def test_returns_valid_min_weight(self):
+        result = _validate_min_weight(1)
+
+        assert result == 1

--- a/xcdat/spatial.py
+++ b/xcdat/spatial.py
@@ -26,7 +26,11 @@ from xcdat.axis import (
     get_dim_keys,
 )
 from xcdat.dataset import _get_data_var
-from xcdat.utils import _if_multidim_dask_array_then_load
+from xcdat.utils import (
+    _get_masked_weights,
+    _if_multidim_dask_array_then_load,
+    _validate_min_weight,
+)
 
 #: Type alias for a dictionary of axis keys mapped to their bounds.
 AxisWeights = Dict[Hashable, xr.DataArray]
@@ -73,9 +77,10 @@ class SpatialAccessor:
         axis: List[SpatialAxis] | Tuple[SpatialAxis, ...] = ("X", "Y"),
         weights: Literal["generate"] | xr.DataArray = "generate",
         keep_weights: bool = False,
-        lat_bounds: Optional[RegionAxisBounds] = None,
-        lon_bounds: Optional[RegionAxisBounds] = None,
+        lat_bounds: RegionAxisBounds | None = None,
+        lon_bounds: RegionAxisBounds | None = None,
         skipna: bool | None = None,
+        min_weight: float | None = None,
     ) -> xr.Dataset:
         """
         Calculates the spatial average for a rectilinear grid over an optionally
@@ -114,22 +119,33 @@ class SpatialAccessor:
         keep_weights : bool, optional
             If calculating averages using weights, keep the weights in the
             final dataset output, by default False.
-        lat_bounds : Optional[RegionAxisBounds], optional
+        lat_bounds : RegionAxisBounds | None, optional
             A tuple of floats/ints for the regional latitude lower and upper
             boundaries. This arg is used when calculating axis weights, but is
             ignored if ``weights`` are supplied. The lower bound cannot be
             larger than the upper bound, by default None.
-        lon_bounds : Optional[RegionAxisBounds], optional
+        lon_bounds : RegionAxisBounds | None, optional
             A tuple of floats/ints for the regional longitude lower and upper
             boundaries. This arg is used when calculating axis weights, but is
             ignored if ``weights`` are supplied. The lower bound can be larger
             than the upper bound (e.g., across the prime meridian, dateline), by
             default None.
-        skipna : bool or None, optional
+        skipna : bool | None, optional
             If True, skip missing values (as marked by NaN). By default, only
             skips missing values for float dtypes; other dtypes either do not
             have a sentinel missing value (int) or ``skipna=True`` has not been
             implemented (object, datetime64 or timedelta64).
+        min_weight : float | None, optional
+            Minimum threshold of data coverage (weight) required to compute
+            a spatial average for a grouping window. Must be between 0 and 1.
+            Useful for ensuring accurate averages in regions with missing data,
+            by default None (equivalent to 0.0).
+
+            The value must be between 0 and 1, where:
+                - 0/``None`` means no minimum threshold (all data is considered,
+                  even if coverage is minimal).
+                - 1 means full data coverage is required (no missing data is
+                  allowed).
 
         Returns
         -------
@@ -189,7 +205,9 @@ class SpatialAccessor:
         """
         ds = self._dataset.copy()
         dv = _get_data_var(ds, data_var)
+
         self._validate_axis_arg(axis)
+        min_weight = _validate_min_weight(min_weight)
 
         if isinstance(weights, str) and weights == "generate":
             if lat_bounds is not None:
@@ -201,7 +219,7 @@ class SpatialAccessor:
             self._weights = weights
 
         self._validate_weights(dv, axis)
-        ds[dv.name] = self._averager(dv, axis, skipna=skipna)
+        ds[dv.name] = self._averager(dv, axis, skipna=skipna, min_weight=min_weight)
 
         if keep_weights:
             ds[self._weights.name] = self._weights
@@ -211,9 +229,9 @@ class SpatialAccessor:
     def get_weights(
         self,
         axis: List[SpatialAxis] | Tuple[SpatialAxis, ...],
-        lat_bounds: Optional[RegionAxisBounds] = None,
-        lon_bounds: Optional[RegionAxisBounds] = None,
-        data_var: Optional[str] = None,
+        lat_bounds: RegionAxisBounds | None = None,
+        lon_bounds: RegionAxisBounds | None = None,
+        data_var: str | None = None,
     ) -> xr.DataArray:
         """
         Get area weights for specified axis keys and an optional target domain.
@@ -232,13 +250,13 @@ class SpatialAccessor:
         ----------
         axis : List[SpatialAxis] | Tuple[SpatialAxis, ...]
             List of axis dimensions to average over.
-        lat_bounds : Optional[RegionAxisBounds]
+        lat_bounds : RegionAxisBounds | None
             Tuple of latitude boundaries for regional selection, by default
             None.
-        lon_bounds : Optional[RegionAxisBounds]
+        lon_bounds : RegionAxisBounds | None
             Tuple of longitude boundaries for regional selection, by default
             None.
-        data_var: Optional[str]
+        data_var: str | None
             The key of the data variable, by default None. Pass this argument
             when the dataset has more than one bounds per axis (e.g., "lon"
             and "zlon_bnds" for the "X" axis), or you want weights for a
@@ -382,7 +400,7 @@ class SpatialAccessor:
             )
 
     def _get_longitude_weights(
-        self, domain_bounds: xr.DataArray, region_bounds: Optional[np.ndarray]
+        self, domain_bounds: xr.DataArray, region_bounds: np.ndarray | None
     ) -> xr.DataArray:
         """Gets weights for the longitude axis.
 
@@ -409,7 +427,7 @@ class SpatialAccessor:
         ----------
         domain_bounds : xr.DataArray
             The array of bounds for the longitude domain.
-        region_bounds : Optional[np.ndarray]
+        region_bounds : np.ndarray | None
             The array of bounds for longitude regional selection.
 
         Returns
@@ -423,7 +441,7 @@ class SpatialAccessor:
             If the there are multiple instances in which the
             domain_bounds[:, 0] > domain_bounds[:, 1]
         """
-        p_meridian_index: Optional[np.ndarray] = None
+        p_meridian_index: np.ndarray | None = None
         d_bounds = domain_bounds.copy()
 
         pm_cells = np.where(domain_bounds[:, 1] - domain_bounds[:, 0] < 0)[0]
@@ -455,7 +473,7 @@ class SpatialAccessor:
         return weights
 
     def _get_latitude_weights(
-        self, domain_bounds: xr.DataArray, region_bounds: Optional[np.ndarray]
+        self, domain_bounds: xr.DataArray, region_bounds: np.ndarray | None
     ) -> xr.DataArray:
         """Gets weights for the latitude axis.
 
@@ -467,7 +485,7 @@ class SpatialAccessor:
         ----------
         domain_bounds : xr.DataArray
             The array of bounds for the latitude domain.
-        region_bounds : Optional[np.ndarray]
+        region_bounds : np.ndarray | None
             The array of bounds for latitude regional selection.
 
         Returns
@@ -711,6 +729,7 @@ class SpatialAccessor:
         data_var: xr.DataArray,
         axis: List[SpatialAxis] | Tuple[SpatialAxis, ...],
         skipna: bool | None = None,
+        min_weight: float = 0.0,
     ) -> xr.DataArray:
         """Perform a weighted average of a data variable.
 
@@ -729,11 +748,22 @@ class SpatialAccessor:
             Data variable inside a Dataset.
         axis : List[SpatialAxis] | Tuple[SpatialAxis, ...]
             List of axis dimensions to average over.
-        skipna : bool or None, optional
+        skipna : bool | None, optional
             If True, skip missing values (as marked by NaN). By default, only
             skips missing values for float dtypes; other dtypes either do not
             have a sentinel missing value (int) or ``skipna=True`` has not been
             implemented (object, datetime64 or timedelta64).
+        min_weight : float, optional
+            Minimum threshold of data coverage (weight) required to compute
+            a spatial average for a grouping window. Must be between 0 and 1.
+            Useful for ensuring accurate averages in regions with missing data,
+            by default 0.0.
+
+            The value must be between 0 and 1, where:
+                - 0 means no minimum threshold (all data is considered, even if
+                  coverage is minimal).
+                - 1 means full data coverage is required (no missing data is
+                  allowed).
 
         Returns
         -------
@@ -745,13 +775,81 @@ class SpatialAccessor:
         ``weights`` must be a DataArray and cannot contain missing values.
         Missing values are replaced with 0 using ``weights.fillna(0)``.
         """
+        dv = data_var.copy()
         weights = self._weights.fillna(0)
 
-        dim = []
+        dim: List[str] = []
         for key in axis:
-            dim.append(get_dim_keys(data_var, key))
+            dim.append(get_dim_keys(dv, key))  # type: ignore
 
         with xr.set_options(keep_attrs=True):
-            weighted_mean = data_var.cf.weighted(weights).mean(dim=dim, skipna=skipna)
+            dv_mean = dv.cf.weighted(weights).mean(dim=dim, skipna=skipna)
 
-        return weighted_mean
+        if min_weight > 0.0:
+            dv_mean = self._mask_var_with_weight_threshold(
+                dv, dv_mean, dim, weights, min_weight
+            )
+
+        return dv_mean
+
+    def _mask_var_with_weight_threshold(
+        self,
+        dv: xr.DataArray,
+        dv_mean: xr.DataArray,
+        dim: List[str],
+        weights: xr.DataArray,
+        min_weight: float,
+    ) -> xr.DataArray:
+        """Mask values that do not meet the minimum weight threshold with np.nan.
+
+        This function is useful for cases where the weighting of data might be
+        skewed based on the availability of data. For example, if a portion of
+        cells in a region has significantly more missing data than other other
+        regions, it can result in inaccurate spatial average calculations.
+        Masking values that do not meet the minimum weight threshold ensures
+        more accurate calculations.
+
+        Parameters
+        ----------
+        dv : xr.DataArray
+            The weighted variable used for getting masked weights.
+        dv_mean : xr.DataArray
+            The average of the weighted variable.
+        dim: List[str]:
+            List of axis dimensions to average over.
+        weights : xr.DataArray
+            A DataArray containing either the regional weights used for weighted
+            averaging. ``weights`` must include the same axis dimensions and
+            dimensional sizes as the data variable.
+        min_weight : float, optional
+            Minimum threshold of data coverage (weight) required to compute
+            a spatial average for a grouping window. Must be between 0 and 1.
+            Useful for ensuring accurate averages in regions with missing data,
+            by default None (equivalent to 0.0).
+
+            The value must be between 0 and 1, where:
+                - 0/``None`` means no minimum threshold (all data is considered,
+                  even if coverage is minimal).
+                - 1 means full data coverage is required (no missing data is
+                  allowed).
+
+        Returns
+        -------
+        xr.DataArray
+            The average of the weighted variable with the minimum weight
+            threshold applied.
+        """
+        # Sum all weights, including zero for missing values.
+        weight_sum_all = weights.sum(dim=dim)
+
+        masked_weights = _get_masked_weights(dv, weights)
+        weight_sum_masked = masked_weights.sum(dim=dim)
+
+        # Get fraction of the available weight.
+        frac = weight_sum_masked / weight_sum_all
+
+        # Nan out values that don't meet specified weight threshold.
+        dv_new = xr.where(frac >= min_weight, dv_mean, np.nan, keep_attrs=True)
+        dv_new.name = dv_mean.name
+
+        return dv_new

--- a/xcdat/utils.py
+++ b/xcdat/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import json
 from typing import Dict, List, Optional, Union
@@ -132,3 +134,60 @@ def _if_multidim_dask_array_then_load(
         return obj.load()
 
     return None
+
+
+def _get_masked_weights(dv: xr.DataArray, weights: xr.DataArray) -> xr.DataArray:
+    """Get weights with missing data (`np.nan`) receiving no weight (zero).
+
+    Parameters
+    ----------
+    dv : xr.DataArray
+        The variable.
+    weights : xr.DataArray
+        A DataArray containing either the regional or temporal weights used for
+        weighted averaging. ``weights`` must include the same axis dimensions
+        and dimensional sizes as the data variable.
+
+    Returns
+    -------
+    xr.DataArray
+        The masked weights.
+    """
+    masked_weights = xr.where(dv.copy().isnull(), 0.0, weights)
+
+    return masked_weights
+
+
+def _validate_min_weight(min_weight: float | None) -> float:
+    """Validate the ``min_weight`` value.
+
+    Parameters
+    ----------
+    min_weight : float | None
+        Fraction of data coverage (i..e, weight) needed to return a
+        spatial average value. Value must range from 0 to 1.
+
+    Returns
+    -------
+    float
+        The required weight percentage.
+
+    Raises
+    ------
+    ValueError
+        If the `min_weight` argument is less than 0.
+    ValueError
+        If the `min_weight` argument is greater than 1.
+    """
+    if min_weight is None:
+        return 0.0
+    elif min_weight < 0.0:
+        raise ValueError(
+            "min_weight argument is less than 0. min_weight must be between 0 and 1.",
+        )
+    elif min_weight > 1.0:
+        raise ValueError(
+            "min_weight argument is greater than 1. min_weight must be between 0 and 1.",
+        )
+
+    return min_weight


### PR DESCRIPTION
## Description

This PR adds an optional argument that requires a minimum fraction of data be available to perform a spatial average. The initial PR is for spatial averaging only (it would need to be expanded to handle temporal averaging). 

- Closes #531

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
