### PR TITLE
Eliminate performance bottleneck in `temporal.group_average()`

### DIFF
--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1558,6 +1558,12 @@ class TemporalAccessor:
             # achieve this, first broadcast the one-dimensional (temporal
             # dimension) shape of the `weights` DataArray to the
             # multi-dimensional shape of its corresponding data variable.
+            weights = self._weights
+            if dv.chunks:
+                # For Dask-backed data variables, chunk the weights along the
+                # time dimension before broadcasting to avoid eager evaluation
+                # of the masking step.
+                weights = weights.chunk({self.dim: dv.chunksizes[self.dim]})
             weights, _ = xr.broadcast(self._weights, dv)
             weights = xr.where(dv.copy().isnull(), 0.0, weights)
 


### PR DESCRIPTION
## Description
Improves performance of `temporal.group_average()` for Dask-backed datasets. Previously, in the `_group_average()` subroutine, the step of masking weights to ensure missing data receives zero weight (`weights = xr.where(dv.copy().isnull(), 0.0, weights`) presented a memory/runtime bottleneck due to eager evaluation when the data variable `dv` is Dask-backed (since `weights` was not Dask-backed). This PR addresses that bottleneck by adding chunking of `weights` along the temporal dimension before broadcasting to the shape of `dv` (and subsequently masking with `xr.where()`) when `dv` is Dask-backed.

- Closes #766

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
