### PR TITLE
Fixes preserving coordinates in regrid2

### DIFF
--- a/xcdat/regridder/regrid2.py
+++ b/xcdat/regridder/regrid2.py
@@ -4,12 +4,8 @@ import numpy as np
 import xarray as xr
 
 import xcdat as xc
-from xcdat.axis import VAR_NAME_MAP, get_dim_keys
+from xcdat.axis import get_dim_keys
 from xcdat.regridder.base import BaseRegridder, _preserve_bounds
-
-# Spatial axes keys used to map to the axes in an input data variable to build
-# the output variable.
-VALID_SPATIAL_AXES_KEYS = ["X", "Y"] + VAR_NAME_MAP["X"] + VAR_NAME_MAP["Y"]
 
 
 class Regrid2Regridder(BaseRegridder):

--- a/xcdat/regridder/regrid2.py
+++ b/xcdat/regridder/regrid2.py
@@ -238,11 +238,24 @@ def _build_dataset(
     output_coords: dict[str, xr.DataArray] = {}
     output_data_vars: dict[str, xr.DataArray] = {}
 
-    dims = list(input_data_var.dims)
+    for dim in input_data_var.dims:
+        dim = str(dim)
+
+        try:
+            axis_name = [x for x, y in ds.cf.axes.items() if dim in y][0]
+        except Exception:
+            raise ValueError(
+                f"Could not determine axis name for dimension {dim}"
+            ) from None
+
+        if axis_name in ["X", "Y"]:
+            output_coords[dim] = output_grid.cf[axis_name]
+        else:
+            output_coords[dim] = input_data_var.cf[axis_name]
 
     output_da = xr.DataArray(
         output_data,
-        dims=dims,
+        dims=input_data_var.dims,
         coords=output_coords,
         attrs=ds[data_var].attrs.copy(),
         name=data_var,


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
When regrid2 constructs the output dataset it did not preserve any coords from the input dataset or the output grid. This PR fixes the issue by populating coords for every dimension from the appropriate source (input dataset, output grid).

- Closes #709 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
