### PR TITLE
Adds option to output regridding weights

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -14,6 +14,7 @@ dependencies:
     - numpy >=2.0.0,<3.0.0
     - pandas
     - python-dateutil
+    - sparse
     - xarray >=2024.03.0
     - xesmf >=0.8.7
     - xgcm

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -14,6 +14,7 @@ dependencies:
     - numpy >=2.0.0,<3.0.0
     - pandas
     - python-dateutil
+    - sparse
     - xarray >=2024.03.0
     - xesmf >=0.8.7
     - xgcm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "numpy >=2.0.0,<3.0.0",
   "pandas",
   "python-dateutil",
+  "sparse",
   "xarray >=2024.03.0",
   "xesmf >=0.8.7",
   "xgcm",

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -605,14 +605,21 @@ class TestRegrid2Regridder:
         assert np.all(output_data.ts == 1)
 
     def test_output_weigths(self):
-        regridder = regrid2.Regrid2Regridder(self.coarse_2d_ds, self.fine_2d_ds, output_weights=True)
+        regridder = regrid2.Regrid2Regridder(
+            self.coarse_2d_ds, self.fine_2d_ds, output_weights=True
+        )
 
         output_ds = regridder.horizontal("ts", self.coarse_2d_ds)
 
         assert "weights" in output_ds
-        assert output_ds["weights"].shape ==  self.fine_2d_ds["ts"].shape + self.coarse_2d_ds["ts"].shape
+        assert (
+            output_ds["weights"].shape
+            == self.fine_2d_ds["ts"].shape + self.coarse_2d_ds["ts"].shape
+        )
 
-        regridder = regrid2.Regrid2Regridder(self.coarse_2d_ds, self.fine_2d_ds, output_weights="ts_weights")
+        regridder = regrid2.Regrid2Regridder(
+            self.coarse_2d_ds, self.fine_2d_ds, output_weights="ts_weights"
+        )
 
         output_ds = regridder.horizontal("ts", self.coarse_2d_ds)
 
@@ -760,14 +767,21 @@ class TestXESMFRegridder:
     def test_output_weights(self):
         ds = self.ds.copy()
 
-        regridder = xesmf.XESMFRegridder(ds, self.new_grid, "bilinear", output_weights=True)
+        regridder = xesmf.XESMFRegridder(
+            ds, self.new_grid, "bilinear", output_weights=True
+        )
 
         output = regridder.horizontal("ts", ds)
 
         assert "weights" in output
-        assert output["weights"].shape == (self.new_grid["lat"].shape[0], self.new_grid["lon"].shape[0]) + (ds["lat"].shape[0], ds["lon"].shape[0])
+        assert output["weights"].shape == (
+            self.new_grid["lat"].shape[0],
+            self.new_grid["lon"].shape[0],
+        ) + (ds["lat"].shape[0], ds["lon"].shape[0])
 
-        regridder = xesmf.XESMFRegridder(ds, self.new_grid, "bilinear", output_weights="ts_weights")
+        regridder = xesmf.XESMFRegridder(
+            ds, self.new_grid, "bilinear", output_weights="ts_weights"
+        )
 
         output = regridder.horizontal("ts", ds)
 

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -604,6 +604,20 @@ class TestRegrid2Regridder:
 
         assert np.all(output_data.ts == 1)
 
