### PR TITLE
[Refactor] Improve the performance of temporal group averaging

### DIFF
--- a/.vscode/xcdat.code-workspace
+++ b/.vscode/xcdat.code-workspace
@@ -61,7 +61,7 @@
         "configurations": [
             {
                 "name": "Python: Current File",
-                "type": "python",
+                "type": "debugpy",
                 "request": "launch",
                 "program": "${file}",
                 "console": "integratedTerminal",

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -2217,6 +2217,26 @@ class TestDepartures:
             xr.testing.assert_identical(result, expected)
 
 
+def _check_each_weight_group_adds_up_to_1(ds: xr.Dataset, weights: xr.DataArray):
+    """Check that the sum of the weights in each group adds up to 1.0 (or 100%).
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The dataset with the temporal accessor class attached.
+    weights : xr.DataArray
+        The weights to check, produced by the `_get_weights` method.
+    """
+    time_lengths = ds.time_bnds[:, 1] - ds.time_bnds[:, 0]
+    time_lengths = time_lengths.astype(np.float64)
+
+    grouped_time_lengths = ds.temporal._group_data(time_lengths)
+
+    actual_sum = ds.temporal._group_data(weights).sum().values
+    expected_sum = np.ones(len(grouped_time_lengths.groups))
+    np.testing.assert_allclose(actual_sum, expected_sum)
+
+
 class Test_GetWeights:
     class TestWeightsForAverageMode:
         @pytest.fixture(autouse=True)
@@ -2289,6 +2309,8 @@ class Test_GetWeights:
             )
             assert np.allclose(result, expected)
 
+            _check_each_weight_group_adds_up_to_1(ds, result)
+
         def test_weights_for_monthly_averages(self):
             ds = self.ds.copy()
 
@@ -2351,6 +2373,8 @@ class Test_GetWeights:
                 ]
             )
             assert np.allclose(result, expected)
+
+            _check_each_weight_group_adds_up_to_1(ds, result)
 
     class TestWeightsForGroupAverageMode:
         @pytest.fixture(autouse=True)
@@ -2423,6 +2447,8 @@ class Test_GetWeights:
             )
             assert np.allclose(result, expected)
 
+            _check_each_weight_group_adds_up_to_1(ds, result)
+
         def test_weights_for_monthly_averages(self):
             ds = self.ds.copy()
 
@@ -2468,6 +2494,8 @@ class Test_GetWeights:
             result = ds.temporal._get_weights(ds.time_bnds)
             expected = np.ones(15)
             assert np.allclose(result, expected)
+
+            _check_each_weight_group_adds_up_to_1(ds, result)
 
         def test_weights_for_seasonal_averages_with_DJF_and_drop_incomplete_seasons(
             self,
@@ -2631,6 +2659,8 @@ class Test_GetWeights:
             )
             assert np.allclose(result, expected, equal_nan=True)
 
+            _check_each_weight_group_adds_up_to_1(ds, result)
+
         def test_weights_for_seasonal_averages_with_JFD(self):
             ds = self.ds.copy()
 
@@ -2701,6 +2731,8 @@ class Test_GetWeights:
                 ]
             )
             assert np.allclose(result, expected)
+
+            _check_each_weight_group_adds_up_to_1(ds, result)
 
         def test_custom_season_time_series_weights(self):
             ds = self.ds.copy()
@@ -2779,6 +2811,8 @@ class Test_GetWeights:
                 ]
             )
             assert np.allclose(result, expected)
+
+            _check_each_weight_group_adds_up_to_1(ds, result)
 
         def test_weights_for_daily_averages(self):
             ds = self.ds.copy()
@@ -2872,6 +2906,8 @@ class Test_GetWeights:
             result = ds.temporal._get_weights(ds.time_bnds)
             expected = np.ones(15)
             assert np.allclose(result, expected)
+
+            _check_each_weight_group_adds_up_to_1(ds, result)
 
     class TestWeightsForClimatologyMode:
         @pytest.fixture(autouse=True)
@@ -3035,6 +3071,8 @@ class Test_GetWeights:
 
             assert np.allclose(result, expected, equal_nan=True)
 
+            _check_each_weight_group_adds_up_to_1(ds, result)
+
         def test_weights_for_seasonal_climatology_with_JFD(self):
             ds = self.ds.copy()
 
