### PR TITLE
Bump to v0.11.2

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 v0.11.2 (02 February 2026)
 --------------------------
 
-This patch release fixes coordinate assignment behavior and dropping of attributes in
+This patch release fixes coordinate assignment behavior and attributes dropping in
 the PCMDI land sea masking API. It also improves documentation around the default
 use of `cftime` in xCDAT.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,26 @@
 History
 =======
 
+v0.11.2 (02 February 2026)
+-------------------------
+
+This patch release fixes coordinate assignment behavior and improves cftime documentation.
+
+Bug Fixes
+~~~~~~~~~
+
+- Replace in-place ``.values`` assignment with ``assign_coords()`` by
+  `Tom Vo`_ in https://github.com/xCDAT/xcdat/pull/827
+
+Documentation
+~~~~~~~~~~~~~
+
+- Update ``cftime`` section in FAQs by
+  `Tom Vo`_ in https://github.com/xCDAT/xcdat/pull/828
+
+**Full Changelog**: https://github.com/xCDAT/xcdat/compare/v0.11.1...v0.11.2
+
+
 v0.11.1 (06 January 2026)
 -------------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@ History
 =======
 
 v0.11.2 (02 February 2026)
--------------------------
+--------------------------
 
 This patch release fixes coordinate assignment behavior and improves cftime documentation.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,13 +5,17 @@ History
 v0.11.2 (02 February 2026)
 --------------------------
 
-This patch release fixes coordinate assignment behavior and improves cftime documentation.
+This patch release fixes coordinate assignment behavior and dropping of attributes in
+the PCMDI land sea masking API. It also improves documentation around the default
+use of `cftime` in xCDAT.
 
 Bug Fixes
 ~~~~~~~~~
 
 - Replace in-place ``.values`` assignment with ``assign_coords()`` by
   `Tom Vo`_ in https://github.com/xCDAT/xcdat/pull/827
+- Fix attributes dropping in `pcmdi_land_sea_mask()` due to change in Xarray 2026.01.0
+  by `Tom Vo`_ in https://github.com/xCDAT/xcdat/pull/829
 
 Documentation
 ~~~~~~~~~~~~~

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -27,7 +27,9 @@ dependencies:
     - nc-time-axis >=1.4.1
     # Documentation
     # ==================
-    - sphinx
+    # NOTE: Constrain sphinx to <=9.0 until support for sphinx-auto-summary-accessors is added in a later version.
+    # See https://github.com/xarray-contrib/sphinx-autosummary-accessors/issues/165
+    - sphinx <=9.0
     - sphinx-autosummary-accessors
     - sphinx-book-theme
     - sphinx-copybutton

--- a/tbump.toml
+++ b/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/xCDAT/xcdat"
 
 [version]
-current = "0.11.1"
+current = "0.11.2"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before

--- a/xcdat/__init__.py
+++ b/xcdat/__init__.py
@@ -29,4 +29,4 @@ from xcdat.utils import compare_datasets  # noqa: F401
 # Initialize xCDAT logger once when the package is imported
 _setup_xcdat_logger()
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"

--- a/xcdat/mask.py
+++ b/xcdat/mask.py
@@ -282,7 +282,7 @@ def pcmdi_land_sea_mask(
     mask = source_regrid.copy()
     # Set keep_attrs=drop_conflicts to ensure that attributes from the argument x (1 in
     # this case) are not copied. This preserves the existing attributes of the
-    # data variable. The default value is None, which removes all attributes,
+    # data variable. The default value None and False removes all attributes,
     # while True would incorrectly copy attributes from x.
     mask[source_data_var] = xr.where(
         source_regrid[source_data_var] > 0.5, 1, 0, keep_attrs="drop_conflicts"

--- a/xcdat/mask.py
+++ b/xcdat/mask.py
@@ -280,12 +280,12 @@ def pcmdi_land_sea_mask(
     )
 
     mask = source_regrid.copy()
-    # Set keep_attrs=False to ensure that attributes from the argument x (1 in
+    # Set keep_attrs=drop_conflicts to ensure that attributes from the argument x (1 in
     # this case) are not copied. This preserves the existing attributes of the
     # data variable. The default value is None, which removes all attributes,
     # while True would incorrectly copy attributes from x.
     mask[source_data_var] = xr.where(
-        source_regrid[source_data_var] > 0.5, 1, 0, keep_attrs=False
+        source_regrid[source_data_var] > 0.5, 1, 0, keep_attrs="drop_conflicts"
     ).astype("i")
 
     lon = mask[source_data_var].cf["X"]


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

Patch release addressing xarray 2026.0.1 breaking change and sphinx compatibility issue.

**Version Bump**
- Update to v0.11.2 in `xcdat/__init__.py`, `tbump.toml`, and `HISTORY.rst`

**Bug Fixes**
- Fix `pcmdi_land_sea_mask()` dropping dataset attributes with xarray 2026.0.1
  - Changed `keep_attrs=False` → `keep_attrs="drop_conflicts"` in `xr.where()` call
  - xarray 2026.0.1 changed `keep_attrs=False` behavior from preserving existing attrs to dropping all attrs
  - Ref: https://github.com/pydata/xarray/issues/10982#issuecomment-3631684345

**Dependencies**
- Constrain `sphinx <=9.0` in dev environment until sphinx-autosummary-accessors adds support
  - Ref: https://github.com/xarray-contrib/sphinx-autosummary-accessors/issues/165


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
