### PR TITLE
Update temporal.py to properly handle piControl simulations

### DIFF
--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1084,7 +1084,11 @@ class TemporalAccessor:
             ds[self.dim].dt.year.values[0],
             ds[self.dim].dt.year.values[-1],
         )
-        incomplete_seasons = (f"{start_year:04d}-01", f"{start_year:04d}-02", f"{end_year:04d}-12")
+        incomplete_seasons = (
+            f"{start_year:04d}-01",
+            f"{start_year:04d}-02",
+            f"{end_year:04d}-12",
+        )
 
         for year_month in incomplete_seasons:
             try:

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -815,7 +815,7 @@ class TemporalAccessor:
         # it becomes obsolete after the data variable is averaged. When the
         # averaged data variable is added to the dataset, the new time dimension
         # and its associated coordinates are also added.
-        ds = ds.drop_dims(self.dim)  # type: ignore
+        ds = ds.drop_dims(self.dim)
         ds[dv_avg.name] = dv_avg
 
         if keep_weights:
@@ -847,7 +847,7 @@ class TemporalAccessor:
         dv = _get_data_var(self._dataset, data_var)
 
         self.data_var = data_var
-        self.dim = get_dim_coords(dv, "T").name
+        self.dim = str(get_dim_coords(dv, "T").name)
 
         if not _contains_datetime_like_objects(dv[self.dim]):
             first_time_coord = dv[self.dim].values[0]
@@ -1119,9 +1119,7 @@ class TemporalAccessor:
         -------
         xr.Dataset
         """
-        ds = ds.sel(  # type: ignore
-            **{self.dim: ~((ds.time.dt.month == 2) & (ds.time.dt.day == 29))}
-        )
+        ds = ds.sel(**{self.dim: ~((ds.time.dt.month == 2) & (ds.time.dt.day == 29))})
         return ds
 
     def _average(self, ds: xr.Dataset, data_var: str) -> xr.DataArray:
@@ -1146,9 +1144,9 @@ class TemporalAccessor:
                 time_bounds = ds.bounds.get_bounds("T", var_key=data_var)
                 self._weights = self._get_weights(time_bounds)
 
-                dv = dv.weighted(self._weights).mean(dim=self.dim)  # type: ignore
+                dv = dv.weighted(self._weights).mean(dim=self.dim)
             else:
-                dv = dv.mean(dim=self.dim)  # type: ignore
+                dv = dv.mean(dim=self.dim)
 
         dv = self._add_operation_attrs(dv)
 

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1084,7 +1084,7 @@ class TemporalAccessor:
             ds[self.dim].dt.year.values[0],
             ds[self.dim].dt.year.values[-1],
         )
-        incomplete_seasons = (f"{start_year}-01", f"{start_year}-02", f"{end_year}-12")
+        incomplete_seasons = (f"{start_year:04d}-01", f"{start_year:04d}-02", f"{end_year:04d}-12")
 
         for year_month in incomplete_seasons:
             try:

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1085,9 +1085,9 @@ class TemporalAccessor:
             ds[self.dim].dt.year.values[-1],
         )
         incomplete_seasons = (
-            f"{start_year:04d}-01",
-            f"{start_year:04d}-02",
-            f"{end_year:04d}-12",
+            f"{int(start_year):04d}-01",
+            f"{int(start_year):04d}-02",
+            f"{int(end_year):04d}-12",
         )
 
         for year_month in incomplete_seasons:


### PR DESCRIPTION
## Description
PiControl simulations can have time step labels as like "0001-01-01". To not lose the first "000" in year, #695 proposed this fix.

- Closes #695
- Convert `self.dim` in `TemporalAccessor` from Hashable to a string to fix mypy warning and remove type ignore comments

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