@@ -3101,6 +3139,8 @@ class Test_GetWeights:
             )
             assert np.allclose(result, expected, equal_nan=True)
 
+            _check_each_weight_group_adds_up_to_1(ds, result)
+
         def test_weights_for_annual_climatology(self):
             ds = self.ds.copy()
 
@@ -3165,6 +3205,8 @@ class Test_GetWeights:
             )
             assert np.allclose(result, expected)
 
+            _check_each_weight_group_adds_up_to_1(ds, result)
+
         def test_weights_for_daily_climatology(self):
             ds = self.ds.copy()
 
@@ -3226,6 +3268,8 @@ class Test_GetWeights:
                 ]
             )
             assert np.allclose(result, expected)
+
+            _check_each_weight_group_adds_up_to_1(ds, result)
 
 
 class Test_Averager:

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1810,7 +1810,7 @@ class TestDepartures:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_monthly_departures_relative_to_climatology_reference_period_with_same_output_freq(
         self,

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -121,7 +121,7 @@ class TestAverage:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
         # Test unweighted averages
         result = ds.temporal.average("ts", weighted=False)
@@ -139,7 +139,7 @@ class TestAverage:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_averages_for_monthly_time_series(self):
         # Set up dataset
@@ -293,7 +293,7 @@ class TestAverage:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
         # Test unweighted averages
         result = ds.temporal.average("ts", weighted=False)
@@ -310,7 +310,7 @@ class TestAverage:
                 "weighted": "False",
             },
         )
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_averages_for_hourly_time_series(self):
         ds = xr.Dataset(
@@ -378,7 +378,7 @@ class TestAverage:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
         # Test unweighted averages
         result = ds.temporal.average("ts", weighted=False)
@@ -396,7 +396,7 @@ class TestAverage:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
 
 class TestGroupAverage:
@@ -619,7 +619,7 @@ class TestGroupAverage:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_seasonal_averages_with_DJF_without_dropping_incomplete_seasons(
         self,
@@ -670,7 +670,7 @@ class TestGroupAverage:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_seasonal_averages_with_JFD(self):
         ds = self.ds.copy()
@@ -729,7 +729,7 @@ class TestGroupAverage:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_custom_seasonal_averages(self):
         ds = self.ds.copy()
@@ -787,7 +787,7 @@ class TestGroupAverage:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_raises_error_with_incorrect_custom_seasons_argument(self):
         # Test raises error with non-3 letter strings
@@ -873,7 +873,7 @@ class TestGroupAverage:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_monthly_averages_with_masked_data(self):
         ds = self.ds.copy()
@@ -924,7 +924,7 @@ class TestGroupAverage:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_daily_averages(self):
         ds = self.ds.copy()
@@ -967,7 +967,7 @@ class TestGroupAverage:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_hourly_averages(self):
         ds = self.ds.copy()
@@ -1011,7 +1011,7 @@ class TestGroupAverage:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
 
 class TestClimatology:
@@ -1105,7 +1105,7 @@ class TestClimatology:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_seasonal_climatology_with_DJF(self):
         ds = self.ds.copy()
@@ -1159,7 +1159,7 @@ class TestClimatology:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     @requires_dask
     def test_chunked_weighted_seasonal_climatology_with_DJF(self):
@@ -1214,7 +1214,7 @@ class TestClimatology:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_seasonal_climatology_with_JFD(self):
         ds = self.ds.copy()
@@ -1265,7 +1265,7 @@ class TestClimatology:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_custom_seasonal_climatology(self):
         ds = self.ds.copy()
@@ -1328,7 +1328,7 @@ class TestClimatology:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_monthly_climatology(self):
         result = self.ds.temporal.climatology("ts", "month")
@@ -1391,7 +1391,7 @@ class TestClimatology:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_unweighted_monthly_climatology(self):
         result = self.ds.temporal.climatology("ts", "month", weighted=False)
@@ -1453,7 +1453,7 @@ class TestClimatology:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_daily_climatology(self):
         result = self.ds.temporal.climatology("ts", "day", weighted=True)
@@ -1515,7 +1515,7 @@ class TestClimatology:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_daily_climatology_drops_leap_days_with_matching_calendar(self):
         time = xr.DataArray(
@@ -1606,7 +1606,7 @@ class TestClimatology:
                 },
             )
 
-            assert result.identical(expected)
+            xr.testing.assert_identical(result, expected)
 
     def test_unweighted_daily_climatology(self):
         result = self.ds.temporal.climatology("ts", "day", weighted=False)
@@ -1668,7 +1668,7 @@ class TestClimatology:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
 
 class TestDepartures:
@@ -1895,7 +1895,7 @@ class TestDepartures:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_seasonal_departures_with_DJF(self):
         ds = self.ds.copy()
@@ -1945,7 +1945,7 @@ class TestDepartures:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_seasonal_departures_with_DJF_and_keep_weights(self):
         ds = self.ds.copy()
@@ -2021,7 +2021,7 @@ class TestDepartures:
             dims=["time_original"],
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_unweighted_seasonal_departures_with_DJF(self):
         ds = self.ds.copy()
@@ -2071,7 +2071,7 @@ class TestDepartures:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_unweighted_seasonal_departures_with_JFD(self):
         ds = self.ds.copy()
@@ -2121,7 +2121,7 @@ class TestDepartures:
             },
         )
 
