### PR TITLE
Fix incorrect dimension used for temporal weights generation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,6 +28,7 @@ Below is a list of top-level API functions that are available in ``xcdat``.
     get_dim_coords
     get_dim_keys
     get_coords_by_name
+    get_bounds_dim
     create_bounds
     create_axis
     create_gaussian_grid

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -12,7 +12,7 @@ from tests.fixtures import (
     lat_bnds,
     lon_bnds,
 )
-from xcdat.bounds import BoundsAccessor
+from xcdat.bounds import BoundsAccessor, get_bounds_dim
 
 logger = logging.getLogger(__name__)
 
@@ -1059,3 +1059,22 @@ class TestAddTimeBounds:
         )
 
         assert result.identical(expected)
+
+
+class TestGetBoundsDim:
+    def test_raises_error_if_no_valid_bounds_dim(self):
+        da_bounds = xr.DataArray(
+            data=np.array([[0, 1], [1, 2], [2, 3]]),
+            dims=["time", "invalid_dim"],
+        )
+        with pytest.raises(ValueError, match="Invalid bounds dimension"):
+            get_bounds_dim(da_bounds)
+
+    @pytest.mark.parametrize("dim", ["bnds", "bnd", "bounds", "bound"])
+    def test_returns_correct_bounds_dim(self, dim):
+        da_bounds = xr.DataArray(
+            data=np.array([[0, 1], [1, 2], [2, 3]]),
+            dims=["time", dim],
+        )
+        result = get_bounds_dim(da_bounds)
+        assert result == dim

--- a/xcdat/__init__.py
+++ b/xcdat/__init__.py
@@ -8,7 +8,7 @@ from xcdat.axis import (  # noqa: F401
     get_dim_keys,
     swap_lon_axis,
 )
-from xcdat.bounds import BoundsAccessor, create_bounds  # noqa: F401
+from xcdat.bounds import BoundsAccessor, create_bounds, get_bounds_dim  # noqa: F401
 from xcdat.dataset import decode_time, open_dataset, open_mfdataset  # noqa: F401
 from xcdat.regridder.accessor import RegridderAccessor  # noqa: F401
 from xcdat.regridder.grid import (  # noqa: F401

--- a/xcdat/bounds.py
+++ b/xcdat/bounds.py
@@ -26,6 +26,10 @@ from xcdat.temporal import (
 
 logger = _setup_custom_logger(__name__)
 
+# A list of valid bounds dimension names, useful for dynamic retrieval using
+# get_bounds_dim().
+VALID_BOUNDS_DIMS = ["bnds", "bnd", "bounds", "bound"]
+
 
 @xr.register_dataset_accessor("bounds")
 class BoundsAccessor:
@@ -1007,3 +1011,40 @@ def create_bounds(axis: CFAxisKey, coord_var: xr.DataArray) -> xr.DataArray:
     )
 
     return bounds
+
+
+def get_bounds_dim(da_bounds: xr.DataArray) -> str:
+    """Identify the bounds dimension in the given bounds DataArray.
+
+    This function checks the dimensions of the provided DataArray to find
+    a valid bounds dimension. Valid bounds dimensions include "bnds", "bnd",
+    "bounds", and "bound".
+
+    Parameters
+    ----------
+    da_bounds : xr.DataArray
+        The bounds DataArray whose dimensions are to be checked for a valid
+        bounds dimension.
+
+    Returns
+    -------
+    str
+        The name of the valid bounds dimension found in the DataArray.
+
+    Raises
+    ------
+    ValueError
+        If no valid bounds dimension is found in the DataArray.
+
+    Notes
+    -----
+    This function is designed to work with DataArrays that include a dimension
+    representing bounds, which is commonly used in geospatial or temporal data.
+    """
+    for dim in VALID_BOUNDS_DIMS:
+        if dim in da_bounds.dims:
+            return dim
+
+    raise ValueError(
+        f"Invalid bounds dimension. Supported dimensions include: {VALID_BOUNDS_DIMS}."
+    )

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1618,8 +1618,8 @@ class TemporalAccessor:
         ----------
         .. [4] https://cfconventions.org/cf-conventions/cf-conventions.html#calendar
         """
-        with xr.set_options(keep_attrs=True):
-            time_lengths: xr.DataArray = time_bounds[:, 1] - time_bounds[:, 0]
+        bounds_dim = bounds.get_bounds_dim(time_bounds)
+        time_lengths = time_bounds.diff(dim=bounds_dim).squeeze()
 
         # Must be cast dtype from "timedelta64[ns]" to "float64", specifically
         # when using Dask arrays. Otherwise, the numpy warning below is thrown:


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #748

This PR addresses an issue in the temporal group average API where weights were calculated using positional indexes to subtract time bounds. This approach mistakenly assumes a fixed order and number of dimensions.

**The Issue**

For example, in issue #748, the time bounds have dimensions arranged as (member, time, bound). The current logic incorrectly uses the "time" dimension for calculating weights instead of the "bound" dimension. This error ultimately leads to the following downstream issue:

```
ValueError: cannot add coordinates with new dimensions to a DataArray
```

**The Solution**

To resolve this, the calculation now uses label-based indexing via the new `get_bounds_dim()` function. This change ensures that the correct dimension ("bound") is identified and used, regardless of the order or number of dimensions in the time bounds array.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x]  I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
