### PR TITLE
Use the median of the delta instead of min for time freq inference 

### DIFF
--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -2105,10 +2105,10 @@ def _infer_freq(time_coords: xr.DataArray) -> Frequency:
         The time frequency.
     """
     # Ensure time_coords is sorted and diffable
-    time_deltas = np.diff(time_coords.values).astype('timedelta64[ns]')
-    
+    time_deltas = np.diff(time_coords.values).astype("timedelta64[ns]")
+
     # Calculate the median delta
-    median_delta = pd.to_timedelta(np.median(time_deltas), unit='ns')
+    median_delta = pd.to_timedelta(np.median(time_deltas), unit="ns")
 
     if median_delta < pd.Timedelta(days=1):
         return "hour"

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -2083,7 +2083,7 @@ class TemporalAccessor:
         return ds_departs
 
 
-def _infer_freq(time_coords: xr.DataArray) -> str:
+def _infer_freq(time_coords: xr.DataArray) -> Frequency:
     """Infers the time frequency from the coordinates.
 
     This method infers the time frequency from the coordinates by
@@ -2101,8 +2101,8 @@ def _infer_freq(time_coords: xr.DataArray) -> str:
 
     Returns
     -------
-    str
-        The inferred time frequency: "hour", "day", "month", or "year".
+    Frequency
+        The time frequency.
     """
     # Ensure time_coords is sorted and diffable
     time_deltas = np.diff(time_coords.values).astype('timedelta64[ns]')


### PR DESCRIPTION
## Description
Using the median of delta is more tolerant when handling small irregularities (e.g., small drift in timestamps).
 min() can be too sensitive and lead to incorrect frequency inference (e.g., #760 which has been tested with this PR)

- Closes #762 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
