### PR TITLE
Remove `mask` from `create_grid()` output to prevent xESMF issue

### DIFF
--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -1165,9 +1165,6 @@ class TestGrid:
 
         assert np.array_equal(new_grid.lat, self.lat)
         assert np.array_equal(new_grid.lon, self.lon)
-        assert np.array_equal(
-            new_grid.mask, xr.DataArray(np.ones((5, 3)), dims=("lat", "lon"))
-        )
 
     def test_create_grid_with_tuple_of_coords_and_no_bounds(self):
         # This case happens if `create_axis` is used without creating bounds,

--- a/xcdat/regridder/grid.py
+++ b/xcdat/regridder/grid.py
@@ -530,8 +530,6 @@ def create_grid(
 
         ds = ds.assign_coords({coords.name: coords})
 
-    ds["mask"] = create_mask(ds)
-
     return ds
 
 


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

The `mask` variable is just for convenience to get the grid shape. It is filled with ones, which means it isn't actually used by xESMF. The user has to manually update the values or replace the mask variable. In this case, I think it makes sense to not add mask variable in `create_grid()`. Otherwise there is more complex work involved to get this to work with xESMF (refer to https://github.com/xCDAT/xcdat/issues/781#issuecomment-3212301318) and https://github.com/pangeo-data/xESMF/issues/447).

- Closes #781 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
