### PR TITLE
Add weight threshold option for temporal operations

### DIFF
--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -2340,7 +2340,7 @@ class TestClimatology:
                 np.array([[[np.nan]], [[np.nan]], [[np.nan]], [[np.nan]], [[np.nan]]]),
                 np.array([[[np.nan]], [[np.nan]], [[np.nan]]]),
             ),
-            # min_weight=0.1.0: JFD below threshold (np.nan);
+            # min_weight=1.0: JFD below threshold (np.nan);
             # MAM, and JJA meet threshold.
             (
                 1.0,

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1523,7 +1523,7 @@ class TestGroupAverage:
     @pytest.mark.parametrize(
         "min_weight, ts_data, expected_data",
         [
-            # min_weight=0.0, all data missing, all output bins should be np.nan
+            # min_weight=0.0, all missing, output is all np.nan
             (
                 0.0,
                 np.array(
@@ -1538,7 +1538,14 @@ class TestGroupAverage:
                 ),
                 np.array([[[np.nan]], [[np.nan]], [[np.nan]]]),
             ),
-            # min_weight=0.5, only one value present in Jan, allows Jan only
+            # min_weight=0.0, all months meet threshold, output is weighted mean.
+            (
+                0.0,
+                np.array([[[2.0]], [[1.0]], [[3.0]], [[4.0]], [[5.0]], [[6.0]]]),
+                np.array([[[1.5]], [[3.5]], [[5.5]]]),
+            ),
+            # min_weight=0.5, (2000, Jan) meets threshold;
+            # (2000, Feb) and (2000, Mar) below threshold (np.nan).
             (
                 0.5,
                 np.array(
@@ -1553,7 +1560,8 @@ class TestGroupAverage:
                 ),
                 np.array([[[1.0]], [[np.nan]], [[np.nan]]]),
             ),
-            # min_weight=0.5, Jan and Feb have one value present, allows both
+            # min_weight=0.5, (2000, Jan) and (2000, Feb) meet threshold;
+            # (2000, Mar) below threshold (np.nan).
             (
                 0.5,
                 np.array(
@@ -1561,7 +1569,8 @@ class TestGroupAverage:
                 ),
                 np.array([[[2.0]], [[3.0]], [[np.nan]]]),
             ),
-            # min_weight=1.0, Jan has both values present, allows Jan only
+            # min_weight=1.0, (2000, Jan) meets threshold;
+            # (2000, Feb) and (2000, Mar) below threshold (np.nan).
             (
                 1.0,
                 np.array(
@@ -1569,13 +1578,7 @@ class TestGroupAverage:
                 ),
                 np.array([[[1.5]], [[np.nan]], [[np.nan]]]),
             ),
-            # min_weight=0.0, all months have both values present, allows all
-            (
-                0.0,
-                np.array([[[2.0]], [[1.0]], [[3.0]], [[4.0]], [[5.0]], [[6.0]]]),
-                np.array([[[1.5]], [[3.5]], [[5.5]]]),
-            ),
-            # min_weight=1.0, all months have both values present, allows all
+            # min_weight=1.0, all months meet threshold, output is weighted mean.
             (
                 1.0,
                 np.array([[[2.0]], [[1.0]], [[3.0]], [[4.0]], [[5.0]], [[6.0]]]),
@@ -1593,12 +1596,12 @@ class TestGroupAverage:
                 "time": xr.DataArray(
                     data=np.array(
                         [
-                            "2000-01-01T00:00:00.000000000",
-                            "2000-01-15T00:00:00.000000000",
-                            "2000-02-01T00:00:00.000000000",
-                            "2000-02-15T00:00:00.000000000",
-                            "2000-03-01T00:00:00.000000000",
-                            "2000-03-15T00:00:00.000000000",
+                            "2000-01-01T00:00:00.000000000",  # (2000, Jan)
+                            "2000-01-15T00:00:00.000000000",  # (2000, Jan)
+                            "2000-02-01T00:00:00.000000000",  # (2000, Feb)
+                            "2000-02-15T00:00:00.000000000",  # (2000, Feb)
+                            "2000-03-01T00:00:00.000000000",  # (2000, Mar)
+                            "2000-03-15T00:00:00.000000000",  # (2000, Mar)
                         ],
                         dtype="datetime64[ns]",
                     ),

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -121,6 +121,7 @@ class TestAverage:
                 "mode": "average",
                 "freq": "year",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
 
@@ -208,6 +209,7 @@ class TestAverage:
                 "mode": "average",
                 "freq": "month",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
 
@@ -295,6 +297,7 @@ class TestAverage:
                 "mode": "average",
                 "freq": "day",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
 
@@ -380,6 +383,7 @@ class TestAverage:
                 "mode": "average",
                 "freq": "hour",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
 
@@ -518,6 +522,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "year",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
 
@@ -569,6 +574,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "year",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
 
@@ -620,6 +626,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "year",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
 
@@ -671,6 +678,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_seasons": "False",
                 "dec_mode": "DJF",
             },
@@ -831,6 +839,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_seasons": "False",
                 "dec_mode": "DJF",
             },
@@ -879,6 +888,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_seasons": "True",
                 "dec_mode": "DJF",
             },
@@ -929,6 +939,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "dec_mode": "DJF",
                 "drop_incomplete_djf": "True",
             },
@@ -978,6 +989,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_seasons": "False",
                 "dec_mode": "JFD",
             },
