### PR TITLE
Add `.zenodo.json` and `CITATION.cff` to cite core authors

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,29 @@
+{
+    "creators": [
+        {
+            "name": "Vo, Tom",
+            "affiliation": "Lawrence Livermore National Laboratory",
+            "orcid": "0000-0002-2461-0191"
+        },
+        {
+            "name": "Po-Chedley, Stephen",
+            "affiliation": "Lawrence Livermore National Laboratory",
+            "orcid": "0000-0002-0390-238X"
+        },
+        {
+            "name": "Boutte, Jason",
+            "affiliation": "Lawrence Livermore National Laboratory",
+            "orcid": "0009-0009-3996-3772"
+        },
+        {
+            "name": "Lee, Jiwoo",
+            "affiliation": "Lawrence Livermore National Laboratory",
+            "orcid": "0000-0002-0016-7199"
+        },
+        {
+            "name": "Zhang, Chengzhu",
+            "affiliation": "Lawrence Livermore National Laboratory",
+            "orcid": "0000-0002-9632-0716"
+        }
+    ]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -25,5 +25,21 @@
             "affiliation": "Lawrence Livermore National Laboratory",
             "orcid": "0000-0002-9632-0716"
         }
+    ],
+    "license": "Apache-2.0",
+    "keywords": [
+        "climate data",
+        "xarray",
+        "climate analysis",
+        "E3SM",
+        "python",
+        "structured grid"
+    ],
+    "related_identifiers": [
+        {
+            "relation": "isSupplementTo",
+            "identifier": "10.21105/joss.06426",
+            "scheme": "doi"
+        }
     ]
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,56 @@
+cff-version: 1.2.0
+message: "If you use xCDAT in your research, please cite it as below."
+title: "xCDAT: Xarray Climate Data Analysis Tools"
+abstract: "xCDAT is an open-source Python package that extends Xarray for climate data analysis on structured grids. It simplifies common analysis operations such as spatial and temporal averaging, climatology calculations, and regridding, promoting software sustainability and scientific reproducibility."
+doi: 10.5281/zenodo.7216173
+license: Apache-2.0
+repository-code: "https://github.com/XCDAT/xcdat"
+url: "https://xcdat.readthedocs.io/"
+authors:
+    - family-names: "Vo"
+      given-names: "Tom"
+      orcid: "https://orcid.org/0000-0002-2461-0191"
+      affiliation: "Lawrence Livermore National Laboratory"
+    - family-names: "Po-Chedley"
+      given-names: "Stephen"
+      orcid: "https://orcid.org/0000-0002-0390-238X"
+      affiliation: "Lawrence Livermore National Laboratory"
+    - family-names: "Boutte"
+      given-names: "Jason"
+      orcid: "https://orcid.org/0009-0009-3996-3772"
+      affiliation: "Lawrence Livermore National Laboratory"
+    - family-names: "Lee"
+      given-names: "Jiwoo"
+      orcid: "https://orcid.org/0000-0002-0016-7199"
+      affiliation: "Lawrence Livermore National Laboratory"
+    - family-names: "Zhang"
+      given-names: "Chengzhu"
+      orcid: "https://orcid.org/0000-0002-9632-0716"
+      affiliation: "Lawrence Livermore National Laboratory"
+preferred-citation:
+    type: article
+    title: "xCDAT: A Python Package for Simple and Robust Analysis of Climate Data"
+    authors:
+        - family-names: "Vo"
+          given-names: "Tom"
+          orcid: "https://orcid.org/0000-0002-2461-0191"
+        - family-names: "Po-Chedley"
+          given-names: "Stephen"
+          orcid: "https://orcid.org/0000-0002-0390-238X"
+        - family-names: "Boutte"
+          given-names: "Jason"
+          orcid: "https://orcid.org/0009-0009-3996-3772"
+        - family-names: "Lee"
+          given-names: "Jiwoo"
+          orcid: "https://orcid.org/0000-0002-0016-7199"
+        - family-names: "Zhang"
+          given-names: "Chengzhu"
+          orcid: "https://orcid.org/0000-0002-9632-0716"
+    journal: "Journal of Open Source Software"
+    volume: 9
+    issue: 98
+    pages: "6426"
+    year: 2024
+    month: 6
+    doi: "10.21105/joss.06426"
+    url: "https://joss.theoj.org/papers/10.21105/joss.06426"


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This pull request adds metadata files to enhance citation and attribution for the `xCDAT` project. The changes include the addition of a `.zenodo.json` file for Zenodo integration and a `CITATION.cff` file for standardized citation formatting.

### Metadata Additions:

* [`.zenodo.json`](diffhunk://#diff-69450eccf330a9c709df151fad75b5a9c02976ac29bd5d251bb16eb367997892R1-R29): Added a file specifying project creators, their affiliations, and ORCID identifiers to enable proper attribution when the project is archived on Zenodo.

* [`CITATION.cff`](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R1-R56): Added a file providing citation details, including project title, abstract, DOI, license, repository link, and preferred citation format, to facilitate standardized referencing of the `xCDAT` project.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