+    def test_output_weigths(self):
+        regridder = regrid2.Regrid2Regridder(self.coarse_2d_ds, self.fine_2d_ds, output_weights=True)
+
+        output_ds = regridder.horizontal("ts", self.coarse_2d_ds)
+
+        assert "weights" in output_ds
+        assert output_ds["weights"].shape ==  self.fine_2d_ds["ts"].shape + self.coarse_2d_ds["ts"].shape
+
+        regridder = regrid2.Regrid2Regridder(self.coarse_2d_ds, self.fine_2d_ds, output_weights="ts_weights")
+
+        output_ds = regridder.horizontal("ts", self.coarse_2d_ds)
+
+        assert "ts_weights" in output_ds
+
     def test_map_longitude_coarse_to_fine(self):
         mapping, weights = regrid2._map_longitude(
             self.coarse_lon_bnds.values, self.fine_lon_bnds.values
@@ -742,6 +756,22 @@ class TestXESMFRegridder:
         assert "lat_bnds" in output
         assert "lon_bnds" in output
         assert "time_bnds" in output
+
+    def test_output_weights(self):
+        ds = self.ds.copy()
+
+        regridder = xesmf.XESMFRegridder(ds, self.new_grid, "bilinear", output_weights=True)
+
+        output = regridder.horizontal("ts", ds)
+
+        assert "weights" in output
+        assert output["weights"].shape == (self.new_grid["lat"].shape[0], self.new_grid["lon"].shape[0]) + (ds["lat"].shape[0], ds["lon"].shape[0])
+
+        regridder = xesmf.XESMFRegridder(ds, self.new_grid, "bilinear", output_weights="ts_weights")
+
+        output = regridder.horizontal("ts", ds)
+
+        assert "ts_weights" in output
 
     @pytest.mark.parametrize(
         "name,value,_",

--- a/xcdat/regridder/regrid2.py
+++ b/xcdat/regridder/regrid2.py
@@ -32,7 +32,12 @@ class Regrid2Regridder(BaseRegridder):
             Dataset containing the source grid.
         output_grid : xr.Dataset
             Dataset containing the destination grid.
-        options : Any
+        unmapped_to_nan : bool
+            If True, unmapped values are set to NaN. Default is True.
+        output_weights : Union[bool, str]
+            If True, output weights are added to the output dataset as weights.
+            If str, the name of the variable to store the weights. Default is False.
+        **options : Any
             Dictionary with extra parameters for the regridder.
 
         Examples

--- a/xcdat/regridder/regrid2.py
+++ b/xcdat/regridder/regrid2.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
+import sparse as sp
 import xarray as xr
 
 import xcdat as xc
@@ -13,7 +14,8 @@ class Regrid2Regridder(BaseRegridder):
         self,
         input_grid: xr.Dataset,
         output_grid: xr.Dataset,
-        unmapped_to_nan=True,
+        unmapped_to_nan: bool = True,
+        output_weights: Union[bool, str] = False,
         **options: Any,
     ):
         """
@@ -55,6 +57,7 @@ class Regrid2Regridder(BaseRegridder):
         super().__init__(input_grid, output_grid, **options)
 
         self._unmapped_to_nan = unmapped_to_nan
+        self._output_weights = output_weights
 
     def vertical(self, data_var: str, ds: xr.Dataset) -> xr.Dataset:
         """Placeholder for base class."""
@@ -91,13 +94,16 @@ class Regrid2Regridder(BaseRegridder):
         # exclude alternative of NaN values if there are any
         input_data_var = input_data_var.where(input_data_var != nan_replace)
 
+        lat_mapping, lat_weights = _map_latitude(src_lat_bnds, dst_lat_bnds)
+        lon_mapping, lon_weights = _map_longitude(src_lon_bnds, dst_lon_bnds)
+
         # horizontal regrid
         output_data = _regrid(
             input_data_var,
-            src_lat_bnds,
-            src_lon_bnds,
-            dst_lat_bnds,
-            dst_lon_bnds,
+            lat_mapping,
+            lon_mapping,
+            lat_weights,
+            lon_weights,
             src_mask,
             unmapped_to_nan=self._unmapped_to_nan,
         )
@@ -110,24 +116,38 @@ class Regrid2Regridder(BaseRegridder):
             self._output_grid,
         )
 
+        if self._output_weights:
+            weights = _sparse_weights(
+                (len(src_lat_bnds), len(src_lon_bnds)),
+                (len(dst_lat_bnds), len(dst_lon_bnds)),
+                len(src_lon_bnds),
+                len(dst_lon_bnds),
+                lat_mapping,
+                lon_mapping,
+                lat_weights,
+                lon_weights,
+            )
+
+            if isinstance(self._output_weights, str):
+                output_ds[self._output_weights] = weights
+            else:
+                output_ds["weights"] = weights
+
         return output_ds
 
 
 def _regrid(
     input_data_var: xr.DataArray,
-    src_lat_bnds: np.ndarray,
-    src_lon_bnds: np.ndarray,
-    dst_lat_bnds: np.ndarray,
-    dst_lon_bnds: np.ndarray,
+    lat_mapping: List[np.ndarray],
+    lon_mapping: List[np.ndarray],
+    lat_weights: List[np.ndarray],
+    lon_weights: List[np.ndarray],
     src_mask: Optional[np.ndarray],
     omitted=None,
     unmapped_to_nan=True,
 ) -> np.ndarray:
     if omitted is None:
         omitted = np.nan
-
-    lat_mapping, lat_weights = _map_latitude(src_lat_bnds, dst_lat_bnds)
-    lon_mapping, lon_weights = _map_longitude(src_lon_bnds, dst_lon_bnds)
 
     # convert to pure numpy
     input_data = input_data_var.astype(np.float32).values
@@ -268,6 +288,63 @@ def _build_dataset(
     output_ds = _preserve_bounds(ds, output_grid, output_ds, ["X", "Y"])
 
     return output_ds
+
+
+def _sparse_weights(
+    in_shape,
+    out_shape,
+    in_width,
+    out_width,
+    lat_mapping,
+    lon_mapping,
+    lat_weights,
+    lon_weights,
+):
+    """
+    Generates a sparse weight matrix for regridding.
+
+    Parameters
+    ----------
+    in_shape : tuple
+        Shape of the input grid.
+    out_shape : tuple
+        Shape of the output grid.
+    in_width : int
+        Width of the input grid row.
+    out_width : int
+        Width of the output grid row.
+    lat_mapping : list
+        List of latitude mappings.
+    lon_mapping : list
+        List of longitude mappings.
+    lat_weights : list
+        List of latitude weights.
+    lon_weights : list
+        List of longitude weights.
+
+    Returns
+    -------
+    xr.DataArray
+        A sparse weight matrix for regridding.
+    """
+    weights = np.zeros((np.prod(out_shape), np.prod(in_shape)), dtype=np.float32)
+
+    for i, y in enumerate(lat_mapping):
+        for j, x in enumerate(lon_mapping):
+            # destination index
+            dst_row = i * out_width + j
+
+            # list of source indexes
+            src_col = ((y * in_width).reshape((-1, 1)) + x).flatten()
+
+            # assign weights to matrix
+            weights[dst_row, src_col] = np.dot(lat_weights[i], lon_weights[j]).flatten()
+
+    # reshape from 2D (src, dest) to 4D (src y, src x, dest y, dest x), then convert to sparse
+    # provides user with simple way to explore weights and mapping
+    sparse_weights = sp.COO.from_numpy(weights).reshape(out_shape + in_shape)
+
+    return xr.DataArray(sparse_weights, dims=["y_out", "x_out", "y_in", "x_in"])
 
 
 def _get_output_coords(

--- a/xcdat/regridder/xesmf.py
+++ b/xcdat/regridder/xesmf.py
@@ -78,6 +78,9 @@ class XESMFRegridder(BaseRegridder):
             regridding methods.
         unmapped_to_nan : bool
             Sets values of unmapped points to `np.nan` instead of 0 (ESMF default).
+        output_weights : Union[bool, str]
+            If True, output weights are added to the output dataset as weights.
+            If str, the name of the variable to store the weights. Default is False.
         **options : Any
             Additional arguments passed to the underlying ``xesmf.XESMFRegridder``
             constructor.

--- a/xcdat/regridder/xesmf.py
+++ b/xcdat/regridder/xesmf.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import xarray as xr
 import xesmf as xe
@@ -29,6 +29,7 @@ class XESMFRegridder(BaseRegridder):
         extrap_num_src_pnts: Optional[int] = None,
         ignore_degenerate: bool = True,
         unmapped_to_nan: bool = True,
+        output_weights: Union[bool, str] = False,
         **options: Any,
     ):
         """Extension of ``xESMF`` regridder.
@@ -141,6 +142,7 @@ class XESMFRegridder(BaseRegridder):
         )
 
         self._extra_options = options