@@ -1140,6 +1152,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_seasons": "False",
                 "dec_mode": "JFD",
             },
@@ -1238,6 +1251,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_seasons": "False",
                 "custom_seasons": [
                     "JanFebMar",
@@ -1304,6 +1318,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_seasons": "True",
                 "custom_seasons": ["JanMarJun", "FebSep"],
             },
@@ -1361,6 +1376,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_seasons": "True",
                 "custom_seasons": ["NovDec", "FebMarApr"],
             },
@@ -1418,6 +1434,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_seasons": "False",
                 "custom_seasons": ["NovDecJanFebMar"],
             },
@@ -1464,6 +1481,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "month",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
 
@@ -1515,6 +1533,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "month",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
 
@@ -1705,6 +1724,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "day",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
 
@@ -1749,6 +1769,7 @@ class TestGroupAverage:
                 "mode": "group_average",
                 "freq": "hour",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
 
@@ -1841,6 +1862,7 @@ class TestClimatology:
                 "mode": "climatology",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "dec_mode": "DJF",
                 "drop_incomplete_seasons": "True",
             },
@@ -1895,6 +1917,7 @@ class TestClimatology:
                 "mode": "climatology",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_seasons": "True",
                 "dec_mode": "DJF",
             },
@@ -2057,6 +2080,7 @@ class TestClimatology:
                 "mode": "climatology",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": min_weight,
                 "drop_incomplete_seasons": "False",
                 "dec_mode": "DJF",
             },
@@ -2121,6 +2145,7 @@ class TestClimatology:
                 "mode": "climatology",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_djf": "True",
                 "dec_mode": "DJF",
             },
@@ -2181,6 +2206,7 @@ class TestClimatology:
                 "mode": "climatology",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "dec_mode": "DJF",
                 "drop_incomplete_djf": "True",
             },
@@ -2238,6 +2264,7 @@ class TestClimatology:
                 "mode": "climatology",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "dec_mode": "DJF",
                 "drop_incomplete_seasons": "True",
             },
@@ -2290,6 +2317,7 @@ class TestClimatology:
                 "mode": "climatology",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_seasons": "False",
                 "dec_mode": "JFD",
             },
@@ -2452,6 +2480,7 @@ class TestClimatology:
                 "mode": "climatology",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": min_weight,
                 "drop_incomplete_seasons": "False",
                 "dec_mode": "JFD",
             },
@@ -2511,6 +2540,7 @@ class TestClimatology:
                 "mode": "climatology",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_seasons": "False",
                 "custom_seasons": [
                     "JanFebMar",
@@ -2567,6 +2597,7 @@ class TestClimatology:
                 "mode": "climatology",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "drop_incomplete_seasons": "False",
                 "custom_seasons": ["NovDecJanFebMar"],
             },
@@ -2632,6 +2663,7 @@ class TestClimatology:
                 "mode": "climatology",
                 "freq": "month",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
 
@@ -2756,6 +2788,7 @@ class TestClimatology:
                 "mode": "climatology",
                 "freq": "day",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
 
@@ -2847,6 +2880,7 @@ class TestClimatology:
                     "mode": "climatology",
                     "freq": "day",
                     "weighted": "True",
+                    "min_weight": 0.0,
                 },
             )
 
@@ -3050,6 +3084,7 @@ class TestDepartures:
                 "mode": "departures",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "dec_mode": "DJF",
                 "drop_incomplete_seasons": "False",
             },
@@ -3105,6 +3140,7 @@ class TestDepartures:
                 "mode": "departures",
                 "freq": "month",
                 "weighted": "True",
