### PR TITLE
Constrain `regionmask >=0.11.0` for numpy 2.0 compatibility 

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -15,7 +15,7 @@ dependencies:
     - pandas
     - pooch >=1.8
     - python-dateutil
-    - regionmask
+    - regionmask >=0.11.0
     - scipy
     - sparse
     - xarray >=2024.03.0

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -15,7 +15,7 @@ dependencies:
     - pandas
     - pooch >=1.8
     - python-dateutil
-    - regionmask
+    - regionmask >=0.11.0
     - scipy
     - sparse
     - xarray >=2024.03.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "pandas",
   "pooch >=1.8",
   "python-dateutil",
-  "regionmask",
+  "regionmask >=0.11.0",
   "scipy",
   "sparse",
   "xarray >=2024.03.0",


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #837 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
