### PR TITLE
Replace in-place `.values` assignment with `assign_coords()`

### DIFF
--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -94,7 +94,8 @@ class TestAddMissingBounds:
 
     def test_skips_adding_bounds_for_coords_that_are_1_dim_singleton(self, caplog):
         # NOTE: Suppress logger warning to avoid polluting test suite.
-        caplog.set_level(logging.CRITICAL)
+        caplog.set_level(logging.CRITICAL, logger="xcdat.bounds")
+
         ds = xr.Dataset(
             coords={
                 "lon": xr.DataArray(
@@ -110,7 +111,7 @@ class TestAddMissingBounds:
 
     def test_skips_adding_bounds_for_coords_that_are_0_dim_singleton(self, caplog):
         # NOTE: Suppress logger warning to avoid polluting test suite.
-        caplog.set_level(logging.CRITICAL)
+        caplog.set_level(logging.CRITICAL, logger="xcdat.bounds")
         ds = xr.Dataset(
             coords={
                 "lon": xr.DataArray(
@@ -125,7 +126,7 @@ class TestAddMissingBounds:
 
     def test_skips_adding_time_bounds_for_coords_that_are_1_dim_singleton(self, caplog):
         # NOTE: Suppress logger warning to avoid polluting test suite.
-        caplog.set_level(logging.CRITICAL)
+        caplog.set_level(logging.CRITICAL, logger="xcdat.bounds")
         ds = xr.Dataset(
             coords={
                 "time": xr.DataArray(
@@ -144,7 +145,7 @@ class TestAddMissingBounds:
         self, caplog
     ):
         # NOTE: Suppress logger warning to avoid polluting test suite.
-        caplog.set_level(logging.CRITICAL)
+        caplog.set_level(logging.CRITICAL, logger="xcdat.bounds")
         ds = xr.Dataset(
             coords={
                 "time": xr.DataArray(
@@ -415,7 +416,7 @@ class TestAddBounds:
         self, caplog
     ):
         # NOTE: Suppress logger warning to avoid polluting test suite.
-        caplog.set_level(logging.CRITICAL)
+        caplog.set_level(logging.CRITICAL, logger="xcdat.bounds")
 
         ds = self.ds.copy()
         del ds.lat.attrs["units"]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,3 +1,5 @@
+import logging
+import pooch
 import pytest
 
 import xcdat._data as data
@@ -21,8 +23,11 @@ class TestGetPcmdiMaskPath:
         assert path.read_bytes() == b"dummy"
 
     @pytest.mark.network
-    def test_get_path_with_real_fetch(self, tmp_path, monkeypatch):
+    def test_get_path_with_real_fetch(self, tmp_path, monkeypatch, caplog):
         """Test fetching the file from the network."""
+        # Suppress pooch logging.
+        pooch.utils.get_logger().disabled = True
+
         # Override the XCDAT_DATA_DIR to use a temporary directory
         monkeypatch.setenv("XCDAT_DATA_DIR", str(tmp_path))
         path = data._get_pcmdi_mask_path()
@@ -31,8 +36,11 @@ class TestGetPcmdiMaskPath:
         assert path.stat().st_size > 1000
 
     @pytest.mark.network
-    def test_get_path_from_cache(self, tmp_path, monkeypatch):
+    def test_get_path_from_cache(self, tmp_path, monkeypatch, caplog):
         """Test fetching the file from the cache."""
+        # Suppress pooch logging.
+        pooch.utils.get_logger().disabled = True
+
         # Override the XCDAT_DATA_DIR to use a temporary directory
         monkeypatch.setenv("XCDAT_DATA_DIR", str(tmp_path))
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,3 @@
-import logging
 import pooch
 import pytest
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -29,7 +29,7 @@ class TestOpenDataset:
 
     def test_raises_warning_if_decode_times_but_no_time_coords_found(self, caplog):
         # Silence warning to not pollute test suite output
-        caplog.set_level(logging.CRITICAL)
+        caplog.set_level(logging.CRITICAL, logger="xcdat.dataset")
 
         ds = generate_dataset(decode_times=False, cf_compliant=True, has_bounds=True)
         ds = ds.drop_dims("time")
@@ -60,7 +60,7 @@ class TestOpenDataset:
 
     def test_skips_decoding_non_cf_compliant_time_with_unsupported_units(self, caplog):
         # Update logger level to silence the logger warning during test runs.
-        caplog.set_level(logging.ERROR)
+        caplog.set_level(logging.ERROR, logger="xcdat.dataset")
 
         ds = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
         ds["time"].attrs["units"] = "year A.D."
@@ -332,7 +332,7 @@ class TestOpenMfDataset:
 
     def test_raises_warning_if_decode_times_but_no_time_coords_found(self, caplog):
         # Silence warning to not pollute test suite output
-        caplog.set_level(logging.CRITICAL)
+        caplog.set_level(logging.CRITICAL, logger="xcdat.dataset")
 
         ds = generate_dataset(decode_times=False, cf_compliant=True, has_bounds=True)
         ds = ds.drop_dims("time")
@@ -600,7 +600,7 @@ class TestDecodeTime:
 
     def test_skips_decoding_time_coords_if_units_is_not_set(self, caplog):
         # Update logger level to silence the logger warning during test runs.
-        caplog.set_level(logging.ERROR)
+        caplog.set_level(logging.ERROR, logger="xcdat.dataset")
 
         ds = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
 
@@ -611,7 +611,7 @@ class TestDecodeTime:
 
     def test_skips_decoding_time_coords_if_units_is_not_supported(self, caplog):
         # Update logger level to silence the logger warning during test runs.
-        caplog.set_level(logging.ERROR)
+        caplog.set_level(logging.ERROR, logger="xcdat.dataset")
 
         # Create the input dataset and update the units.
         ds = generate_dataset(decode_times=False, cf_compliant=False, has_bounds=True)
@@ -872,7 +872,7 @@ class TestDecodeTime:
 
     def test_decodes_time_coords_and_bounds_without_calendar_attr_set(self, caplog):
         # Update logger level to silence the logger warning during test runs.
-        caplog.set_level(logging.ERROR)
+        caplog.set_level(logging.ERROR, logger="xcdat.dataset")
 
         ds = xr.Dataset(
             coords={

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1495,7 +1495,7 @@ class Test_PostProcessDataset:
             ],
             dtype="object",
         )
-        ds.time.data[:] = uncentered_time
+        ds["time"] = ds.time.copy(data=uncentered_time)
         ds.time.encoding = {
             "source": None,
             "original_shape": ds.time.shape,

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -48,7 +48,7 @@ class TestAverage:
 
     def test_defaults_calendar_attribute_to_standard_if_missing(self, caplog):
         # Silence warning to not pollute test suite output
-        caplog.set_level(logging.CRITICAL)
+        caplog.set_level(logging.CRITICAL, logger="xcdat.temporal")
 
         ds: xr.Dataset = generate_dataset(
             decode_times=True, cf_compliant=False, has_bounds=True
@@ -468,7 +468,7 @@ class TestGroupAverage:
 
     def test_defaults_calendar_attribute_to_standard_if_missing(self, caplog):
         # Silence warning to not pollute test suite output
-        caplog.set_level(logging.CRITICAL)
+        caplog.set_level(logging.CRITICAL, logger="xcdat.temporal")
 
         ds: xr.Dataset = generate_dataset(
             decode_times=True, cf_compliant=False, has_bounds=True
@@ -1268,7 +1268,7 @@ class TestGroupAverage:
         self,
     ):
         ds = self.ds.copy()
-        ds["time"].values[:] = np.array(
+        new_time = np.array(
             [
                 "2000-01-16T12:00:00.000000000",
                 "2000-02-15T12:00:00.000000000",
@@ -1278,6 +1278,7 @@ class TestGroupAverage:
             ],
             dtype="datetime64[ns]",
         )
+        ds["time"] = ds.time.copy(data=new_time)
 
         result = ds.temporal.group_average(
             "ts",
@@ -1329,7 +1330,7 @@ class TestGroupAverage:
 
     def test_weighted_custom_seasonal_averages_drops_incomplete_seasons(self):
         ds = self.ds.copy()
-        ds["time"].values[:] = np.array(
+        new_time = np.array(
             [
                 "2000-11-16T12:00:00.000000000",
                 "2000-12-16T12:00:00.000000000",
@@ -1339,6 +1340,8 @@ class TestGroupAverage:
             ],
             dtype="datetime64[ns]",
         )
+
+        ds["time"] = ds.time.copy(data=new_time)
 
         custom_seasons = [["Nov", "Dec"], ["Feb", "Mar", "Apr"]]
 
@@ -1388,7 +1391,7 @@ class TestGroupAverage:
         self,
     ):
         ds = self.ds.copy()
-        ds["time"].values[:] = np.array(
+        new_time = np.array(
             [
                 "2000-11-16T12:00:00.000000000",
                 "2000-12-16T12:00:00.000000000",
@@ -1398,6 +1401,7 @@ class TestGroupAverage:
             ],
             dtype="datetime64[ns]",
         )
+        ds["time"] = ds.time.copy(data=new_time)
 
         custom_seasons = [
             ["Nov", "Dec", "Jan", "Feb", "Mar"],
@@ -1795,7 +1799,7 @@ class TestClimatology:
 
     def test_defaults_calendar_attribute_to_standard_if_missing(self, caplog):
         # Silence warning to not pollute test suite output
-        caplog.set_level(logging.CRITICAL)
+        caplog.set_level(logging.CRITICAL, logger="xcdat.temporal")
 
         ds: xr.Dataset = generate_dataset(
             decode_times=True, cf_compliant=False, has_bounds=True
@@ -3009,7 +3013,7 @@ class TestDepartures:
 
     def test_defaults_calendar_attribute_to_standard_if_missing(self, caplog):
         # Silence warning to not pollute test suite output
-        caplog.set_level(logging.CRITICAL)
+        caplog.set_level(logging.CRITICAL, logger="xcdat.temporal")
 
         ds: xr.Dataset = generate_dataset(
             decode_times=True, cf_compliant=False, has_bounds=True

--- a/xcdat/axis.py
+++ b/xcdat/axis.py
@@ -514,9 +514,13 @@ def _align_lon_to_360(
 
     # After appending the extra set of bounds, update the last coordinate from
     # 0 to 360.
+    new_coords = {}
     for key, coord in ds_lon.coords.items():
-        coord.values[-1] = 360
-        ds_lon[key] = coord
+        values = coord.values.copy()
+        values[-1] = 360
+        new_coords[key] = coord.copy(data=values)
+
+    ds_lon = ds_lon.assign_coords(new_coords)
 
     # Get the data variables related to the longitude axis and concatenate each
     # with the value at the prime meridian.

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1357,23 +1357,56 @@ class TemporalAccessor:
         >>>  (2001, "DJF", 1), (2001, "DJF", 2)]
         """
         ds_new = ds.copy()
-        time_coords = ds_new[self.dim].copy()
-        dec_indexes = time_coords.dt.month == 12
+        time_coords = ds_new[self.dim]
+
+        is_december = time_coords.dt.month == 12
 
         if isinstance(time_coords.values[0], cftime.datetime):
-            time_coords.values[dec_indexes] = [
-                time.replace(year=time.year + 1)
-                for time in time_coords.values[dec_indexes]
-            ]
+            shift_func = self._shift_cftime_year
         else:
-            time_coords.values[dec_indexes] = [
-                pd.Timestamp(time) + pd.DateOffset(years=1)
-                for time in time_coords.values[dec_indexes]
-            ]
+            shift_func = self._shift_datetime_year
 
-        ds_new = ds_new.assign_coords({self.dim: time_coords})
+        shifted_time = xr.apply_ufunc(shift_func, time_coords, vectorize=True)
+        shifted_time_dec_only = xr.where(is_december, shifted_time, time_coords)
+        shifted_time_dec_only.encoding = time_coords.encoding.copy()
+
+        ds_new = ds_new.assign_coords({self.dim: shifted_time_dec_only})
 
         return ds_new
+
+    def _shift_cftime_year(self, time: cftime.datetime) -> cftime.datetime:
+        """
+        Shift the year of a cftime.datetime object by 1.
+
+        Parameters
+        ----------
+        time : cftime.datetime
+            The cftime.datetime object to shift.
+
+        Returns
+        -------
+        cftime.datetime
+            The cftime.datetime object with the year incremented by 1.
+        """
+        return time.replace(year=time.year + 1)
+
+    def _shift_datetime_year(self, time) -> pd.Timestamp:
+        """
+        Shift the year of a datetime-like object by 1.
+
+        Parameters
+        ----------
+        time : datetime-like
+            The datetime-like object to shift.
+
+        Returns
+        -------
+        pd.Timestamp
+            The datetime-like object with the year incremented by 1.
+        """
+        ts = pd.Timestamp(time)
+
+        return ts.replace(year=ts.year + 1)
 
     def _drop_incomplete_djf(self, dataset: xr.Dataset) -> xr.Dataset:
         """Drops incomplete DJF seasons within a continuous time series.

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1420,7 +1420,7 @@ class TemporalAccessor:
         """
         ts = pd.Timestamp(time)
 
-        return ts.replace(year=ts.year + 1)
+        return ts + pd.DateOffset(years=1)
 
     def _drop_incomplete_djf(self, dataset: xr.Dataset) -> xr.Dataset:
         """Drops incomplete DJF seasons within a continuous time series.

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -1354,7 +1354,7 @@ class TemporalAccessor:
         >>>  (2001, "DJF", 1), (2001, "DJF", 2)]
         """
         ds_new = ds.copy()
-        time_coords = ds_new[self.dim]
+        time_coords = ds_new[self.dim].copy()
 
         is_december = time_coords.dt.month == 12
 

--- a/xcdat/temporal.py
+++ b/xcdat/temporal.py
@@ -3,7 +3,7 @@
 import warnings
 from datetime import datetime
 from itertools import chain
-from typing import Literal, TypedDict, get_args
+from typing import Callable, Literal, TypedDict, get_args
 
 import cf_xarray  # noqa: F401
 import cftime
@@ -1307,22 +1307,19 @@ class TemporalAccessor:
                 span_months.extend(month_ints[: month_ints.index(1)])
             break
 
-        if span_months:
-            time_coords = ds_new[self.dim].copy()
-            indexes = time_coords.dt.month.isin(span_months)
+        if not span_months:
+            return ds_new
 
-            if isinstance(time_coords.values[0], cftime.datetime):
-                time_coords.values[indexes] = [
-                    time.replace(year=time.year + 1)
-                    for time in time_coords.values[indexes]
-                ]
-            else:
-                time_coords.values[indexes] = [
-                    pd.Timestamp(time) + pd.DateOffset(years=1)
-                    for time in time_coords.values[indexes]
-                ]
+        time_coords = ds_new[self.dim].copy()
+        indexes = time_coords.dt.month.isin(span_months)
 
-            ds_new = ds_new.assign_coords({self.dim: time_coords})
+        shift_func = self._get_shift_func(time_coords)
+        shifted_time = xr.apply_ufunc(shift_func, time_coords, vectorize=True)
+
+        shifted_time_span_only = xr.where(indexes, shifted_time, time_coords)
+        shifted_time_span_only.encoding = time_coords.encoding.copy()
+
+        ds_new = ds_new.assign_coords({self.dim: shifted_time_span_only})
 
         return ds_new
 
@@ -1361,18 +1358,35 @@ class TemporalAccessor:
 
         is_december = time_coords.dt.month == 12
 
-        if isinstance(time_coords.values[0], cftime.datetime):
-            shift_func = self._shift_cftime_year
-        else:
-            shift_func = self._shift_datetime_year
-
+        shift_func = self._get_shift_func(time_coords)
         shifted_time = xr.apply_ufunc(shift_func, time_coords, vectorize=True)
+
         shifted_time_dec_only = xr.where(is_december, shifted_time, time_coords)
         shifted_time_dec_only.encoding = time_coords.encoding.copy()
 
         ds_new = ds_new.assign_coords({self.dim: shifted_time_dec_only})
 
         return ds_new
+
+    def _get_shift_func(self, time_coords: xr.DataArray) -> Callable:
+        """Gets the appropriate year shifting function based on time coordinate type.
+
+        Parameters
+        ----------
+        time_coords : xr.DataArray
+            The time coordinates.
+
+        Returns
+        -------
+        Callable
+            The year shifting function.
+        """
+        if isinstance(time_coords.values[0], cftime.datetime):
+            shift_func = self._shift_cftime_year
+        else:
+            shift_func = self._shift_datetime_year
+
+        return shift_func
 
     def _shift_cftime_year(self, time: cftime.datetime) -> cftime.datetime:
         """
@@ -2253,7 +2267,7 @@ def _infer_freq(time_coords: xr.DataArray) -> Frequency:
     time_deltas = np.diff(time_coords.values).astype("timedelta64[ns]")
 
     # Calculate the median delta
-    median_delta = pd.to_timedelta(np.median(time_deltas), unit="ns")
+    median_delta = pd.to_timedelta(np.median(time_deltas))
 
     if median_delta < pd.Timedelta(days=1):
         return "hour"


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

Closes #826

This pull request addresses a bug where assigning values to dimension coordinates using `.values[]` or `.data[]` breaks due to read-only arrays in recent versions of xarray. The fix replaces in-place mutations with proper copy-and-assign patterns using `assign_coords()`.

**Changes:**
- Refactored temporal shifting methods to use `xr.where()` and `xr.apply_ufunc()` instead of in-place array mutations
- Updated axis alignment to use coordinate copying and `assign_coords()` instead of direct value assignment
- Fixed test fixtures to use proper coordinate assignment patterns instead of in-place mutations

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