+                "min_weight": 0.0,
             },
         )
         expected["time_bnds"] = xr.DataArray(
@@ -3183,6 +3219,7 @@ class TestDepartures:
             attrs={
                 "test_attr": "test",
                 "operation": "temporal_avg",
+                "min_weight": 0.0,
                 "mode": "departures",
                 "freq": "season",
                 "weighted": "True",
@@ -3341,6 +3378,7 @@ class TestDepartures:
                 "mode": "departures",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": min_weight,
                 "dec_mode": "DJF",
                 "drop_incomplete_seasons": "False",
             },
@@ -3397,6 +3435,7 @@ class TestDepartures:
                 "mode": "departures",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "dec_mode": "DJF",
                 "drop_incomplete_djf": "True",
             },
@@ -3449,6 +3488,7 @@ class TestDepartures:
                 "mode": "departures",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "dec_mode": "DJF",
                 "drop_incomplete_seasons": "False",
             },
@@ -3730,6 +3770,7 @@ class TestDepartures:
                 "mode": "departures",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": min_weight,
                 "drop_incomplete_seasons": "False",
                 "dec_mode": "JFD",
             },
@@ -3823,6 +3864,7 @@ class TestDepartures:
                             "mode": "departures",
                             "freq": "day",
                             "weighted": "True",
+                            "min_weight": 0.0,
                         },
                     ),
                 },

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -802,17 +802,6 @@ class TestGroupAverage:
                             cftime.DatetimeGregorian(2001, 1, 1),
                         ],
                     ),
-                    coords={
-                        "time": np.array(
-                            [
-                                cftime.DatetimeGregorian(2000, 1, 1),
-                                cftime.DatetimeGregorian(2000, 4, 1),
-                                cftime.DatetimeGregorian(2000, 7, 1),
-                                cftime.DatetimeGregorian(2000, 10, 1),
-                                cftime.DatetimeGregorian(2001, 1, 1),
-                            ],
-                        )
-                    },
                     dims=["time"],
                     attrs={
                         "axis": "T",

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -494,14 +494,6 @@ class TestGroupAverage:
                             cftime.DatetimeGregorian(2001, 1, 1),
                         ],
                     ),
-                    coords={
-                        "time": np.array(
-                            [
-                                cftime.DatetimeGregorian(2000, 1, 1),
-                                cftime.DatetimeGregorian(2001, 1, 1),
-                            ],
-                        )
-                    },
                     dims=["time"],
                     attrs={
                         "axis": "T",
@@ -596,14 +588,6 @@ class TestGroupAverage:
                             cftime.DatetimeGregorian(2001, 1, 1),
                         ],
                     ),
