### PR TITLE
Fix regrid2 alignment of output and input dims for final dataarray

### DIFF
--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -195,16 +195,16 @@ class TestGetDimCoords:
         )
 
         result = get_dim_coords(ds, "X")
-        assert result.identical(ds["lon"])  # type: ignore
+        assert result.identical(ds["lon"])
 
         result = get_dim_coords(ds, "Y")
-        assert result.identical(ds["lat"])  # type: ignore
+        assert result.identical(ds["lat"])
 
         result = get_dim_coords(ds, "T")
-        assert result.identical(ds["time"])  # type: ignore
+        assert result.identical(ds["time"])
 
         result = get_dim_coords(ds, "Z")
-        assert result.identical(ds["lev"])  # type: ignore
+        assert result.identical(ds["lev"])
 
     def test_returns_dataset_dimension_coordinate_vars_using_axis_attr(self):
         # For example, E3SM datasets might have "ilev" and "lev" dimensions
@@ -214,7 +214,7 @@ class TestGetDimCoords:
             coords={"ilev": self.ds_axis.ilev, "lev": self.ds_axis.lev}
         )
 
-        assert result.identical(expected)  # type: ignore
+        assert result.identical(expected)
 
     def test_returns_dataset_dimension_coordinate_vars_using_standard_name_attr(self):
         # For example, E3SM datasets might have "ilev" and "lev" dimensions
@@ -223,7 +223,7 @@ class TestGetDimCoords:
         result = get_dim_coords(self.ds_sn, "Z")
         expected = xr.Dataset(coords={"ilev": self.ds_sn.ilev, "lev": self.ds_sn.lev})
 
-        assert result.identical(expected)  # type: ignore
+        assert result.identical(expected)
 
     def test_returns_dataarray_dimension_coordinate_var_using_axis_attr(self):
         result = get_dim_coords(self.ds_axis.hyai, "Z")

--- a/xcdat/regridder/grid.py
+++ b/xcdat/regridder/grid.py
@@ -138,7 +138,7 @@ def _create_gaussian_axis(nlats: int) -> tuple[xr.DataArray, xr.DataArray]:
         },
     )
 
-    bounds = (180.0 / np.pi) * np.arcsin(bounds)  # type: ignore
+    bounds = (180.0 / np.pi) * np.arcsin(bounds)
 
     bounds_data = np.zeros((points.shape[0], 2))
     bounds_data[:, 0] = bounds[:-1]

--- a/xcdat/regridder/grid.py
+++ b/xcdat/regridder/grid.py
@@ -138,7 +138,7 @@ def _create_gaussian_axis(nlats: int) -> tuple[xr.DataArray, xr.DataArray]:
         },
     )
 
-    bounds = (180.0 / np.pi) * np.arcsin(bounds)
+    bounds = (180.0 / np.pi) * np.arcsin(bounds)  # type: ignore
 
     bounds_data = np.zeros((points.shape[0], 2))
     bounds_data[:, 0] = bounds[:-1]

--- a/xcdat/regridder/regrid2.py
+++ b/xcdat/regridder/regrid2.py
@@ -285,7 +285,7 @@ def _build_dataset(
 
     output_da = xr.DataArray(
         output_data,
-        dims=dv_input.dims,
+        dims=output_coords.keys(),
         coords=output_coords,
         attrs=ds[data_var].attrs.copy(),
         name=data_var,
@@ -386,25 +386,25 @@ def _get_output_coords(
         aligned with the dimensions of the input data variable.
     """
     output_coords: dict[str, xr.DataArray] = {}
+    input_dims = [str(dim) for dim in dv_input.dims]
 
     # First get the X and Y axes from the output grid.
     for key in ["X", "Y"]:
         input_coord = xc.get_dim_coords(dv_input, key)  # type: ignore
         output_coord = xc.get_dim_coords(output_grid, key)  # type: ignore
 
-        # Align the output coordinate name and dimension with the input
-        # coordinate's name.
-        output_coord = output_coord.rename({output_coord.name: input_coord.name})
-        output_coord.name = input_coord.name
-        output_coords[str(output_coord.name)] = output_coord  # type: ignore
+        output_coords[str(input_coord.name)] = output_coord  # type: ignore
 
     # Get the remaining axes the input data variable (e.g., "time").
     for dim in dv_input.dims:
         if dim not in output_coords:
             output_coords[str(dim)] = dv_input[dim]
 
-    # Sort the coords to align with the input data variable dims.
-    output_coords = {str(dim): output_coords[str(dim)] for dim in dv_input.dims}
+    # Sort the coords to align with order of input data variable dims. Rename
+    # the dictionary keys to match output grid dimensions.
+    output_coords = {
+        str(output_coords[dim].name): output_coords[dim] for dim in input_dims
+    }
 
     return output_coords
 

--- a/xcdat/regridder/regrid2.py
+++ b/xcdat/regridder/regrid2.py
@@ -392,7 +392,11 @@ def _get_output_coords(
         input_coord = xc.get_dim_coords(dv_input, key)  # type: ignore
         output_coord = xc.get_dim_coords(output_grid, key)  # type: ignore
 
-        output_coords[str(input_coord.name)] = output_coord  # type: ignore
+        # Align the output coordinate name and dimension with the input
+        # coordinate's name.
+        output_coord = output_coord.rename({output_coord.name: input_coord.name})
+        output_coord.name = input_coord.name
+        output_coords[str(output_coord.name)] = output_coord  # type: ignore
 
     # Get the remaining axes the input data variable (e.g., "time").
     for dim in dv_input.dims:

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1364,8 +1364,8 @@ class TemporalAccessor:
         # method concatenates the time dimension to non-time dimension data
         # vars, which is not a desired behavior.
         ds = dataset.copy()
-        ds_time = ds.get([v for v in ds.data_vars if self.dim in ds[v].dims])  # type: ignore
-        ds_no_time = ds.get([v for v in ds.data_vars if self.dim not in ds[v].dims])  # type: ignore
+        ds_time = ds.get([v for v in ds.data_vars if self.dim in ds[v].dims])
+        ds_no_time = ds.get([v for v in ds.data_vars if self.dim not in ds[v].dims])
 
         start_year, end_year = (
             ds[self.dim].dt.year.values[0],


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #780 

 `Regrid2` is updated to map the output grid dimensions with the input dataset dimensions, while ensuring the output dataset retains the original input dimension names.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
