### PR TITLE
Fix xgcm 0.10 padding compatibility

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -20,7 +20,7 @@ dependencies:
     - sparse
     - xarray >=2024.03.0
     - xesmf >=0.8.7
-    - xgcm >=0.9.0
+    - xgcm >=0.10.0
     # Quality Assurance
     # ==================
     - types-python-dateutil

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -20,7 +20,7 @@ dependencies:
     - sparse
     - xarray >=2024.03.0
     - xesmf >=0.8.7
-    - xgcm >=0.9.0
+    - xgcm >=0.10.0
     # Optional - enables additional features.
     # =========================================
     - matplotlib-base >=3.8.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "sparse",
   "xarray >=2024.03.0",
   "xesmf >=0.8.7",
-  "xgcm >=0.9.0",
+  "xgcm >=0.10.0",
 ]
 
 [project.urls]

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -40,6 +40,46 @@ class TestXGCMRegridder:
         z = grid.create_axis("lev", np.linspace(10000, 2000, 2), generate_bounds=False)
         self.output_grid = grid.create_grid(z=z)
 
+    @pytest.mark.parametrize(
+        ("periodic", "expected_padding"),
+        ((False, "fill"), (True, "periodic")),
+    )
+    def test_periodic_padding(self, periodic, expected_padding):
+        regridder = xgcm.XGCMRegridder(
+            self.ds, self.output_grid, method="linear", periodic=periodic
+        )
+
+        assert regridder._extra_init_options == {"padding": expected_padding}
+
+    @pytest.mark.parametrize(
+        ("extra_init_options", "expected_options"),
+        (
+            ({"boundary": "extend"}, {"padding": "extend"}),
+            ({"padding": "extend"}, {"padding": "extend"}),
+            (
+                {"boundary": "fill", "padding": "extend"},
+                {"padding": "extend"},
+            ),
+            (
+                {"boundary": "fill", "fill_value": 1e27},
+                {"padding": "fill", "fill_value": 1e27},
+            ),
+        ),
+    )
+    def test_padding_precedence(self, extra_init_options, expected_options):
+        original_options = extra_init_options.copy()
+
+        regridder = xgcm.XGCMRegridder(
+            self.ds,
+            self.output_grid,
+            method="linear",
+            periodic=True,
+            extra_init_options=extra_init_options,
+        )
+
+        assert regridder._extra_init_options == expected_options
+        assert extra_init_options == original_options
+
     @mock.patch("xgcm.Grid")
     def test_infer_target_data(self, grid):
         ds = self.ds.copy(True)

--- a/xcdat/regridder/xgcm.py
+++ b/xcdat/regridder/xgcm.py
@@ -120,7 +120,7 @@ class XGCMRegridder(BaseRegridder):
         >>>     ds,
         >>>     output_grid,
         >>>     method="linear",
-        >>>     extra_init_options={"boundary": "fill", "fill_value": 1e27},
+        >>>     extra_init_options={"padding": "fill", "fill_value": 1e27},
         >>>     mask_edges=True
         >>> )
         """
@@ -138,8 +138,17 @@ class XGCMRegridder(BaseRegridder):
 
         if extra_init_options is None:
             extra_init_options = {}
+        else:
+            extra_init_options = extra_init_options.copy()
 
-        extra_init_options["periodic"] = periodic
+        # xgcm v0.10.0 renamed ``boundary`` to ``padding`` and removed
+        # ``periodic``. Normalize both legacy options to the new argument.
+        boundary = extra_init_options.pop("boundary", None)
+        if "padding" not in extra_init_options:
+            default_padding = "periodic" if periodic else "fill"
+            extra_init_options["padding"] = (
+                default_padding if boundary is None else boundary
+            )
 
         self._extra_init_options = extra_init_options
         self._extra_options = options


### PR DESCRIPTION
## Description

Fix xgcm 0.10 compatibility by translating xCDAT's legacy grid options to the new `padding` API. This restores vertical regridding without requiring caller changes.

- Replace removed `periodic` grid option with equivalent `padding` behavior.
- Preserve legacy `boundary` support and explicit `padding` precedence without mutating caller options.
- Raise minimum xgcm version to 0.10.0 across package and Conda environments.
- Update documentation example and add option compatibility tests.
- Closes #839

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