-                    coords={
-                        "time": np.array(
-                            [
-                                cftime.DatetimeGregorian(2000, 1, 1),
-                                cftime.DatetimeGregorian(2001, 1, 1),
-                            ],
-                        )
-                    },
                     dims=["time"],
                     attrs={
                         "axis": "T",
@@ -626,57 +610,6 @@ class TestGroupAverage:
         xr.testing.assert_allclose(result, expected)
         assert result.ts.attrs == expected.ts.attrs
         assert result.time.attrs == expected.time.attrs
-
-    def test_weighted_seasonal_averages_with_DJF_without_dropping_incomplete_seasons(
-        self,
-    ):
-        ds = self.ds.copy()
-
-        result = ds.temporal.group_average(
-            "ts",
-            "season",
-            season_config={"dec_mode": "DJF", "drop_incomplete_seasons": False},
-        )
-        expected = ds.copy()
-        expected = expected.drop_dims("time")
-        expected["ts"] = xr.DataArray(
-            name="ts",
-            data=np.array([[[2.0]], [[1.0]], [[1.0]], [[1.0]], [[2.0]]]),
-            coords={
-                "lat": expected.lat,
-                "lon": expected.lon,
-                "time": xr.DataArray(
-                    data=np.array(
-                        [
-                            cftime.DatetimeGregorian(2000, 1, 1),
-                            cftime.DatetimeGregorian(2000, 4, 1),
-                            cftime.DatetimeGregorian(2000, 7, 1),
-                            cftime.DatetimeGregorian(2000, 10, 1),
-                            cftime.DatetimeGregorian(2001, 1, 1),
-                        ],
-                    ),
-                    dims=["time"],
-                    attrs={
-                        "axis": "T",
-                        "long_name": "time",
-                        "standard_name": "time",
-                        "bounds": "time_bnds",
-                    },
-                ),
-            },
-            dims=["time", "lat", "lon"],
-            attrs={
-                "test_attr": "test",
-                "operation": "temporal_avg",
-                "mode": "group_average",
-                "freq": "season",
-                "weighted": "True",
-                "drop_incomplete_seasons": "False",
-                "dec_mode": "DJF",
-            },
-        )
-
-        xr.testing.assert_identical(result, expected)
 
     def test_weighted_seasonal_averages_with_DJF_and_drop_incomplete_seasons(self):
         ds = generate_dataset(decode_times=True, cf_compliant=True, has_bounds=True)
@@ -776,6 +709,65 @@ class TestGroupAverage:
 
         xr.testing.assert_identical(result, expected)
 
+    def test_weighted_seasonal_averages_with_DJF_without_dropping_incomplete_seasons(
+        self,
+    ):
+        ds = self.ds.copy()
+        ds["ts"] = xr.DataArray(
+            data=np.array(
+                [[[2.0]], [[1.0]], [[1.0]], [[1.0]], [[2.0]]], dtype="float64"
+            ),
+            coords={"time": self.ds.time, "lat": self.ds.lat, "lon": self.ds.lon},
+            dims=["time", "lat", "lon"],
+            attrs={"test_attr": "test"},
+        )
+
+        result = ds.temporal.group_average(
+            "ts",
+            "season",
+            season_config={"dec_mode": "DJF", "drop_incomplete_djf": False},
+        )
+        expected = ds.copy()
+        expected = expected.drop_dims("time")
+        expected["ts"] = xr.DataArray(
+            name="ts",
+            data=np.array([[[2.0]], [[1.0]], [[1.0]], [[1.0]], [[2.0]]]),
+            coords={
+                "lat": expected.lat,
+                "lon": expected.lon,
+                "time": xr.DataArray(
+                    data=np.array(
+                        [
+                            cftime.DatetimeGregorian(2000, 1, 1),
+                            cftime.DatetimeGregorian(2000, 4, 1),
+                            cftime.DatetimeGregorian(2000, 7, 1),
+                            cftime.DatetimeGregorian(2000, 10, 1),
+                            cftime.DatetimeGregorian(2001, 1, 1),
+                        ],
+                    ),
+                    dims=["time"],
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
+                    },
+                ),
+            },
+            dims=["time", "lat", "lon"],
+            attrs={
+                "test_attr": "test",
+                "operation": "temporal_avg",
+                "mode": "group_average",
+                "freq": "season",
+                "weighted": "True",
+                "dec_mode": "DJF",
+                "drop_incomplete_djf": "False",
+            },
+        )
+
+        xr.testing.assert_identical(result, expected)
+
     def test_weighted_seasonal_averages_with_JFD(self):
         ds = self.ds.copy()
 
@@ -802,17 +794,102 @@ class TestGroupAverage:
                             cftime.DatetimeGregorian(2001, 1, 1),
                         ],
                     ),
-                    coords={
-                        "time": np.array(
-                            [
-                                cftime.DatetimeGregorian(2000, 1, 1),
-                                cftime.DatetimeGregorian(2000, 4, 1),
-                                cftime.DatetimeGregorian(2000, 7, 1),
-                                cftime.DatetimeGregorian(2000, 10, 1),
-                                cftime.DatetimeGregorian(2001, 1, 1),
-                            ],
-                        )
+                    dims=["time"],
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
                     },