-        assert result.identical(expected)
+        xr.testing.assert_identical(result, expected)
 
     def test_weighted_daily_departures_drops_leap_days_with_matching_calendar(self):
         time = xr.DataArray(
@@ -2214,7 +2214,7 @@ class TestDepartures:
                 },
             )
 
-            assert result.identical(expected)
+            xr.testing.assert_identical(result, expected)
 
 
 class Test_GetWeights:

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -747,16 +747,16 @@ class TemporalAccessor:
         # calling the group average or climatology APIs in step #3.
         ds = self._preprocess_dataset(ds)
 
-        # 3. Calculate the grouped average and climatology of the data variable.
+        # 3. Get the observational data variable.
         # ----------------------------------------------------------------------
-        # The climatology and grouped average APIs are called on the copied
-        # dataset to create separate instances of the `TemporalAccessor` class.
-        # This is done to avoid overriding the attributes of the current
-        # instance of `TemporalAccessor` (set in step #1 above).
+        # NOTE: The xCDAT APIs are called on copies of the original dataset to
+        # create separate instances of the `TemporalAccessor` class. This is
+        # done to avoid overriding the attributes of the current instance of
+        # `TemporalAccessor`, which is set by step #1.
+        ds_obs = ds.copy()
 
         # Group averaging is only required if the dataset's frequency (input)
         # differs from the `freq` arg (output).
-        ds_obs = ds.copy()
         inferred_freq = _infer_freq(ds[self.dim])
         if inferred_freq != freq:
             ds_obs = ds_obs.temporal.group_average(
@@ -767,7 +767,10 @@ class TemporalAccessor:
                 season_config,
             )
 