+        self._output_weights = output_weights
 
     def vertical(self, data_var: str, ds: xr.Dataset) -> xr.Dataset:
         """Placeholder for base class."""
@@ -155,6 +157,7 @@ class XESMFRegridder(BaseRegridder):
                 f"The data variable '{data_var}' does not exist in the dataset."
             )
 
+        # import pdb; pdb.set_trace()
         regridder = xe.Regridder(
             self._input_grid,
             self._output_grid,
@@ -166,5 +169,11 @@ class XESMFRegridder(BaseRegridder):
 
         output_ds = xr.Dataset({data_var: output_da}, attrs=ds.attrs)
         output_ds = _preserve_bounds(ds, self._output_grid, output_ds, ["X", "Y"])
+
+        if self._output_weights:
+            if isinstance(self._output_weights, str):
+                output_ds[self._output_weights] = regridder.w
+            else:
+                output_ds["weights"] = regridder.w
 
         return output_ds


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
Adds `output_weights` option to `regrid2` and `xesmf` regridders.
Can be set to true/false to include weights as `weights` variable in output dataset.
If it's a `str`, this will be the name of the variable in the output dataset.

The `regrid2` regridder formats it's weights as a sparse array with dimensions (`out_y`, `out_x`, `in_y`, `in_x`).
This matches the behavior of the xesmf regridder. Sparse array is used for space efficiency.

- Closes #550 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