+                ),
+            },
+            dims=["time", "lat", "lon"],
+            attrs={
+                "test_attr": "test",
+                "operation": "temporal_avg",
+                "mode": "group_average",
+                "freq": "season",
+                "weighted": "True",
+                "dec_mode": "JFD",
+            },
+        )
+
+        xr.testing.assert_identical(result, expected)
+
+    def test_weighted_seasonal_averages_with_JFD_with_min_weight_threshold_of_100_percent(
+        self,
+    ):
+        time = xr.DataArray(
+            data=np.array(
+                [
+                    "2000-01-16T12:00:00.000000000",
+                    "2000-02-15T12:00:00.000000000",
+                    "2000-03-16T12:00:00.000000000",
+                    "2000-06-16T00:00:00.000000000",
+                    "2000-12-16T00:00:00.000000000",
+                ],
+                dtype="datetime64[ns]",
+            ),
+            dims=["time"],
+            attrs={"axis": "T", "long_name": "time", "standard_name": "time"},
+        )
+        time.encoding = {"calendar": "standard"}
+        time_bnds = xr.DataArray(
+            name="time_bnds",
+            data=np.array(
+                [
+                    ["2000-01-01T00:00:00.000000000", "2000-02-01T00:00:00.000000000"],
+                    ["2000-02-01T00:00:00.000000000", "2000-03-01T00:00:00.000000000"],
+                    ["2000-03-01T00:00:00.000000000", "2000-04-01T00:00:00.000000000"],
+                    ["2000-06-01T00:00:00.000000000", "2000-07-01T00:00:00.000000000"],
+                    ["2000-11-01T00:00:00.000000000", "2001-01-01T00:00:00.000000000"],
+                ],
+                dtype="datetime64[ns]",
+            ),
+            coords={"time": time},
+            dims=["time", "bnds"],
+            attrs={"xcdat_bounds": "True"},
+        )
+
+        ds = xr.Dataset(
+            data_vars={"time_bnds": time_bnds},
+            coords={"lat": [-90], "lon": [0], "time": time},
+        )
+        ds.time.attrs["bounds"] = "time_bnds"
+
+        ds["ts"] = xr.DataArray(
+            data=np.array(
+                [[[np.nan]], [[1.0]], [[1.0]], [[1.0]], [[2.0]]], dtype="float64"
+            ),
+            coords={"time": self.ds.time, "lat": self.ds.lat, "lon": self.ds.lon},
+            dims=["time", "lat", "lon"],
+            attrs={"test_attr": "test"},
+        )
+
+        # NOTE: If a cell has a missing value for any of the seasons, the average
+        # for that season should be masked with a min_weight threshold of 100%.
+        result = ds.temporal.group_average(
+            "ts",
+            "season",
+            season_config={"dec_mode": "JFD"},
+            min_weight=1.0,
+        )
+        expected = ds.copy()
+        expected = expected.drop_dims("time")
+        expected["ts"] = xr.DataArray(
+            name="ts",
+            data=np.array([[[np.nan]], [[1.0]], [[1.0]]]),
+            coords={
+                "lat": expected.lat,
+                "lon": expected.lon,
+                "time": xr.DataArray(
+                    data=np.array(
+                        [
+                            cftime.DatetimeGregorian(2000, 1, 1),
+                            cftime.DatetimeGregorian(2000, 4, 1),
+                            cftime.DatetimeGregorian(2000, 7, 1),
+                        ],
+                    ),
                     dims=["time"],
                     attrs={
                         "axis": "T",
@@ -1185,6 +1262,102 @@ class TestGroupAverage:
                             cftime.DatetimeGregorian(2000, 3, 1),
                             cftime.DatetimeGregorian(2000, 6, 1),
                             cftime.DatetimeGregorian(2000, 9, 1),
+                            cftime.DatetimeGregorian(2001, 2, 1),
+                        ],
+                    ),
+                    dims=["time"],
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
+                    },
+                ),
+            },
+            dims=["time", "lat", "lon"],
+            attrs={
+                "test_attr": "test",
+                "operation": "temporal_avg",
+                "mode": "group_average",
+                "freq": "month",
+                "weighted": "True",
+            },
+        )
+
+        xr.testing.assert_identical(result, expected)
+
+    def test_weighted_monthly_averages_with_masked_data_and_min_weight_threshold_of_100_percent(
+        self,
+    ):
+        # Set up dataset
+        ds = xr.Dataset(
+            coords={
+                "lat": [-90],
+                "lon": [0],
+                "time": xr.DataArray(
+                    data=np.array(
+                        [
+                            "2000-01-01T00:00:00.000000000",
+                            "2000-02-01T00:00:00.000000000",
+                            "2000-02-15T00:00:00.000000000",
+                            "2000-04-01T00:00:00.000000000",
+                            "2001-02-01T00:00:00.000000000",
+                        ],
+                        dtype="datetime64[ns]",
+                    ),
+                    dims=["time"],
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
+                    },
+                ),
+            }
+        )
+        ds.time.encoding = {"calendar": "standard"}
+
+        ds["time_bnds"] = xr.DataArray(
+            name="time_bnds",
+            data=np.array(
+                [
+                    ["2000-01-01T00:00:00.000000000", "2000-02-01T00:00:00.000000000"],
+                    ["2000-02-01T00:00:00.000000000", "2000-03-01T00:00:00.000000000"],
+                    ["2000-02-01T00:00:00.000000000", "2000-03-01T00:00:00.000000000"],
+                    ["2000-04-01T00:00:00.000000000", "2000-05-01T00:00:00.000000000"],
+                    ["2001-02-01T00:00:00.000000000", "2001-03-01T00:00:00.000000000"],
+                ],
+                dtype="datetime64[ns]",
+            ),
+            coords={"time": ds.time},
+            dims=["time", "bnds"],
+            attrs={"xcdat_bounds": "True"},
+        )
+
+        ds["ts"] = xr.DataArray(
+            data=np.array([[[2]], [[np.nan]], [[1]], [[1]], [[1]]]),
+            coords={"lat": ds.lat, "lon": ds.lon, "time": ds.time},
+            dims=["time", "lat", "lon"],
+            attrs={"test_attr": "test"},
+        )
+
+        # NOTE: If a cell has a missing value for any of the months, the average
+        # for that month should be masked with a min_weight threshold of 100%.
+        result = ds.temporal.group_average("ts", "month", min_weight=0.55)
+        expected = ds.copy()
+        expected = expected.drop_dims("time")
+        expected["ts"] = xr.DataArray(
+            name="ts",
+            data=np.array([[[2.0]], [[np.nan]], [[1.0]], [[1.0]]]),
+            coords={
+                "lat": expected.lat,
+                "lon": expected.lon,
+                "time": xr.DataArray(
+                    data=np.array(
+                        [
+                            cftime.DatetimeGregorian(2000, 1, 1),
+                            cftime.DatetimeGregorian(2000, 2, 1),
+                            cftime.DatetimeGregorian(2000, 4, 1),
                             cftime.DatetimeGregorian(2001, 2, 1),
                         ],
                     ),

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -3219,10 +3219,10 @@ class TestDepartures:
             attrs={
                 "test_attr": "test",
                 "operation": "temporal_avg",
-                "min_weight": 0.0,
                 "mode": "departures",
                 "freq": "season",
                 "weighted": "True",
+                "min_weight": 0.0,
                 "dec_mode": "DJF",
                 "drop_incomplete_seasons": "False",
             },

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -494,6 +494,14 @@ class TestGroupAverage:
                             cftime.DatetimeGregorian(2001, 1, 1),
                         ],
                     ),
+                    coords={
+                        "time": np.array(
+                            [
+                                cftime.DatetimeGregorian(2000, 1, 1),
+                                cftime.DatetimeGregorian(2001, 1, 1),
+                            ],
+                        )
+                    },
                     dims=["time"],
                     attrs={
                         "axis": "T",
@@ -588,6 +596,14 @@ class TestGroupAverage:
                             cftime.DatetimeGregorian(2001, 1, 1),
                         ],
                     ),