-        ds_climo = ds.temporal.climatology(
+        # 4. Calculate the climatology of the data variable.
+        # ----------------------------------------------------------------------
+        ds_climo = ds.copy()
+        ds_climo = ds_climo.temporal.climatology(
             data_var,
             freq,
             weighted,
@@ -776,35 +779,11 @@ class TemporalAccessor:
             season_config,
         )
 
-        # 4. Group the averaged data variable values by the time `freq`.
+        # 5. Calculate the departures for the data variable.
         # ----------------------------------------------------------------------
-        # This step allows us to perform xarray's grouped arithmetic to
-        # calculate departures.
-        dv_obs = ds_obs[data_var].copy()
-        self._labeled_time = self._label_time_coords(dv_obs[self.dim])
-        dv_obs_grouped = self._group_data(dv_obs)
+        ds_departs = self._calculate_departures(ds_obs, ds_climo, data_var)
 
-        # 5. Align time dimension names using the labeled time dimension name.
-        # ----------------------------------------------------------------------
-        dv_climo = ds_climo[data_var]
-
-        # 6. Calculate the departures for the data variable.
-        # ----------------------------------------------------------------------
-        # departures = observation - climatology
-        with xr.set_options(keep_attrs=True):
-            dv_departs = dv_obs_grouped - dv_climo
-            dv_departs = self._add_operation_attrs(dv_departs)
-
-            # The original time dimension is dropped from the dataset to
-            # accomodate the new time dimension and its associated coordinates.
-            ds_obs = ds_obs.drop_dims(str(self.dim))
-            ds_obs[data_var] = dv_departs
-
-        if weighted and keep_weights:
-            self._weights = ds_climo.time_wts
-            ds_obs = self._keep_weights(ds_obs)
-
-        return ds_obs
+        return ds_departs
 
     def _averager(
         self,
@@ -1306,7 +1285,7 @@ class TemporalAccessor:
             dv_gb = dv.groupby(f"{self.dim}.{self._freq}")
         else:
             dv = dv.assign_coords({self.dim: self._labeled_time})
-            dv_gb = dv.groupby(self._labeled_time.name)
+            dv_gb = dv.groupby(self.dim)
 
         return dv_gb
 
@@ -1653,6 +1632,10 @@ class TemporalAccessor:
     def _keep_weights(self, ds: xr.Dataset) -> xr.Dataset:
         """Keep the weights in the dataset.
 
+        The labeled time coordinates for the weights are replaced with the
+        original time coordinates and the dimension name is appended with
+        "_original".
+
         Parameters
         ----------
         ds : xr.Dataset
@@ -1663,16 +1646,11 @@ class TemporalAccessor:
         xr.Dataset
             The dataset with the weights used for averaging.
         """
-        # Append "_original" to the name of the weights` time coordinates to
-        # avoid conflict with the grouped time coordinates in the Dataset (can
-        # have a different shape).
         if self._mode in ["group_average", "climatology"]:
-            self._weights = self._weights.rename({self.dim: f"{self.dim}_original"})
-            # Only keep the original time coordinates, not the ones labeled
-            # by group.
-            self._weights = self._weights.drop_vars(self._labeled_time.name)
+            weights = self._weights.assign_coords({self.dim: self._dataset[self.dim]})
+            weights = weights.rename({self.dim: f"{self.dim}_original"})
 
-        ds[self._weights.name] = self._weights
+        ds[weights.name] = weights
 
         return ds
 
@@ -1716,6 +1694,60 @@ class TemporalAccessor:
                 data_var.attrs["custom_seasons"] = list(custom_seasons.keys())
 
         return data_var
+
+    def _calculate_departures(
+        self,
+        ds_obs: xr.Dataset,
+        ds_climo: xr.Dataset,
+        data_var: str,
+    ) -> xr.Dataset:
+        """Calculate the departures for a data variable.
+
+        How this methods works:
+
+            1. Label the observational data variable's time coordinates by their
+               appropriate time group. For example, the first two time
+               coordinates 2000-01-01 and 2000-02-01 are replaced with the
+               "01-01-01" and "01-02-01" monthly groups.
+            2. Calculate departures by subtracting the climatology from the
+               labeled observational data using Xarray's grouped arithmetic with
+               automatic broadcasting (departures = obs - climo).
+            3. Restore the original time coordinates to the departures variable
+               to preserve the "year" of the time coordinates. For example,
+               the first two time coordinates 01-01-01 and 01-02-01 are reverted
+               back to 2000-01-01 and 2000-02-01.
+
+        Parameters
+        ----------
+        ds_obs : xr.Dataset
+            The observational dataset.
+        dv_climo : xr.Dataset
+            The climatology dataset.
+        data_var : str
+            The key of the data variable for calculating departures.
+
+        Returns
+        -------
+        xr.Dataset
+            The dataset containing the departures for a data variable.
+        """
+        ds_departs = ds_obs.copy()
+
+        dv_obs = ds_obs[data_var].copy()
+        self._labeled_time = self._label_time_coords(dv_obs[self.dim])
+        dv_obs_grouped = self._group_data(dv_obs)
+
+        dv_climo = ds_climo[data_var].copy()
+
+        with xr.set_options(keep_attrs=True):
+            dv_departs = dv_obs_grouped - dv_climo
+
+        dv_departs = self._add_operation_attrs(dv_departs)
+
+        dv_departs = dv_departs.assign_coords({self.dim: ds_obs[self.dim]})
+        ds_departs[data_var] = dv_departs
+
+        return ds_departs
 
 
 def _infer_freq(time_coords: xr.DataArray) -> Frequency:

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -783,6 +783,10 @@ class TemporalAccessor:
         # ----------------------------------------------------------------------
         ds_departs = self._calculate_departures(ds_obs, ds_climo, data_var)
 
+        if keep_weights:
+            self._weights = ds_climo[f"{self.dim}_wts"]
+            ds_departs = self._keep_weights(ds_departs)
+
         return ds_departs
 
     def _averager(
@@ -1644,6 +1648,8 @@ class TemporalAccessor:
         if self._mode in ["group_average", "climatology"]:
             weights = self._weights.assign_coords({self.dim: self._dataset[self.dim]})
             weights = weights.rename({self.dim: f"{self.dim}_original"})
+        else:
+            weights = self._weights
 
         ds[weights.name] = weights
 

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1250,7 +1250,7 @@ class TemporalAccessor:
         if isinstance(time_lengths.data, Array):
             time_lengths = time_lengths.astype("timedelta64[ns]")
 
-        time_lengths = time_lengths.astype("float64")
+        time_lengths = time_lengths.astype(np.float64)
 
         grouped_time_lengths = self._group_data(time_lengths)
         weights: xr.DataArray = grouped_time_lengths / grouped_time_lengths.sum()

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1221,9 +1221,6 @@ class TemporalAccessor:
         divided by the total sum of the time lengths in its group to get its
         corresponding weight.
 
-        The sum of the weights for each group is validated to ensure it equals
-        1.0.
-
         Parameters
         ----------
         time_bounds : xr.DataArray

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -783,7 +783,7 @@ class TemporalAccessor:
         # ----------------------------------------------------------------------
         ds_departs = self._calculate_departures(ds_obs, ds_climo, data_var)
 
-        if keep_weights:
+        if weighted and keep_weights:
             self._weights = ds_climo[f"{self.dim}_wts"]
             ds_departs = self._keep_weights(ds_departs)
 

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1248,18 +1248,13 @@ class TemporalAccessor:
         # or time unit (with rare exceptions see release notes). To avoid this
         # warning please use the scalar types `np.float64`, or string notation.`
         if isinstance(time_lengths.data, Array):
-            time_lengths.load()
+            time_lengths = time_lengths.astype("timedelta64[ns]")
 
-        time_lengths = time_lengths.astype(np.float64)
+        time_lengths = time_lengths.astype("float64")
 
         grouped_time_lengths = self._group_data(time_lengths)
         weights: xr.DataArray = grouped_time_lengths / grouped_time_lengths.sum()
         weights.name = f"{self.dim}_wts"
-
-        # Validate the sum of weights for each group is 1.0.
-        actual_sum = self._group_data(weights).sum().values
-        expected_sum = np.ones(len(grouped_time_lengths.groups))
-        np.testing.assert_allclose(actual_sum, expected_sum)
 
         return weights
 

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1741,7 +1741,6 @@ class TemporalAccessor:
             dv_departs = dv_obs_grouped - dv_climo
 
         dv_departs = self._add_operation_attrs(dv_departs)
-
         dv_departs = dv_departs.assign_coords({self.dim: ds_obs[self.dim]})
         ds_departs[data_var] = dv_departs
 


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #688 

## TODO:

- [x] Identify performance bottlenecks
   1. Generating labeled time coordinates (aka assign groups) and adding it to the existing time dimension with existing coordinates, then performing the Xarray groupby yields extremely slow results (not sure why, it's an Xarray issue). (Refer to [comment](https://github.com/xCDAT/xcdat/issues/688#issuecomment-2319299638)) -- replace time coords with labeled time coords directly for grouping, rather than adding labeled time coords as auxiliary coords on the time dimension (which slows things down in Xarray for some reason, need to ask Xarray forum)
   2. In `_get_weights()`, loading time lengths into memory is slow ([lines](https://github.com/xCDAT/xcdat/blob/584fccee91f559089e4bb24c9cc45983b998bf4a/xcdat/temporal.py#L1281-L1290)) -- replace with casting to `"timedelta64[ns]"` then `float64`
   3. In `_get_weights()`, performing validation to check the sums of weights for each group adds up to 1 is slow ([lines](https://github.com/xCDAT/xcdat/blob/584fccee91f559089e4bb24c9cc45983b998bf4a/xcdat/temporal.py#L1296-L1299)) -- remove this unnecessary assertion
- [ ] ~~Identify performance optimizations -- I don't think this is necessary right now~~
   1. Xarray `groupby` with vs. without `flox` package
   2. Try with Dask chunking
- [x] Make sure unit tests still pass
- [x] Measure performance difference between this branch and `main`
- [x] Perform regression testing between branch code on same dataset

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