+                    coords={
+                        "time": np.array(
+                            [
+                                cftime.DatetimeGregorian(2000, 1, 1),
+                                cftime.DatetimeGregorian(2001, 1, 1),
+                            ],
+                        )
+                    },
                     dims=["time"],
                     attrs={
                         "axis": "T",
@@ -786,6 +802,17 @@ class TestGroupAverage:
                             cftime.DatetimeGregorian(2001, 1, 1),
                         ],
                     ),
+                    coords={
+                        "time": np.array(
+                            [
+                                cftime.DatetimeGregorian(2000, 1, 1),
+                                cftime.DatetimeGregorian(2000, 4, 1),
+                                cftime.DatetimeGregorian(2000, 7, 1),
+                                cftime.DatetimeGregorian(2000, 10, 1),
+                                cftime.DatetimeGregorian(2001, 1, 1),
+                            ],
+                        )
+                    },
                     dims=["time"],
                     attrs={
                         "axis": "T",

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -2103,14 +2103,15 @@ class TemporalAccessor:
         xr.DataArray
             The data variable with a temporal averaging attributes.
         """
-        data_var.attrs.update(
-            {
-                "operation": "temporal_avg",
-                "mode": self._mode,
-                "freq": self._freq,
-                "weighted": str(self._weighted),
-            }
-        )
+        attrs_to_set = {
+            "operation": "temporal_avg",
+            "mode": self._mode,
+            "freq": self._freq,
+            "weighted": str(self._weighted),
+        }
+
+        if self._weighted and hasattr(self, "_min_weight"):
+            attrs_to_set["min_weight"] = self._min_weight  # type: ignore
 
         if self._freq == "season":
             drop_incomplete_seasons = self._season_config["drop_incomplete_seasons"]
@@ -2119,16 +2120,18 @@ class TemporalAccessor:
             # TODO: Deprecate drop_incomplete_djf. This attr is only set if the
             # user does not set drop_incomplete_seasons.
             if drop_incomplete_seasons is False and drop_incomplete_djf is not False:
-                data_var.attrs["drop_incomplete_djf"] = str(drop_incomplete_djf)
+                attrs_to_set["drop_incomplete_djf"] = str(drop_incomplete_djf)
             else:
-                data_var.attrs["drop_incomplete_seasons"] = str(drop_incomplete_seasons)
+                attrs_to_set["drop_incomplete_seasons"] = str(drop_incomplete_seasons)
 
             custom_seasons = self._season_config.get("custom_seasons")
             if custom_seasons is not None:
-                data_var.attrs["custom_seasons"] = list(custom_seasons.keys())
+                attrs_to_set["custom_seasons"] = list(custom_seasons.keys())  # type: ignore
             else:
                 dec_mode = self._season_config.get("dec_mode")
-                data_var.attrs["dec_mode"] = dec_mode
+                attrs_to_set["dec_mode"] = dec_mode  # type: ignore
+
+        data_var.attrs.update(attrs_to_set)
 
         return data_var
 

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -464,6 +464,7 @@ class TemporalAccessor:
         reference_period: tuple[str, str] | None = None,
         season_config: SeasonConfigInput = DEFAULT_SEASON_CONFIG,
         skipna: bool | None = None,
+        min_weight: float | None = None,
     ):
         """Returns a Dataset with the climatology of a data variable.
 
@@ -574,6 +575,10 @@ class TemporalAccessor:
             skips missing values for float dtypes; other dtypes either do not
             have a sentinel missing value (int) or ``skipna=True`` has not been
             implemented (object, datetime64 or timedelta64).
+        min_weight : float | None, optional
+            Fraction of data coverage (i..e, weight) needed to return a
+            temporal average value. Value must range from 0 to 1, by default
+            None (equivalent to ``min_weight=0.0``).
 
         Returns
         -------
@@ -658,6 +663,7 @@ class TemporalAccessor:
             reference_period,
             season_config,
             skipna,
+            min_weight=min_weight,
         )
 
     def departures(
@@ -669,6 +675,7 @@ class TemporalAccessor:
         reference_period: tuple[str, str] | None = None,
         season_config: SeasonConfigInput = DEFAULT_SEASON_CONFIG,
         skipna: bool | None = None,
+        min_weight: float | None = None,
     ) -> xr.Dataset:
         """
         Returns a Dataset with the climatological departures (anomalies) for a
@@ -790,6 +797,10 @@ class TemporalAccessor:
             skips missing values for float dtypes; other dtypes either do not
             have a sentinel missing value (int) or ``skipna=True`` has not been
             implemented (object, datetime64 or timedelta64).
+        min_weight : float | None, optional
+            Fraction of data coverage (i..e, weight) needed to return a
+            temporal average value. Value must range from 0 to 1, by default
+            None (equivalent to ``min_weight=0.0``).
 
         Returns
         -------
@@ -870,7 +881,13 @@ class TemporalAccessor:
         inferred_freq = _infer_freq(ds[self.dim])
         if inferred_freq != freq:
             ds_obs = ds_obs.temporal.group_average(
-                data_var, freq, weighted, keep_weights, season_config, skipna
+                data_var,
+                freq,
+                weighted,
+                keep_weights,
+                season_config,
+                skipna,
+                min_weight,
             )
 
         # 4. Calculate the climatology of the data variable.
@@ -884,6 +901,7 @@ class TemporalAccessor:
             reference_period,
             season_config,
             skipna,
+            min_weight=min_weight,
         )
 
         # 5. Calculate the departures for the data variable.

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -370,7 +370,7 @@ class TemporalAccessor:
             have a sentinel missing value (int) or ``skipna=True`` has not been
             implemented (object, datetime64 or timedelta64).
         min_weight : float | None, optional
-            Fraction of data coverage (i..e, weight) needed to return a
+            Fraction of data coverage (i.e., weight) needed to return a
             temporal average value. Value must range from 0 to 1, by default
             None (equivalent to ``min_weight=0.0``).
 
@@ -576,7 +576,7 @@ class TemporalAccessor:
             have a sentinel missing value (int) or ``skipna=True`` has not been
             implemented (object, datetime64 or timedelta64).
         min_weight : float | None, optional
-            Fraction of data coverage (i..e, weight) needed to return a
+            Fraction of data coverage (i.e., weight) needed to return a
             temporal average value. Value must range from 0 to 1, by default
             None (equivalent to ``min_weight=0.0``).
 
@@ -798,7 +798,7 @@ class TemporalAccessor:
             have a sentinel missing value (int) or ``skipna=True`` has not been
             implemented (object, datetime64 or timedelta64).
         min_weight : float | None, optional
-            Fraction of data coverage (i..e, weight) needed to return a
+            Fraction of data coverage (i.e., weight) needed to return a
             temporal average value. Value must range from 0 to 1, by default
             None (equivalent to ``min_weight=0.0``).
 
@@ -1028,7 +1028,7 @@ class TemporalAccessor:
             predefined seasons are passed, configs for custom seasons are
             ignored and vice versa, by default DEFAULT_SEASON_CONFIG.
         min_weight : float | None, optional
-            Fraction of data coverage (i..e, weight) needed to return a
+            Fraction of data coverage (i.e., weight) needed to return a
             temporal average value. Value must range from 0 to 1, by default
             None (equivalent to ``min_weight=0.0``).
 
@@ -1649,7 +1649,7 @@ class TemporalAccessor:
             # Apply the weights to data.
             dv_weighted = dv * weights
 
-            # Group and sum weighted data, skippiing NaNs if specified.
+            # Group and sum weighted data, skipping NaNs if specified.
             dv_group_sum = self._group_data(dv_weighted).sum(skipna=skipna)
 
             # Mask weights where data is missing (set to zero).

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1652,19 +1652,17 @@ class TemporalAccessor:
             # Group and sum weighted data, skipping NaNs if specified.
             dv_group_sum = self._group_data(dv_weighted).sum(skipna=skipna)
 
-            # Mask weights where data is missing (set to zero).
-            masked_weights = _get_masked_weights(dv_weighted, self._weights)
-
-            # Group and sum masked weights.
+            # Mask weights where data is missing (set to zero), then
+            # group and sum the masked weights. This ensures that only weights
+            # corresponding to non-missing data are used in the denominator of
+            # the weighted average.
+            masked_weights = _get_masked_weights(dv, self._weights)
             masked_weights_group_sum = self._group_data(masked_weights).sum(
                 skipna=skipna
             )
 
             # Compute weighted average using the formula:
             # WA = sum(data * weights) / sum(weights for non-missing data)
-            # The denominator ensures that only weights for non-missing data
-            # are included, so missing data (with zero weight) does not
-            # affect the result.
             dv_avg = dv_group_sum / masked_weights_group_sum
 
             # Mask averaged data where the fraction of weights in each group

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -2110,7 +2110,7 @@ class TemporalAccessor:
             "weighted": str(self._weighted),
         }
 
-        if self._weighted and hasattr(self, "_min_weight"):
+        if self._weighted:
             attrs_to_set["min_weight"] = self._min_weight  # type: ignore
 
         if self._freq == "season":

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1667,11 +1667,19 @@ class TemporalAccessor:
             # affect the result.
             dv_avg = dv_group_sum / masked_weights_group_sum
 
-            # Set averaged data to NaN where masked weights are below the
-            # minimum threshold.
+            # Mask averaged data where the fraction of weights in each group
+            # does not meet the minimum weight threshold (fractional).
             if self._min_weight > 0.0:
+                # The sum of all weights in each group (i.e., full coverage)
+                weight_sum_all = self._group_data(self._weights).sum(skipna=skipna)
+
+                # Fraction of weights present in each group.
+                weight_fraction = masked_weights_group_sum / weight_sum_all
+
+                # Mask the averaged data where the weight fraction is below
+                # the minimum weight threshold.
                 dv_avg = xr.where(
-                    masked_weights_group_sum >= self._min_weight,
+                    weight_fraction >= self._min_weight,
                     dv_avg,
                     np.nan,
                     keep_attrs=True,

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1635,7 +1635,7 @@ class TemporalAccessor:
             dv_group_sum = self._group_data(dv_weighted).sum(skipna=skipna)
 
             # Mask weights where data is missing (set to zero).
-            masked_weights = _get_masked_weights(dv, self._weights)
+            masked_weights = _get_masked_weights(dv_weighted, self._weights)
 
             # Group and sum masked weights.
             masked_weights_group_sum = self._group_data(masked_weights).sum(
@@ -1649,10 +1649,6 @@ class TemporalAccessor:
             # affect the result.
             dv_avg = dv_group_sum / masked_weights_group_sum
 
-            # Restore the data variables name which gets lost with groupby
-            # arithmetic.
-            dv_avg.name = dv.name
-
             # Set averaged data to NaN where masked weights are below the
             # minimum threshold.
             if self._min_weight > 0.0:
@@ -1662,6 +1658,10 @@ class TemporalAccessor:
                     np.nan,
                     keep_attrs=True,
                 )
+
+            # Restore the data variables name which gets lost after arithmetic
+            # and masking operations.
+            dv_avg.name = dv.name
 
         return dv_avg
 

--- a/xcdat/utils.py
+++ b/xcdat/utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 import json
 

--- a/xcdat/utils.py
+++ b/xcdat/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import json
 


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This PR adds a `min_weight` threshold parameter to temporal group averaging APIs, allowing users to set a minimum data coverage requirement for temporal averaging. This enhancement ensures temporal averages are only computed when sufficient data is available, with values below the threshold being set to NaN.

- Adds `min_weight` parameter to `group_average`, `climatology`, and `departures` methods
- Implements weight threshold validation and masking in weighted temporal averaging
- Refactors weighted averaging logic into a dedicated `_weighted_group_average` method

## More Context
- Related to #531 
- Related to #672 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
